### PR TITLE
Code clean-up: fix linter warnings (recommended config) in the linter code

### DIFF
--- a/formatter/default.go
+++ b/formatter/default.go
@@ -18,7 +18,7 @@ func (f *Default) Name() string {
 }
 
 // Format formats the failures gotten from the lint.
-func (f *Default) Format(failures <-chan lint.Failure, config lint.RulesConfig) (string, error) {
+func (f *Default) Format(failures <-chan lint.Failure, _ lint.RulesConfig) (string, error) {
 	for failure := range failures {
 		fmt.Printf("%v: %s\n", failure.Position.Start, failure.Failure)
 	}

--- a/formatter/unix.go
+++ b/formatter/unix.go
@@ -19,7 +19,7 @@ func (f *Unix) Name() string {
 }
 
 // Format formats the failures gotten from the lint.
-func (f *Unix) Format(failures <-chan lint.Failure, config lint.RulesConfig) (string, error) {
+func (f *Unix) Format(failures <-chan lint.Failure, _ lint.RulesConfig) (string, error) {
 	for failure := range failures {
 		fmt.Printf("%v: [%s] %s\n", failure.Position.Start, failure.RuleName, failure.Failure)
 	}

--- a/rule/blank-imports.go
+++ b/rule/blank-imports.go
@@ -10,7 +10,7 @@ import (
 type BlankImportsRule struct{}
 
 // Apply applies the rule to given file.
-func (r *BlankImportsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *BlankImportsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST
@@ -38,7 +38,7 @@ type lintBlankImports struct {
 	onFailure func(lint.Failure)
 }
 
-func (w lintBlankImports) Visit(n ast.Node) ast.Visitor {
+func (w lintBlankImports) Visit(_ ast.Node) ast.Visitor {
 	// In package main and in tests, we don't complain about blank imports.
 	if w.file.Pkg.IsMain() || w.file.IsTest() {
 		return nil

--- a/rule/bool-literal-in-expr.go
+++ b/rule/bool-literal-in-expr.go
@@ -11,7 +11,7 @@ import (
 type BoolLiteralRule struct{}
 
 // Apply applies the rule to given file.
-func (r *BoolLiteralRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *BoolLiteralRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {

--- a/rule/confusing-naming.go
+++ b/rule/confusing-naming.go
@@ -49,7 +49,7 @@ var allPkgs = packages{pkgs: make([]pkgMethods, 1)}
 type ConfusingNamingRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ConfusingNamingRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ConfusingNamingRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 	fileAst := file.AST
 	pkgm := allPkgs.methodNames(file.Pkg)

--- a/rule/confusing-results.go
+++ b/rule/confusing-results.go
@@ -10,7 +10,7 @@ import (
 type ConfusingResultsRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ConfusingResultsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ConfusingResultsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST
@@ -59,9 +59,9 @@ func (w lintConfusingResults) Visit(n ast.Node) ast.Visitor {
 				Failure:    "unnamed results of the same type may be confusing, consider using named results",
 			})
 			break
-		} else {
-			lastType = t.Name
 		}
+		lastType = t.Name
+
 	}
 
 	return w

--- a/rule/constant-logical-expr.go
+++ b/rule/constant-logical-expr.go
@@ -13,7 +13,7 @@ import (
 type ConstantLogicalExprRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ConstantLogicalExprRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ConstantLogicalExprRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {

--- a/rule/context-as-argument.go
+++ b/rule/context-as-argument.go
@@ -10,7 +10,7 @@ import (
 type ContextAsArgumentRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ContextAsArgumentRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ContextAsArgumentRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/rule/context-keys-type.go
+++ b/rule/context-keys-type.go
@@ -12,7 +12,7 @@ import (
 type ContextKeysType struct{}
 
 // Apply applies the rule to given file.
-func (r *ContextKeysType) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ContextKeysType) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/rule/cyclomatic.go
+++ b/rule/cyclomatic.go
@@ -47,7 +47,7 @@ type lintCyclomatic struct {
 	onFailure  func(lint.Failure)
 }
 
-func (w lintCyclomatic) Visit(n ast.Node) ast.Visitor {
+func (w lintCyclomatic) Visit(_ ast.Node) ast.Visitor {
 	f := w.file
 	for _, decl := range f.AST.Decls {
 		if fn, ok := decl.(*ast.FuncDecl); ok {

--- a/rule/deep-exit.go
+++ b/rule/deep-exit.go
@@ -11,7 +11,7 @@ import (
 type DeepExitRule struct{}
 
 // Apply applies the rule to given file.
-func (r *DeepExitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *DeepExitRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 	onFailure := func(failure lint.Failure) {
 		failures = append(failures, failure)

--- a/rule/dot-imports.go
+++ b/rule/dot-imports.go
@@ -10,7 +10,7 @@ import (
 type DotImportsRule struct{}
 
 // Apply applies the rule to given file.
-func (r *DotImportsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *DotImportsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST
@@ -38,7 +38,7 @@ type lintImports struct {
 	onFailure func(lint.Failure)
 }
 
-func (w lintImports) Visit(n ast.Node) ast.Visitor {
+func (w lintImports) Visit(_ ast.Node) ast.Visitor {
 	for i, is := range w.fileAst.Imports {
 		_ = i
 		if is.Name != nil && is.Name.Name == "." && !w.file.IsTest() {

--- a/rule/empty-block.go
+++ b/rule/empty-block.go
@@ -10,7 +10,7 @@ import (
 type EmptyBlockRule struct{}
 
 // Apply applies the rule to given file.
-func (r *EmptyBlockRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *EmptyBlockRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {

--- a/rule/error-naming.go
+++ b/rule/error-naming.go
@@ -13,7 +13,7 @@ import (
 type ErrorNamingRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ErrorNamingRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ErrorNamingRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST
@@ -41,7 +41,7 @@ type lintErrors struct {
 	onFailure func(lint.Failure)
 }
 
-func (w lintErrors) Visit(n ast.Node) ast.Visitor {
+func (w lintErrors) Visit(_ ast.Node) ast.Visitor {
 	for _, decl := range w.fileAst.Decls {
 		gd, ok := decl.(*ast.GenDecl)
 		if !ok || gd.Tok != token.VAR {

--- a/rule/error-return.go
+++ b/rule/error-return.go
@@ -10,7 +10,7 @@ import (
 type ErrorReturnRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ErrorReturnRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ErrorReturnRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/rule/error-strings.go
+++ b/rule/error-strings.go
@@ -14,7 +14,7 @@ import (
 type ErrorStringsRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ErrorStringsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ErrorStringsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/rule/errorf.go
+++ b/rule/errorf.go
@@ -13,7 +13,7 @@ import (
 type ErrorfRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ErrorfRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ErrorfRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -15,7 +15,7 @@ import (
 type ExportedRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ExportedRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ExportedRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	if isTest(file) {

--- a/rule/file-header.go
+++ b/rule/file-header.go
@@ -51,7 +51,7 @@ type lintFileHeader struct {
 	onFailure func(lint.Failure)
 }
 
-func (w lintFileHeader) Visit(n ast.Node) ast.Visitor {
+func (w lintFileHeader) Visit(_ ast.Node) ast.Visitor {
 	g := w.fileAst.Comments[0]
 	failure := lint.Failure{
 		Node:       w.fileAst,

--- a/rule/flag-param.go
+++ b/rule/flag-param.go
@@ -10,7 +10,7 @@ import (
 type FlagParamRule struct{}
 
 // Apply applies the rule to given file.
-func (r *FlagParamRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *FlagParamRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {

--- a/rule/get-return.go
+++ b/rule/get-return.go
@@ -12,7 +12,7 @@ import (
 type GetReturnRule struct{}
 
 // Apply applies the rule to given file.
-func (r *GetReturnRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *GetReturnRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {

--- a/rule/if-return.go
+++ b/rule/if-return.go
@@ -12,7 +12,7 @@ import (
 type IfReturnRule struct{}
 
 // Apply applies the rule to given file.
-func (r *IfReturnRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *IfReturnRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {

--- a/rule/imports-blacklist.go
+++ b/rule/imports-blacklist.go
@@ -54,7 +54,7 @@ type blacklistedImports struct {
 	blacklist map[string]bool
 }
 
-func (w blacklistedImports) Visit(n ast.Node) ast.Visitor {
+func (w blacklistedImports) Visit(_ ast.Node) ast.Visitor {
 	for _, is := range w.fileAst.Imports {
 		if is.Path != nil && !w.file.IsTest() && w.blacklist[is.Path.Value] {
 			w.onFailure(lint.Failure{

--- a/rule/increment-decrement.go
+++ b/rule/increment-decrement.go
@@ -12,7 +12,7 @@ import (
 type IncrementDecrementRule struct{}
 
 // Apply applies the rule to given file.
-func (r *IncrementDecrementRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *IncrementDecrementRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/rule/indent-error-flow.go
+++ b/rule/indent-error-flow.go
@@ -11,7 +11,7 @@ import (
 type IndentErrorFlowRule struct{}
 
 // Apply applies the rule to given file.
-func (r *IndentErrorFlowRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *IndentErrorFlowRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {
@@ -77,4 +77,3 @@ func (w lintElse) Visit(node ast.Node) ast.Visitor {
 	}
 	return w
 }
-

--- a/rule/modifies-param.go
+++ b/rule/modifies-param.go
@@ -11,7 +11,7 @@ import (
 type ModifiesParamRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ModifiesParamRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ModifiesParamRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {

--- a/rule/modifies-value-receiver.go
+++ b/rule/modifies-value-receiver.go
@@ -124,7 +124,7 @@ func (w lintModifiesValRecRule) skipType(t ast.Expr) bool {
 	return strings.HasPrefix(rtName, "[]") || strings.HasPrefix(rtName, "map[")
 }
 
-func (_ lintModifiesValRecRule) getNameFromExpr(ie ast.Expr) string {
+func (lintModifiesValRecRule) getNameFromExpr(ie ast.Expr) string {
 	ident, ok := ie.(*ast.Ident)
 	if !ok {
 		return ""

--- a/rule/package-comments.go
+++ b/rule/package-comments.go
@@ -17,7 +17,7 @@ import (
 type PackageCommentsRule struct{}
 
 // Apply applies the rule to given file.
-func (r *PackageCommentsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *PackageCommentsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	if isTest(file) {
@@ -45,7 +45,7 @@ type lintPackageComments struct {
 	onFailure func(lint.Failure)
 }
 
-func (l *lintPackageComments) Visit(n ast.Node) ast.Visitor {
+func (l *lintPackageComments) Visit(_ ast.Node) ast.Visitor {
 	if l.file.IsTest() {
 		return nil
 	}

--- a/rule/range.go
+++ b/rule/range.go
@@ -12,7 +12,7 @@ import (
 type RangeRule struct{}
 
 // Apply applies the rule to given file.
-func (r *RangeRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *RangeRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {

--- a/rule/receiver-naming.go
+++ b/rule/receiver-naming.go
@@ -11,7 +11,7 @@ import (
 type ReceiverNamingRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ReceiverNamingRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *ReceiverNamingRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -11,7 +11,7 @@ import (
 type RedefinesBuiltinIDRule struct{}
 
 // Apply applies the rule to given file.
-func (r *RedefinesBuiltinIDRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *RedefinesBuiltinIDRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	var builtInConstAndVars = map[string]bool{

--- a/rule/superfluous-else.go
+++ b/rule/superfluous-else.go
@@ -12,7 +12,7 @@ import (
 type SuperfluousElseRule struct{}
 
 // Apply applies the rule to given file.
-func (r *SuperfluousElseRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *SuperfluousElseRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 	onFailure := func(failure lint.Failure) {
 		failures = append(failures, failure)

--- a/rule/time-naming.go
+++ b/rule/time-naming.go
@@ -13,7 +13,7 @@ import (
 type TimeNamingRule struct{}
 
 // Apply applies the rule to given file.
-func (r *TimeNamingRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *TimeNamingRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {
@@ -50,7 +50,7 @@ func (w *lintTimeNames) Visit(node ast.Node) ast.Visitor {
 		if pt, ok := typ.(*types.Pointer); ok {
 			typ = pt.Elem()
 		}
-		if !isNamedType(w.file.Pkg, typ, "time", "Duration") {
+		if !isNamedType(typ, "time", "Duration") {
 			continue
 		}
 		suffix := ""
@@ -83,7 +83,7 @@ var timeSuffixes = []string{
 	"MS", "Ms",
 }
 
-func isNamedType(p *lint.Package, typ types.Type, importPath, name string) bool {
+func isNamedType(typ types.Type, importPath, name string) bool {
 	n, ok := typ.(*types.Named)
 	if !ok {
 		return false

--- a/rule/unexported-return.go
+++ b/rule/unexported-return.go
@@ -12,7 +12,7 @@ import (
 type UnexportedReturnRule struct{}
 
 // Apply applies the rule to given file.
-func (r *UnexportedReturnRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *UnexportedReturnRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/rule/unnecessary-stmt.go
+++ b/rule/unnecessary-stmt.go
@@ -11,7 +11,7 @@ import (
 type UnnecessaryStmtRule struct{}
 
 // Apply applies the rule to given file.
-func (r *UnnecessaryStmtRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *UnnecessaryStmtRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 	onFailure := func(failure lint.Failure) {
 		failures = append(failures, failure)

--- a/rule/unreachable-code.go
+++ b/rule/unreachable-code.go
@@ -10,7 +10,7 @@ import (
 type UnreachableCodeRule struct{}
 
 // Apply applies the rule to given file.
-func (r *UnreachableCodeRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *UnreachableCodeRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 	onFailure := func(failure lint.Failure) {
 		failures = append(failures, failure)

--- a/rule/var-declarations.go
+++ b/rule/var-declarations.go
@@ -13,7 +13,7 @@ import (
 type VarDeclarationsRule struct{}
 
 // Apply applies the rule to given file.
-func (r *VarDeclarationsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *VarDeclarationsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	fileAst := file.AST

--- a/test/utils.go
+++ b/test/utils.go
@@ -35,13 +35,13 @@ func testRule(t *testing.T, filename string, rule lint.Rule, config ...*lint.Rul
 		c[rule.Name()] = *config[0]
 	}
 	if parseInstructions(t, filename, src) == nil {
-		assertSuccess(t, baseDir, stat, src, []lint.Rule{rule}, c)
+		assertSuccess(t, baseDir, stat, []lint.Rule{rule}, c)
 		return
 	}
 	assertFailures(t, baseDir, stat, src, []lint.Rule{rule}, c)
 }
 
-func assertSuccess(t *testing.T, baseDir string, fi os.FileInfo, src []byte, rules []lint.Rule, config map[string]lint.RuleConfig) error {
+func assertSuccess(t *testing.T, baseDir string, fi os.FileInfo, rules []lint.Rule, config map[string]lint.RuleConfig) error {
 	l := lint.New(func(file string) ([]byte, error) {
 		return ioutil.ReadFile(baseDir + file)
 	})
@@ -220,7 +220,8 @@ func srcLine(src []byte, p token.Position) string {
 	return string(src[lo:hi])
 }
 
-func TestLine(t *testing.T) {
+// TestLine tests srcLine function
+func TestLine(t *testing.T) { //revive:disable-line:exported
 	tests := []struct {
 		src    string
 		offset int
@@ -242,7 +243,8 @@ func TestLine(t *testing.T) {
 	}
 }
 
-func TestLintName(t *testing.T) {
+// TestLintName tests lint.Name function
+func TestLintName(t *testing.T) { //revive:disable-line:exported
 	tests := []struct {
 		name, want string
 	}{
@@ -301,7 +303,8 @@ func exportedType(typ types.Type) bool {
 	return true
 }
 
-func TestExportedType(t *testing.T) {
+// TestExportedType tests exportedType function
+func TestExportedType(t *testing.T) { //revive:disable-line:exported
 	tests := []struct {
 		typString string
 		exp       bool
@@ -356,7 +359,8 @@ func isGenerated(src []byte) bool {
 	return false
 }
 
-func TestIsGenerated(t *testing.T) {
+// TestIsGenerated tests isGenerated function
+func TestIsGenerated(t *testing.T) { //revive:disable-line:exported
 	tests := []struct {
 		source    string
 		generated bool


### PR DESCRIPTION
Executed `revive` with the recommended configuration on `revive`'s code
Fixed all issues. 