### PR TITLE
Add missed max-public-structs rule to all list

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,6 +66,7 @@ var allRules = append([]lint.Rule{
 	&rule.RedefinesBuiltinIDRule{},
 	&rule.ImportsBlacklistRule{},
 	&rule.FunctionResultsLimitRule{},
+	&rule.MaxPublicStructsRule{},
 }, defaultRules...)
 
 var allFormatters = []lint.Formatter{


### PR DESCRIPTION
A just faced with `cannot find rule: max-public-structs` when I tried to use this rule.