### PR TITLE
Refactors `atomic` rule code to move `gofmt` function to utils.go (issue #79) 

### DIFF
--- a/rule/constant-logical-expr.go
+++ b/rule/constant-logical-expr.go
@@ -1,11 +1,8 @@
 package rule
 
 import (
-	"bytes"
-	"fmt"
 	"github.com/mgechev/revive/lint"
 	"go/ast"
-	"go/format"
 	"go/token"
 )
 
@@ -43,7 +40,7 @@ func (w *lintConstantLogicalExpr) Visit(node ast.Node) ast.Visitor {
 			return w
 		}
 
-		if !w.areEqual(n.X, n.Y) {
+		if gofmt(n.X) != gofmt(n.Y) { // check if subexpressions are the same
 			return w
 		}
 
@@ -79,21 +76,6 @@ func (w *lintConstantLogicalExpr) isInequalityOperator(t token.Token) bool {
 	}
 
 	return false
-}
-
-func (w lintConstantLogicalExpr) areEqual(x, y ast.Expr) bool {
-	fset := token.NewFileSet()
-	var buf1 bytes.Buffer
-	if err := format.Node(&buf1, fset, x); err != nil {
-		return false // keep going in case of error
-	}
-
-	var buf2 bytes.Buffer
-	if err := format.Node(&buf2, fset, y); err != nil {
-		return false // keep going in case of error
-	}
-
-	return fmt.Sprintf("%s", buf1.Bytes()) == fmt.Sprintf("%s", buf2.Bytes())
 }
 
 func (w lintConstantLogicalExpr) newFailure(node ast.Node, msg string) {

--- a/rule/utils.go
+++ b/rule/utils.go
@@ -1,8 +1,10 @@
 package rule
 
 import (
+	"bytes"
 	"fmt"
 	"go/ast"
+	"go/printer"
 	"go/token"
 	"go/types"
 	"regexp"
@@ -178,4 +180,12 @@ func isExprABooleanLit(n ast.Node) (lexeme string, ok bool) {
 	}
 
 	return oper.Name, (oper.Name == trueName || oper.Name == falseName)
+}
+
+// gofmt returns a string representation of the expression.
+func gofmt(x ast.Expr) string {
+	buf := bytes.Buffer{}
+	fs := token.NewFileSet()
+	printer.Fprint(&buf, fs, x)
+	return buf.String()
 }


### PR DESCRIPTION
Closes #79 
