### PR TITLE
Fix mgechev/dots timestamp mismatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fatih/structtag v1.0.0
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
-	github.com/mgechev/dots v0.0.0-20190603122614-18fa4c4b71cc
+	github.com/mgechev/dots v0.0.0-20181228164730-18fa4c4b71cc
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/pkg/errors v0.8.1
 	golang.org/x/sys v0.0.0-20190815002308-fde4db37ae7a // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,8 @@ github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8Bz
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mgechev/dots v0.0.0-20180605013149-8e09d8ea2757 h1:KTwJ7Lo3KDKMknRYN5JEFRGIM4IkG59QjFFM2mxsMEU=
-github.com/mgechev/dots v0.0.0-20180605013149-8e09d8ea2757/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
-github.com/mgechev/dots v0.0.0-20190603122614-18fa4c4b71cc h1:ErGdrZWM/CrAz0FVwcznlAScsmr2pdSMMPMwFL9TNmw=
-github.com/mgechev/dots v0.0.0-20190603122614-18fa4c4b71cc/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
+github.com/mgechev/dots v0.0.0-20181228164730-18fa4c4b71cc h1:SQHr6jXnsY5YmRoO7RWDcZjmC3PgwPW/xQ9TYJ/SiRY=
+github.com/mgechev/dots v0.0.0-20181228164730-18fa4c4b71cc/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc h1:rQ1O4ZLYR2xXHXgBCCfIIGnuZ0lidMQw2S5n1oOv+Wg=
 github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=


### PR DESCRIPTION
Fix #223 

Maybe something like this solve the issue because it is clear that there is a commit timestamp mismatch between https://github.com/mgechev/dots/commits/master and `revive` `go.mod` and `go.sum` and on new go version, there is a validation

```
// go.mod 
// this 
github.com/mgechev/dots v0.0.0-20190603122614-18fa4c4b71cc

// should be 
github.com/mgechev/dots v0.0.0-20181228164730-18fa4c4b71cc
```

```
// go.sum
// this
github.com/mgechev/dots v0.0.0-20190603122614-18fa4c4b71cc h1:ErGdrZWM/CrAz0FVwcznlAScsmr2pdSMMPMwFL9TNmw=  
github.com/mgechev/dots v0.0.0-20190603122614-18fa4c4b71cc/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=

// should be
github.com/mgechev/dots v0.0.0-20181228164730-18fa4c4b71cc h1:SQHr6jXnsY5YmRoO7RWDcZjmC3PgwPW/xQ9TYJ/SiRY=
github.com/mgechev/dots v0.0.0-20181228164730-18fa4c4b71cc/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
```
I really have no idea how could this happen during upgrade (https://github.com/mgechev/revive/commit/c5e9877a561d0cac008fd5365042d35de7f8778b https://github.com/mgechev/revive/pull/133)   since it should always pick the right timestamp from git. `mgechev/dots` even has the same date of the commit itself `2019-06-03` that made on revive