### PR TITLE
docs: add gitea to "Who uses Revive"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Here's how `revive` is different from `golint`:
 - [`tidb`](https://github.com/pingcap/tidb) - TiDB is a distributed HTAP database compatible with the MySQL protocol
 - [`ferret`](https://github.com/MontFerret/ferret) - Declarative web scraping
 - [`gopass`](https://github.com/gopasspw/gopass) - The slightly more awesome standard unix password manager for teams
+- [`gitea`](https://github.com/go-gitea/gitea) - Git with a cup of tea, painless self-hosted git service
 
 *Open a PR to add your project*.
 


### PR DESCRIPTION
Gitea is now using revive: https://github.com/go-gitea/gitea/commit/20c54f88b23bbf56ac3cc3a74baeed98d7ab0844
