### PR TITLE
Extend rule struct-tag to warn on private fields with tags

### DIFF
--- a/fixtures/struct-tag.go
+++ b/fixtures/struct-tag.go
@@ -1,5 +1,7 @@
 package fixtures
 
+import "time"
+
 type decodeAndValidateRequest struct {
 	// BEAWRE : the flag of URLParam should match the const string URLParam
 	URLParam         string          `json:"-" path:"url_param" validate:"numeric"`
@@ -17,6 +19,8 @@ type decodeAndValidateRequest struct {
 	MandatoryStruct4 mandatoryStruct `json:"mandatoryStruct" required:"false"`
 	OptionalStruct   *optionalStruct `json:"optionalStruct,omitempty"`
 	OptionalQuery    string          `json:"-" querystring:"queryfoo"`
+	optionalQuery    string          `json:"-" querystring:"queryfoo"` // MATCH /tag on not-exported field optionalQuery/
+
 }
 
 type RangeAllocation struct {

--- a/rule/struct-tag.go
+++ b/rule/struct-tag.go
@@ -2,11 +2,12 @@ package rule
 
 import (
 	"fmt"
-	"github.com/fatih/structtag"
-	"github.com/mgechev/revive/lint"
 	"go/ast"
 	"strconv"
 	"strings"
+
+	"github.com/fatih/structtag"
+	"github.com/mgechev/revive/lint"
 )
 
 // StructTagRule lints struct tags.
@@ -58,6 +59,10 @@ func (w lintStructTagRule) Visit(node ast.Node) ast.Visitor {
 // checkTaggedField checks the tag of the given field.
 // precondition: the field has a tag
 func (w lintStructTagRule) checkTaggedField(f *ast.Field) {
+	if len(f.Names) > 0 && !f.Names[0].IsExported() {
+		w.addFailure(f, "tag on not-exported field "+f.Names[0].Name)
+	}
+
 	tags, err := structtag.Parse(strings.Trim(f.Tag.Value, "`"))
 	if err != nil || tags == nil {
 		w.addFailure(f.Tag, "malformed tag")


### PR DESCRIPTION
Minor extension of `struct-tag` rule to warn when a private field has tags.
