### PR TITLE
Set error code to 1 by default

### DIFF
--- a/defaults.toml
+++ b/defaults.toml
@@ -1,7 +1,7 @@
 ignoreGeneratedHeader = false
 severity = "warning"
 confidence = 0.8
-errorCode = 0
+errorCode = 1
 warningCode = 0
 
 [rule.blank-imports]


### PR DESCRIPTION
The status code is used for the majority of CIs.
Setting this value by default remove the need to have a configuration file.