### PR TITLE
Cyan for readability (better contrast)

### DIFF
--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -21,7 +21,7 @@ func (f *Stylish) Name() string {
 }
 
 func formatFailure(failure lint.Failure, severity lint.Severity) []string {
-	fString := color.BlueString(failure.Failure)
+	fString := color.CyanString(failure.Failure)
 	fName := color.RedString(failure.RuleName)
 	lineColumn := failure.Position
 	pos := fmt.Sprintf("(%d, %d)", lineColumn.Start.Line, lineColumn.Start.Column)


### PR DESCRIPTION
- Changed from dark blue to cyan on "stylish" formatted errors, dark blue on black can be pretty hard to read if your office has windows or lights.