### PR TITLE
simpler (new rule)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ List of all available rules. The rules ported from `golint` are left unchanged a
 | `deep-exit`           |  n/a   | Looks for program exits in funcs other than `main()` or `init()` |    no    |  no   |
 | `unused-parameter`    |  n/a   | Suggests to rename or remove unused function parameters          |    no    |  no   |
 | `unreachable-code`    |  n/a   | Warns on unreachable code                                        |    no    |  no   |
+| `simpler`             |  n/a   | Proposes code simplifications                                    |    no    |  no   |
 
 ## Available Formatters
 

--- a/config.go
+++ b/config.go
@@ -56,6 +56,7 @@ var allRules = append([]lint.Rule{
 	&rule.DeepExitRule{},
 	&rule.UnusedParamRule{},
 	&rule.UnreachableCodeRule{},
+	&rule.SimplerRule{},
 }, defaultRules...)
 
 var allFormatters = []lint.Formatter{

--- a/fixtures/simpler.go
+++ b/fixtures/simpler.go
@@ -1,0 +1,30 @@
+package fixtures
+
+func foo(a, b, c, d int) {
+	if bar == true { // MATCH /omit comparison with boolean constants/
+
+	}
+	for f() || false != yes { // MATCH /omit comparison with boolean constants/
+
+	}
+}
+
+func bar() {
+	a := 1
+loop:
+	for {
+		switch a {
+		case 1:
+			a++
+			println("one")
+			break // MATCH /omit unnecessary break at the end of case clause/
+		case 2:
+			println("two")
+			break loop
+		default:
+			println("default")
+		}
+	}
+
+	return // MATCH /omit unnecessary return statement/
+}

--- a/rule/simpler.go
+++ b/rule/simpler.go
@@ -1,0 +1,122 @@
+package rule
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// SimplerRule lints code to suggest simplifications.
+type SimplerRule struct{}
+
+// Apply applies the rule to given file.
+func (r *SimplerRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+	var failures []lint.Failure
+	onFailure := func(failure lint.Failure) {
+		failures = append(failures, failure)
+	}
+
+	var branchingFunctions = map[string]map[string]bool{
+		"os": map[string]bool{"Exit": true},
+		"log": map[string]bool{
+			"Fatal":   true,
+			"Fatalf":  true,
+			"Fatalln": true,
+			"Panic":   true,
+			"Panicf":  true,
+			"Panicln": true,
+		},
+	}
+
+	w := lintSimplerRule{onFailure, branchingFunctions}
+	ast.Walk(w, file.AST)
+	return failures
+}
+
+// Name returns the rule name.
+func (r *SimplerRule) Name() string {
+	return "simpler"
+}
+
+type lintSimplerRule struct {
+	onFailure          func(lint.Failure)
+	branchingFunctions map[string]map[string]bool
+}
+
+const (
+	trueName  = "true"
+	falseName = "false"
+)
+
+func (w lintSimplerRule) Visit(node ast.Node) ast.Visitor {
+	switch n := node.(type) {
+	case *ast.BinaryExpr:
+		if n.Op != token.EQL && n.Op != token.NEQ {
+			return w
+		}
+
+		w.checkBinaryExpr(n)
+	case *ast.FuncDecl:
+		if n.Body == nil || n.Type.Results != nil {
+			return w
+		}
+		stmts := n.Body.List
+		if len(stmts) == 0 {
+			return w
+		}
+
+		lastStmt := stmts[len(stmts)-1]
+		rs, ok := lastStmt.(*ast.ReturnStmt)
+		if !ok {
+			return w
+		}
+
+		if len(rs.Results) == 0 {
+			w.newFailure(lastStmt, "omit unnecessary return statement")
+		}
+	case *ast.CaseClause:
+		if n.Body == nil {
+			return w
+		}
+		stmts := n.Body
+		if len(stmts) == 0 {
+			return w
+		}
+
+		lastStmt := stmts[len(stmts)-1]
+		rs, ok := lastStmt.(*ast.BranchStmt)
+		if !ok {
+			return w
+		}
+
+		if rs.Tok == token.BREAK && rs.Label == nil {
+			w.newFailure(lastStmt, "omit unnecessary break at the end of case clause")
+		}
+	}
+
+	return w
+}
+
+func isExprABooleanLit(n ast.Node) bool {
+	oper, ok := n.(*ast.Ident)
+	return ok && (oper.Name == trueName || oper.Name == falseName)
+}
+func (w lintSimplerRule) checkBinaryExpr(be *ast.BinaryExpr) {
+	if isExprABooleanLit(be.X) {
+		w.newFailure(be, "omit comparison with boolean constants")
+	}
+
+	if isExprABooleanLit(be.Y) {
+		w.newFailure(be, "omit comparison with boolean constants")
+	}
+}
+
+func (w lintSimplerRule) newFailure(node ast.Node, msg string) {
+	w.onFailure(lint.Failure{
+		Confidence: 1,
+		Node:       node,
+		Category:   "style",
+		Failure:    msg,
+	})
+}

--- a/test/simpler_test.go
+++ b/test/simpler_test.go
@@ -1,0 +1,12 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+// TestSimplerNaming rule.
+func TestSimplerNaming(t *testing.T) {
+	testRule(t, "simpler", &rule.SimplerRule{})
+}


### PR DESCRIPTION
This rule proposes code simplifications:
- unnecessary `return` and `break` statements
- unnecessary comparisons with boolean constants

Examples (from k8s vendor):

```go
func (p *UpdateLoadBalancerParams) SetFordisplay(v bool) {
	if p.p == nil {
		p.p = make(map[string]interface{})
	}
	p.p["fordisplay"] = v
	return   // omit unnecessary return statement
}
``` 

```go
func yaml_emitter_need_more_events(emitter *yaml_emitter_t) bool {
	if emitter.events_head == len(emitter.events) {
		return true
	}
	var accumulate int
	switch emitter.events[emitter.events_head].typ {
	case yaml_DOCUMENT_START_EVENT:
		accumulate = 1
		break // omit unnecessary break at the end of case clause
	case yaml_SEQUENCE_START_EVENT:
		accumulate = 2
		break // omit unnecessary break at the end of case clause
	case yaml_MAPPING_START_EVENT:
		accumulate = 3
		break // omit unnecessary break at the end of case clause
	default:
		return false
	}

	if s.eof == true { // omit comparison with boolean constants
		s.position.Line++
		s.position.Column = 0
		s.eof = false
	}
```