### PR TITLE
fix error return rule to allow multiple error return values

### DIFF
--- a/fixtures/golint/error-return.go
+++ b/fixtures/golint/error-return.go
@@ -41,3 +41,13 @@ func l() (int, error, int) { // MATCH /error should be the last type when return
 func m() (x int, err error, y int) { // MATCH /error should be the last type when returning multiple items/
 	return 0, nil, 0
 }
+
+// Check for multiple error returns but with errors at the end.
+func n() (int, error, error) { // ok
+	return 0, nil, nil
+}
+
+// Check for multiple error returns mixed in order, but keeping one error at last position.
+func o() (int, error, int, error) { // ok
+	return 0, nil, 0, nil
+}

--- a/rule/error-return.go
+++ b/rule/error-return.go
@@ -47,6 +47,9 @@ func (w lintErrorReturn) Visit(n ast.Node) ast.Visitor {
 	if len(ret) <= 1 {
 		return w
 	}
+	if isIdent(ret[len(ret)-1].Type, "error") {
+		return true
+	}
 	// An error return parameter should be the last parameter.
 	// Flag any error parameters found before the last.
 	for _, r := range ret[:len(ret)-1] {

--- a/rule/error-return.go
+++ b/rule/error-return.go
@@ -48,7 +48,7 @@ func (w lintErrorReturn) Visit(n ast.Node) ast.Visitor {
 		return w
 	}
 	if isIdent(ret[len(ret)-1].Type, "error") {
-		return true
+		return nil
 	}
 	// An error return parameter should be the last parameter.
 	// Flag any error parameters found before the last.


### PR DESCRIPTION
please check golint related updates here: golang/lint@8379672

When returning multiple values with an error,
lint checks if the error is the last return value.
But the implementation actually is checking for all return values
except for the last one, and throw the alert if it found an error.

There is a (edge) case where some function returning more than one error
is getting a false positive even when the last return value is an error.

This patch adds an early check, to see if the last return value is an error
and if so, it will pass silently.

<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follows the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
