### PR TITLE
Do not require additional newline for disabling multiple rules

### DIFF
--- a/fixtures/disable-annotations2.go
+++ b/fixtures/disable-annotations2.go
@@ -1,0 +1,21 @@
+package fixtures
+
+func foo1() {
+	//revive:disable-next-line:var-naming
+	var invalid_name = 0
+	var invalid_name2 = 1 //revive:disable-line:var-naming
+}
+
+func foo2() {
+	//revive:disable-next-line:var-naming
+	//revive:disable
+	var invalid_name = 0
+	var invalid_name2 = 1
+}
+
+func foo3() {
+	//revive:enable
+	//revive:disable-next-line:var-naming
+	var invalid_name = 0
+	var invalid_name2 = 1 // MATCH /don't use underscores in Go names; var invalid_name2 should be invalidName2/
+}

--- a/fixtures/disable-annotations2.go
+++ b/fixtures/disable-annotations2.go
@@ -7,7 +7,7 @@ func foo1() {
 }
 
 func foo2() {
-	//revive:disable-next-line:var-naming
+	// 		revive:disable-next-line:var-naming
 	//revive:disable
 	var invalid_name = 0
 	var invalid_name2 = 1
@@ -15,7 +15,10 @@ func foo2() {
 
 func foo3() {
 	//revive:enable
-	//revive:disable-next-line:var-naming
+	// revive:disable-next-line:var-naming
 	var invalid_name = 0
+	// not a valid annotation revive:disable-next-line:var-naming
 	var invalid_name2 = 1 // MATCH /don't use underscores in Go names; var invalid_name2 should be invalidName2/
+	/* revive:disable-next-line:var-naming */
+	var invalid_name3 = 0 // MATCH /don't use underscores in Go names; var invalid_name3 should be invalidName3/
 }

--- a/fixtures/line-length-limit.go
+++ b/fixtures/line-length-limit.go
@@ -5,3 +5,13 @@ import "fmt"
 func foo(a, b int) {
 	fmt.Printf("single line characters out of limit") // MATCH /line is 105 characters, out of limit 100/
 }
+
+// revive:disable-next-line:line-length-limit
+// The length of this comment line is over 80 characters, this is bad for readability.
+
+// Warn: the testing framework does not allow to check for failures in comments
+
+func toto() {
+	// revive:disable-next-line:line-length-limit
+	fmt.Println("This line is way too long. In my opinion, it should be shortened.")
+}

--- a/lint/file.go
+++ b/lint/file.go
@@ -127,7 +127,7 @@ type enableDisableConfig struct {
 }
 
 func (f *File) disabledIntervals(rules []Rule) disabledIntervalsMap {
-	re := regexp.MustCompile(`^\s*revive:(enable|disable)(?:-(line|next-line))?(:)?([^\s]*)?(\s|$)`)
+	re := regexp.MustCompile(`revive:(enable|disable)(?:-(line|next-line))?(?::([^\s]+))?`)
 
 	enabledDisabledRulesMap := make(map[string][]enableDisableConfig)
 
@@ -195,35 +195,36 @@ func (f *File) disabledIntervals(rules []Rule) disabledIntervalsMap {
 
 	handleComment := func(filename string, c *ast.CommentGroup, line int) {
 		text := c.Text()
-		parts := re.FindStringSubmatch(text)
-		if len(parts) == 0 {
+		matches := re.FindAllStringSubmatch(text, -1)
+		if len(matches) == 0 {
 			return
 		}
-
-		ruleNames := []string{}
-		if len(parts) > 4 {
-			tempNames := strings.Split(parts[4], ",")
-			for _, name := range tempNames {
-				name = strings.Trim(name, "\n")
-				if len(name) > 0 {
-					ruleNames = append(ruleNames, name)
+		for _, matchParts := range matches {
+			ruleNames := []string{}
+			if len(matchParts) > 2 {
+				tempNames := strings.Split(matchParts[3], ",")
+				for _, name := range tempNames {
+					name = strings.Trim(name, "\n")
+					if len(name) > 0 {
+						ruleNames = append(ruleNames, name)
+					}
 				}
 			}
-		}
 
-		// TODO: optimize
-		if len(ruleNames) == 0 {
-			for _, rule := range rules {
-				ruleNames = append(ruleNames, rule.Name())
+			// TODO: optimize
+			if len(ruleNames) == 0 {
+				for _, rule := range rules {
+					ruleNames = append(ruleNames, rule.Name())
+				}
 			}
-		}
 
-		handleRules(filename, parts[2], parts[1] == "enable", line, ruleNames)
+			handleRules(filename, matchParts[2], matchParts[1] == "enable", line, ruleNames)
+		}
 	}
 
 	comments := f.AST.Comments
 	for _, c := range comments {
-		handleComment(f.Name, c, f.ToPosition(c.Pos()).Line)
+		handleComment(f.Name, c, f.ToPosition(c.End()).Line)
 	}
 
 	return getEnabledDisabledIntervals()

--- a/lint/file.go
+++ b/lint/file.go
@@ -127,7 +127,7 @@ type enableDisableConfig struct {
 }
 
 func (f *File) disabledIntervals(rules []Rule) disabledIntervalsMap {
-	re := regexp.MustCompile(`^\s*revive:(enable|disable)(?:-(line|next-line))?(:|\s|$)`)
+	re := regexp.MustCompile(`^\s*revive:(enable|disable)(?:-(line|next-line))?(:)?([^\s]*)?(\s|$)`)
 
 	enabledDisabledRulesMap := make(map[string][]enableDisableConfig)
 
@@ -199,11 +199,10 @@ func (f *File) disabledIntervals(rules []Rule) disabledIntervalsMap {
 		if len(parts) == 0 {
 			return
 		}
-		str := re.FindString(text)
-		ruleNamesString := strings.Split(text, str)
+
 		ruleNames := []string{}
-		if len(ruleNamesString) == 2 {
-			tempNames := strings.Split(ruleNamesString[1], ",")
+		if len(parts) > 4 {
+			tempNames := strings.Split(parts[4], ",")
 			for _, name := range tempNames {
 				name = strings.Trim(name, "\n")
 				if len(name) > 0 {

--- a/test/disable-annotations_test.go
+++ b/test/disable-annotations_test.go
@@ -10,3 +10,7 @@ import (
 func TestDisabledAnnotations(t *testing.T) {
 	testRule(t, "disable-annotations", &rule.ExportedRule{}, &lint.RuleConfig{})
 }
+
+func TestModifiedAnnotations(t *testing.T) {
+	testRule(t, "disable-annotations2", &rule.VarNamingRule{}, &lint.RuleConfig{})
+}


### PR DESCRIPTION
Closes #102 
Added test on disabling annotations with `next-line` and `line` modifiers. These tests cope with the error case identified by the issue #102 

