### PR TITLE
Add formatter NDJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ go get -u github.com/mgechev/revive
 - `-formatter [NAME]` - formatter to be used for the output. The currently available formatters are:
   - `default` - will output the failures the same way that `golint` does.
   - `json` - outputs the failures in JSON format.
+  - `ndjson` - outputs the failures as stream in newline delimited JSON (NDJSON) format.
   - `friendly` - outputs the failures when found. Shows summary of all the failures.
   - `stylish` - formats the failures in a table. Keep in mind that it doesn't stream the output so it might be perceived as slower compared to others.
 

--- a/config.go
+++ b/config.go
@@ -61,6 +61,7 @@ var allFormatters = []lint.Formatter{
 	&formatter.Stylish{},
 	&formatter.Friendly{},
 	&formatter.JSON{},
+	&formatter.JSONStream{},
 	&formatter.Default{},
 }
 

--- a/config.go
+++ b/config.go
@@ -61,7 +61,7 @@ var allFormatters = []lint.Formatter{
 	&formatter.Stylish{},
 	&formatter.Friendly{},
 	&formatter.JSON{},
-	&formatter.JSONStream{},
+	&formatter.NDJSON{},
 	&formatter.Default{},
 }
 

--- a/formatter/json-stream.go
+++ b/formatter/json-stream.go
@@ -1,0 +1,31 @@
+package formatter
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// JSONStream is an implementation of the Formatter interface
+// which formats the errors to JSON.
+type JSONStream struct {
+	Metadata lint.FormatterMetadata
+}
+
+// Name returns the name of the formatter
+func (f *JSONStream) Name() string {
+	return "json-stream"
+}
+
+// Format formats the failures gotten from the lint.
+func (f *JSONStream) Format(failures <-chan lint.Failure, _ lint.RulesConfig) (string, error) {
+	enc := json.NewEncoder(os.Stdout)
+	for failure := range failures {
+		err := enc.Encode(failure)
+		if err != nil {
+			return "", err
+		}
+	}
+	return "", nil
+}

--- a/formatter/json-stream.go
+++ b/formatter/json-stream.go
@@ -19,10 +19,13 @@ func (f *JSONStream) Name() string {
 }
 
 // Format formats the failures gotten from the lint.
-func (f *JSONStream) Format(failures <-chan lint.Failure, _ lint.RulesConfig) (string, error) {
+func (f *JSONStream) Format(failures <-chan lint.Failure, config lint.RulesConfig) (string, error) {
 	enc := json.NewEncoder(os.Stdout)
 	for failure := range failures {
-		err := enc.Encode(failure)
+		obj := jsonObject{}
+		obj.Severity = severity(config, failure)
+		obj.Failure = failure
+		err := enc.Encode(obj)
 		if err != nil {
 			return "", err
 		}

--- a/formatter/ndjson.go
+++ b/formatter/ndjson.go
@@ -7,19 +7,19 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// JSONStream is an implementation of the Formatter interface
-// which formats the errors to JSON.
-type JSONStream struct {
+// NDJSON is an implementation of the Formatter interface
+// which formats the errors to NDJSON stream.
+type NDJSON struct {
 	Metadata lint.FormatterMetadata
 }
 
 // Name returns the name of the formatter
-func (f *JSONStream) Name() string {
-	return "json-stream"
+func (f *NDJSON) Name() string {
+	return "ndjson"
 }
 
 // Format formats the failures gotten from the lint.
-func (f *JSONStream) Format(failures <-chan lint.Failure, config lint.RulesConfig) (string, error) {
+func (f *NDJSON) Format(failures <-chan lint.Failure, config lint.RulesConfig) (string, error) {
 	enc := json.NewEncoder(os.Stdout)
 	for failure := range failures {
 		obj := jsonObject{}


### PR DESCRIPTION
Adds newline delimited JSON stream. 
To be able to process the JSON data a little earlier ([example](https://github.com/morphy2k/linter-revive/blob/5596c5fe76ba178871c628ffb6472eefbe959f65/lib/main.js#L58))