### PR TITLE
Rule range var in closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ List of all available rules. The rules ported from `golint` are left unchanged a
 | `redefines-builtin-id`|  n/a   | Warns on redefinitions of builtin identifiers                    |    no    |  no   |
 | `function-result-limit` |  int | Specifies the maximum number of results a function can return    |    no    |  no   |
 | `imports-blacklist`   | []string | Disallows importing the specified packages                     |    no    |  no   |
+| `range-val-in-closure`|  n/a   | Warns if range value is used in a closure dispatched as goroutine|    no    |  no   |
 
 ## Configurable rules
 

--- a/config.go
+++ b/config.go
@@ -67,7 +67,7 @@ var allRules = append([]lint.Rule{
 	&rule.ImportsBlacklistRule{},
 	&rule.FunctionResultsLimitRule{},
 	&rule.MaxPublicStructsRule{},
-	&rule.RangValInClosureRule{},
+	&rule.RangeValInClosureRule{},
 }, defaultRules...)
 
 var allFormatters = []lint.Formatter{

--- a/config.go
+++ b/config.go
@@ -67,6 +67,7 @@ var allRules = append([]lint.Rule{
 	&rule.ImportsBlacklistRule{},
 	&rule.FunctionResultsLimitRule{},
 	&rule.MaxPublicStructsRule{},
+	&rule.RangValInClosureRule{},
 }, defaultRules...)
 
 var allFormatters = []lint.Formatter{

--- a/fixtures/range-val-in-closure.go
+++ b/fixtures/range-val-in-closure.go
@@ -1,0 +1,32 @@
+package fixtures
+
+func foo() {
+	for _, newg := range groups {
+		go func() { // MATCH /range value 'newg' seems to be referenced inside the closure/
+			<-m.block
+			newg.run(m.opts.Context)
+		}()
+		go func() {
+			<-m.block
+			newg.run(m.opts.Context)
+		}(newg)
+	}
+}
+
+func bar() {
+	// from github.com/bazelbuild/bazel-gazelle/cmd/gazelle/update-repos.go:148:6
+	for i, imp := range c.importPaths {
+		go func(i int) { // MATCH /range value 'imp' seems to be referenced inside the closure/
+			defer wg.Done()
+			repo, err := repos.UpdateRepo(rc, imp)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			repo.Remote = "" // don't set these explicitly
+			repo.VCS = ""
+			rule := repos.GenerateRule(repo)
+			genRules[i] = rule
+		}(i)
+	}
+}

--- a/fixtures/range-val-in-closure.go
+++ b/fixtures/range-val-in-closure.go
@@ -35,3 +35,18 @@ func bar() {
 		}(i)
 	}
 }
+
+func foo2() {
+	for i, newg := range groups {
+		newg := newg
+		go func() {
+			<-m.block
+			newg.run(m.opts.Context)
+		}()
+		go func() { // MATCH /range value 'i' seems to be referenced inside the closure/
+			i++
+			<-m.block
+			newg.run(m.opts.Context)
+		}(newg)
+	}
+}

--- a/fixtures/range-val-in-closure.go
+++ b/fixtures/range-val-in-closure.go
@@ -1,12 +1,17 @@
 package fixtures
 
 func foo() {
-	for _, newg := range groups {
+	for i, newg := range groups {
 		go func() { // MATCH /range value 'newg' seems to be referenced inside the closure/
 			<-m.block
 			newg.run(m.opts.Context)
 		}()
 		go func() {
+			<-m.block
+			newg.run(m.opts.Context)
+		}(newg)
+		go func() { // MATCH /range value 'i' seems to be referenced inside the closure/
+			i++
 			<-m.block
 			newg.run(m.opts.Context)
 		}(newg)

--- a/rule/range-val-in-closure.go
+++ b/rule/range-val-in-closure.go
@@ -1,0 +1,102 @@
+package rule
+
+import (
+	"fmt"
+	"go/ast"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// RangValInClosureRule looks for iteration vars used in closures.
+type RangValInClosureRule struct{}
+
+// Apply applies the rule to given file.
+func (r *RangValInClosureRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+	var failures []lint.Failure
+
+	onFailure := func(failure lint.Failure) {
+		failures = append(failures, failure)
+	}
+
+	w := lintRangValInClosureRule{onFailure: onFailure}
+	ast.Walk(w, file.AST)
+	return failures
+}
+
+// Name returns the rule name.
+func (r *RangValInClosureRule) Name() string {
+	return "range-val-in-closure"
+}
+
+type lintRangValInClosureRule struct {
+	params    map[string]bool
+	onFailure func(lint.Failure)
+}
+
+func (lintRangValInClosureRule) retrieveParamNames(pl []*ast.Field) map[string]bool {
+	result := make(map[string]bool, len(pl))
+	for _, p := range pl {
+		for _, n := range p.Names {
+			result[n.Name] = true
+		}
+	}
+	return result
+}
+
+func (w lintRangValInClosureRule) Visit(node ast.Node) ast.Visitor {
+	switch n := node.(type) {
+	case *ast.RangeStmt:
+		ident, ok := n.Value.(*ast.Ident)
+		if !ok {
+			return w
+		}
+
+		id := ident.Name
+
+		fselect := func(n ast.Node) bool { // picks go statements
+			_, ok := n.(*ast.GoStmt)
+			return ok
+		}
+
+		goStmts := pick(n.Body, fselect, nil)
+
+	GoStmtIter:
+		for _, gs := range goStmts {
+			gs, _ := gs.(*ast.GoStmt)
+
+			cf := gs.Call.Fun
+			fLit, ok := cf.(*ast.FuncLit)
+			if !ok {
+				continue
+			}
+
+			// check if the range value (id) is passed as argument
+			for _, arg := range gs.Call.Args {
+				ident, ok := arg.(*ast.Ident)
+				if ok {
+					if ident.Name == id {
+						continue GoStmtIter
+					}
+				}
+			}
+
+			fselect := func(n ast.Node) bool { // picks reference to the range value (id)
+				ident, ok := n.(*ast.Ident)
+				return ok && ident.Name == id
+			}
+
+			ref2Id := pick(fLit.Body, fselect, nil)
+
+			if len(ref2Id) > 0 {
+				w.onFailure(lint.Failure{
+					Confidence: 0.8,
+					Node:       fLit,
+					Category:   "logic",
+					Failure:    fmt.Sprintf("range value '%s' seems to be referenced inside the closure", id),
+				})
+			}
+		}
+	}
+
+	return w
+}

--- a/test/range-val-in-closure_test.go
+++ b/test/range-val-in-closure_test.go
@@ -1,0 +1,11 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestRangValInClosure(t *testing.T) {
+	testRule(t, "range-val-in-closure", &rule.RangValInClosureRule{})
+}

--- a/test/range-val-in-closure_test.go
+++ b/test/range-val-in-closure_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-func TestRangValInClosure(t *testing.T) {
-	testRule(t, "range-val-in-closure", &rule.RangValInClosureRule{})
+// TestRangeValInClosure tests RangeValInClosure rule
+func TestRangeValInClosure(t *testing.T) {
+	testRule(t, "range-val-in-closure", &rule.RangeValInClosureRule{})
 }


### PR DESCRIPTION
Warns if a range value is used in a closure dispatched as goroutine.

Inspired by http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/index.html#closure_for_it_vars