### PR TITLE
Fix rule for documentation of exported types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: go
 go: "1.10.x"
 
 install: make install
-script: make build && make test.all
+script: make build && make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: test
+
 deps.devtools:
 	@go get github.com/golang/dep/cmd/dep
 
@@ -7,6 +9,6 @@ install: deps.devtools
 build:
 	@go build
 
-test.all:
+test:
 	@go test -v ./test/...
 

--- a/fixtures/golint/exported.go
+++ b/fixtures/golint/exported.go
@@ -7,6 +7,9 @@ type (
 
 	// A is shortcut for []O.
 	A = []O
+
+	// This Person type is simple
+	Person = map[string]interface{}
 )
 
 type Foo struct{} // MATCH /exported type Foo should have comment or be unexported/

--- a/fixtures/golint/exported.go
+++ b/fixtures/golint/exported.go
@@ -1,0 +1,12 @@
+// Package golint comment
+package golint
+
+type (
+	// O is a shortcut (alias) for map[string]interface{}, e.g. a JSON object.
+	O = map[string]interface{}
+
+	// A is shortcut for []O.
+	A = []O
+)
+
+type Foo struct{} // MATCH /exported type Foo should have comment or be unexported/

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -146,7 +146,7 @@ func (w *lintExported) lintTypeDoc(t *ast.TypeSpec, doc *ast.CommentGroup) {
 	}
 
 	s := doc.Text()
-	articles := [...]string{"A", "An", "The"}
+	articles := [...]string{"A", "An", "The", "This"}
 	for _, a := range articles {
 		if t.Name.Name == a {
 			continue

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -148,6 +148,9 @@ func (w *lintExported) lintTypeDoc(t *ast.TypeSpec, doc *ast.CommentGroup) {
 	s := doc.Text()
 	articles := [...]string{"A", "An", "The"}
 	for _, a := range articles {
+		if t.Name.Name == a {
+			continue
+		}
 		if strings.HasPrefix(s, a+" ") {
 			s = s[len(a)+1:]
 			break


### PR DESCRIPTION
The rule was failing in the following case:

```go
// A is an awesome type
type A = int
```

...because revive was skipping the leading `A`, considering it as an article.

@chavacava would you check this out?