### PR TITLE
optimizes import-blacklist

### DIFF
--- a/rule/imports-blacklist.go
+++ b/rule/imports-blacklist.go
@@ -2,7 +2,6 @@ package rule
 
 import (
 	"fmt"
-	"go/ast"
 
 	"github.com/mgechev/revive/lint"
 )
@@ -13,6 +12,11 @@ type ImportsBlacklistRule struct{}
 // Apply applies the rule to given file.
 func (r *ImportsBlacklistRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
+
+	if file.IsTest() {
+		return failures // skip, test file
+	}
+
 	blacklist := make(map[string]bool, len(arguments))
 
 	for _, arg := range arguments {
@@ -20,24 +24,24 @@ func (r *ImportsBlacklistRule) Apply(file *lint.File, arguments lint.Arguments) 
 		if !ok {
 			panic(fmt.Sprintf("Invalid argument to the imports-blacklist rule. Expecting a string, got %T", arg))
 		}
-		// we add quotes if nt present, because when parsed, the value of the AST node, will be quoted
+		// we add quotes if not present, because when parsed, the value of the AST node, will be quoted
 		if len(argStr) > 2 && argStr[0] != '"' && argStr[len(argStr)-1] != '"' {
 			argStr = fmt.Sprintf(`"%s"`, argStr)
 		}
 		blacklist[argStr] = true
 	}
 
-	fileAst := file.AST
-	walker := blacklistedImports{
-		file:    file,
-		fileAst: fileAst,
-		onFailure: func(failure lint.Failure) {
-			failures = append(failures, failure)
-		},
-		blacklist: blacklist,
+	for _, is := range file.AST.Imports {
+		path := is.Path
+		if path != nil && blacklist[path.Value] {
+			failures = append(failures, lint.Failure{
+				Confidence: 1,
+				Failure:    "should not use the following blacklisted import: " + path.Value,
+				Node:       is,
+				Category:   "imports",
+			})
+		}
 	}
-
-	ast.Walk(walker, fileAst)
 
 	return failures
 }
@@ -45,25 +49,4 @@ func (r *ImportsBlacklistRule) Apply(file *lint.File, arguments lint.Arguments) 
 // Name returns the rule name.
 func (r *ImportsBlacklistRule) Name() string {
 	return "imports-blacklist"
-}
-
-type blacklistedImports struct {
-	file      *lint.File
-	fileAst   *ast.File
-	onFailure func(lint.Failure)
-	blacklist map[string]bool
-}
-
-func (w blacklistedImports) Visit(_ ast.Node) ast.Visitor {
-	for _, is := range w.fileAst.Imports {
-		if is.Path != nil && !w.file.IsTest() && w.blacklist[is.Path.Value] {
-			w.onFailure(lint.Failure{
-				Confidence: 1,
-				Failure:    fmt.Sprintf("should not use the following blacklisted import: %s", is.Path.Value),
-				Node:       is,
-				Category:   "imports",
-			})
-		}
-	}
-	return nil
 }

--- a/test/import-blacklist_test.go
+++ b/test/import-blacklist_test.go
@@ -14,3 +14,13 @@ func TestImportsBlacklist(t *testing.T) {
 		Arguments: args,
 	})
 }
+
+func BenchmarkImportsBlacklist(b *testing.B) {
+	args := []interface{}{"crypto/md5", "crypto/sha1"}
+	var t *testing.T
+	for i := 0; i <= b.N; i++ {
+		testRule(t, "imports-blacklist", &rule.ImportsBlacklistRule{}, &lint.RuleConfig{
+			Arguments: args,
+		})
+	}
+}


### PR DESCRIPTION
Refactoring of `import-blacklist` to simplify code by removing unnecessary call to `ast.Walk` + other minor modifications.

Current vs new benchmarks:

```
$ benchdiff old.txt new.txt
benchmark                       old ns/op     new ns/op     delta
BenchmarkImportsBlacklist-4     114217        111158        -2.68%

benchmark                       old allocs     new allocs     delta
BenchmarkImportsBlacklist-4     455            448            -1.54%

benchmark                       old bytes     new bytes     delta
BenchmarkImportsBlacklist-4     38589         38265         -0.84%
```