### PR TITLE
Add rule 'range-val-address'

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -44,6 +44,7 @@ List of all available rules.
   - [package-comments](#package-comments)
   - [range](#range)
   - [range-val-in-closure](#range-val-in-closure)
+  - [range-val-address](#range-val-address)
   - [receiver-naming](#receiver-naming)
   - [redefines-builtin-id](#redefines-builtin-id)
   - [string-of-int](#string-of-int)
@@ -391,6 +392,12 @@ _Configuration_: N/A
 
 _Description_: Range variables in a loop are reused at each iteration; therefore a goroutine created in a loop will point to the range variable with from the upper scope. This way, the goroutine could use the variable with an undesired value.
 This rule warns when a range value (or index) is used inside a closure
+
+_Configuration_: N/A
+
+## range-val-address
+
+_Description_: Range variables in a loop are reused at each iteration. This rule warns when assigning the address of the variable.
 
 _Configuration_: N/A
 

--- a/config.go
+++ b/config.go
@@ -70,6 +70,7 @@ var allRules = append([]lint.Rule{
 	&rule.FunctionResultsLimitRule{},
 	&rule.MaxPublicStructsRule{},
 	&rule.RangeValInClosureRule{},
+	&rule.RangeValAddress{},
 	&rule.WaitGroupByValueRule{},
 	&rule.AtomicRule{},
 	&rule.EmptyLinesRule{},

--- a/fixtures/range-val-address.go
+++ b/fixtures/range-val-address.go
@@ -1,0 +1,47 @@
+package fixtures
+
+func rangeValAddress() {
+	m := map[string]*string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for _, value := range mySlice {
+		m["address"] = &value // MATCH /suspicious assignment in range-loop. variables always have the same address/
+	}
+}
+
+func rangeValAddress2() {
+	m := map[string]*string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for i := range mySlice {
+		m["address"] = &mySlice[i]
+	}
+}
+
+func rangeValAddress3() {
+	m := map[string]*string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for _, value := range mySlice {
+		a := &value // MATCH /suspicious assignment in range-loop. variables always have the same address/
+		m["address"] = a
+	}
+}
+
+func rangeValAddress4() {
+	m := []*string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for _, value := range mySlice {
+		m = append(m, &value) // MATCH /suspicious assignment in range-loop. variables always have the same address/
+	}
+}
+
+func rangeValAddress5() {
+	m := map[*string]string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for _, value := range mySlice {
+		m[&value] = value // MATCH /suspicious assignment in range-loop. variables always have the same address/
+	}
+}

--- a/fixtures/range-val-address.go
+++ b/fixtures/range-val-address.go
@@ -5,7 +5,7 @@ func rangeValAddress() {
 
 	mySlice := []string{"A", "B", "C"}
 	for _, value := range mySlice {
-		m["address"] = &value // MATCH /suspicious assignment in range-loop. variables always have the same address/
+		m["address"] = &value // MATCH /suspicious assignment of 'value'. range-loop variables always have the same address/
 	}
 }
 
@@ -23,7 +23,7 @@ func rangeValAddress3() {
 
 	mySlice := []string{"A", "B", "C"}
 	for _, value := range mySlice {
-		a := &value // MATCH /suspicious assignment in range-loop. variables always have the same address/
+		a := &value // MATCH /suspicious assignment of 'value'. range-loop variables always have the same address/
 		m["address"] = a
 	}
 }
@@ -33,7 +33,7 @@ func rangeValAddress4() {
 
 	mySlice := []string{"A", "B", "C"}
 	for _, value := range mySlice {
-		m = append(m, &value) // MATCH /suspicious assignment in range-loop. variables always have the same address/
+		m = append(m, &value) // MATCH /suspicious assignment of 'value'. range-loop variables always have the same address/
 	}
 }
 
@@ -42,6 +42,6 @@ func rangeValAddress5() {
 
 	mySlice := []string{"A", "B", "C"}
 	for _, value := range mySlice {
-		m[&value] = value // MATCH /suspicious assignment in range-loop. variables always have the same address/
+		m[&value] = value // MATCH /suspicious assignment of 'value'. range-loop variables always have the same address/
 	}
 }

--- a/rule/range-val-address.go
+++ b/rule/range-val-address.go
@@ -81,10 +81,12 @@ func (bw rangeBodyVisitor) Visit(node ast.Node) ast.Visitor {
 			if bw.isAccessingRangeValueAddress(e) {
 				bw.onFailure(bw.newFailure(e))
 			}
-		case *ast.CallExpr: // e.g. ...append(arr, &value)
-			for _, v := range e.Args {
-				if bw.isAccessingRangeValueAddress(v) {
-					bw.onFailure(bw.newFailure(e))
+		case *ast.CallExpr:
+			if fun, ok := e.Fun.(*ast.Ident); ok && fun.Name == "append" { // e.g. ...append(arr, &value)
+				for _, v := range e.Args {
+					if bw.isAccessingRangeValueAddress(v) {
+						bw.onFailure(bw.newFailure(e))
+					}
 				}
 			}
 		}

--- a/rule/range-val-address.go
+++ b/rule/range-val-address.go
@@ -1,0 +1,96 @@
+package rule
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// RangeValAddress lints
+type RangeValAddress struct{}
+
+// Apply applies the rule to given file.
+func (r *RangeValAddress) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	var failures []lint.Failure
+
+	walker := rangeValAddress{
+		onFailure: func(failure lint.Failure) {
+			failures = append(failures, failure)
+		},
+	}
+
+	ast.Walk(walker, file.AST)
+
+	return failures
+}
+
+// Name returns the rule name.
+func (r *RangeValAddress) Name() string {
+	return "range-val-address"
+}
+
+type rangeValAddress struct {
+	onFailure func(lint.Failure)
+}
+
+func (w rangeValAddress) Visit(node ast.Node) ast.Visitor {
+	n, ok := node.(*ast.RangeStmt)
+	if ok {
+		rangeValue := w.getNameFromExpr(n.Value)
+		if rangeValue == "" {
+			return w
+		}
+
+		fselect := func(n ast.Node) bool {
+			asgmt, ok := n.(*ast.AssignStmt)
+			if ok {
+				for _, exp := range asgmt.Lhs {
+					e, ok := exp.(*ast.IndexExpr)
+					if ok {
+						u, ok := e.Index.(*ast.UnaryExpr) // e.g. a[&value]...
+						if ok && u.Op == token.AND && w.getNameFromExpr(u.X) == rangeValue {
+							return true
+						}
+					}
+				}
+
+				for _, exp := range asgmt.Rhs {
+					switch e := exp.(type) {
+					case *ast.UnaryExpr: // e.g. ...&value
+						if e.Op == token.AND && w.getNameFromExpr(e.X) == rangeValue {
+							return true
+						}
+					case *ast.CallExpr: // e.g. ...append(arr, &value)
+						for _, v := range e.Args {
+							u, ok := v.(*ast.UnaryExpr)
+							if ok && u.Op == token.AND && w.getNameFromExpr(u.X) == rangeValue {
+								return true
+							}
+						}
+					}
+				}
+			}
+			return false
+		}
+
+		assignmentsToReceiver := pick(n.Body, fselect, nil)
+		for _, assignment := range assignmentsToReceiver {
+			w.onFailure(lint.Failure{
+				Node:       assignment,
+				Confidence: 1,
+				Failure:    "suspicious assignment in range-loop. variables always have the same address",
+			})
+		}
+	}
+	return w
+}
+
+func (rangeValAddress) getNameFromExpr(ie ast.Expr) string {
+	ident, ok := ie.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+
+	return ident.Name
+}

--- a/test/range-val-address_test.go
+++ b/test/range-val-address_test.go
@@ -1,0 +1,12 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
+)
+
+func TestRangeValAddress(t *testing.T) {
+	testRule(t, "range-val-address", &rule.RangeValAddress{}, &lint.RuleConfig{})
+}


### PR DESCRIPTION
See issue #352 for details

this rule will add the functionality to lint unwanted address assignments in range-loops.
i added a few test cases and these tests are passing. 
as i stated in issue #352, i have no experience with golang ast, so please review in detail.

Closes #352
