### PR TITLE
New formatter: unix

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,6 +72,7 @@ var allFormatters = []lint.Formatter{
 	&formatter.JSON{},
 	&formatter.NDJSON{},
 	&formatter.Default{},
+	&formatter.Unix{},
 	&formatter.Checkstyle{},
 }
 

--- a/formatter/unix.go
+++ b/formatter/unix.go
@@ -1,0 +1,27 @@
+package formatter
+
+import (
+	"fmt"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// Unix is an implementation of the Formatter interface
+// which formats the errors to a simple line based error format
+//  main.go:24:9: [errorf] should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
+type Unix struct {
+	Metadata lint.FormatterMetadata
+}
+
+// Name returns the name of the formatter
+func (f *Unix) Name() string {
+	return "unix"
+}
+
+// Format formats the failures gotten from the lint.
+func (f *Unix) Format(failures <-chan lint.Failure, config lint.RulesConfig) (string, error) {
+	for failure := range failures {
+		fmt.Printf("%v: [%s] %s\n", failure.Position.Start, failure.RuleName, failure.Failure)
+	}
+	return "", nil
+}


### PR DESCRIPTION
here an example:

```bash
$ revive -config revive.toml -formatter unix
main.go:24:9: [errorf] should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
```

I think it's better than default because it clearly shows which rule is violated.

Furthermore it would facilitate result parsing by other tools which would enable better linter composition with revive, for example with the following regexp:
```
^(.+):(\d+):(\d+): \[(.+)\] (.+)$
```