### PR TITLE
fixes issue #98

### DIFF
--- a/fixtures/line-length-limit.go
+++ b/fixtures/line-length-limit.go
@@ -5,3 +5,13 @@ import "fmt"
 func foo(a, b int) {
 	fmt.Printf("single line characters out of limit") // MATCH /line is 105 characters, out of limit 100/
 }
+
+// revive:disable-next-line:line-length-limit
+// The length of this comment line is over 80 characters, this is bad for readability.
+
+// Warn: the testing framework does not allow to check for failures in comments
+
+func toto() {
+	// revive:disable-next-line:line-length-limit
+	fmt.Println("This line is way too long. In my opinion, it should be shortened.")
+}

--- a/lint/file.go
+++ b/lint/file.go
@@ -127,7 +127,7 @@ type enableDisableConfig struct {
 }
 
 func (f *File) disabledIntervals(rules []Rule) disabledIntervalsMap {
-	re := regexp.MustCompile(`^\s*revive:(enable|disable)(?:-(line|next-line))?(:|\s|$)`)
+	re := regexp.MustCompile(`^\s*revive:(enable|disable)(?:-(line|next-line))?(:)?([^\s]*)?(\s|$)`)
 
 	enabledDisabledRulesMap := make(map[string][]enableDisableConfig)
 
@@ -199,11 +199,10 @@ func (f *File) disabledIntervals(rules []Rule) disabledIntervalsMap {
 		if len(parts) == 0 {
 			return
 		}
-		str := re.FindString(text)
-		ruleNamesString := strings.Split(text, str)
+
 		ruleNames := []string{}
-		if len(ruleNamesString) == 2 {
-			tempNames := strings.Split(ruleNamesString[1], ",")
+		if len(parts) > 4 {
+			tempNames := strings.Split(parts[4], ",")
 			for _, name := range tempNames {
 				name = strings.Trim(name, "\n")
 				if len(name) > 0 {


### PR DESCRIPTION
Closes #98

Warn: I've updated the test fixture for the `line-length-limit` rule but `revive`'s testing framework is not able to check failures on comments.
