### PR TITLE
removes type-checking from empty-block rule

### DIFF
--- a/rule/empty-block.go
+++ b/rule/empty-block.go
@@ -2,7 +2,6 @@ package rule
 
 import (
 	"go/ast"
-	"go/types"
 
 	"github.com/mgechev/revive/lint"
 )
@@ -18,12 +17,7 @@ func (r *EmptyBlockRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure
 		failures = append(failures, failure)
 	}
 
-	err := file.Pkg.TypeCheck()
-	if err != nil {
-		panic("unable to type check " + file.Name + ":" + err.Error())
-	}
-
-	w := lintEmptyBlock{make(map[*ast.BlockStmt]bool, 0), file.Pkg, onFailure}
+	w := lintEmptyBlock{make(map[*ast.BlockStmt]bool, 0), onFailure}
 	ast.Walk(w, file.AST)
 	return failures
 }
@@ -35,7 +29,6 @@ func (r *EmptyBlockRule) Name() string {
 
 type lintEmptyBlock struct {
 	ignore    map[*ast.BlockStmt]bool
-	pkg       *lint.Package
 	onFailure func(lint.Failure)
 }
 
@@ -48,10 +41,14 @@ func (w lintEmptyBlock) Visit(node ast.Node) ast.Visitor {
 		w.ignore[n.Body] = true
 		return w
 	case *ast.RangeStmt:
-		t := w.pkg.TypeOf(n.X)
-
-		if _, ok := t.(*types.Chan); ok {
-			w.ignore[n.Body] = true
+		if len(n.Body.List) == 0 {
+			w.onFailure(lint.Failure{
+				Confidence: 0.9,
+				Node:       n,
+				Category:   "logic",
+				Failure:    "this block is empty, you can remove it",
+			})
+			return nil // skip visiting the range subtree (it will produce a duplicated failure)
 		}
 	case *ast.BlockStmt:
 		if !w.ignore[n] && len(n.List) == 0 {

--- a/testdata/empty-block.go
+++ b/testdata/empty-block.go
@@ -35,9 +35,9 @@ func g(f func() bool) {
 
 	}
 
-	// issue 386
+	// issue 386, then overwritten by issue 416
 	var c = make(chan int)
-	for range c {
+	for range c { // MATCH /this block is empty, you can remove it/
 	}
 
 	var s = "a string"


### PR DESCRIPTION
Closes #416 

Updated tests but as described in #424 we are currently incapable of testing on confidence level.
I've did some manual testing.

```
# set confidence = 1 in config, then
$ ./revive -config ./defaults.toml testdata/empty-block.go 
testdata/empty-block.go:13:2: this block is empty, you can remove it
testdata/empty-block.go:18:19: this block is empty, you can remove it
testdata/empty-block.go:26:9: this block is empty, you can remove it
testdata/empty-block.go:30:26: this block is empty, you can remove it
testdata/empty-block.go:34:6: this block is empty, you can remove it

# set confidence = 0.9 in config, then
$ ./revive -config ./defaults.toml testdata/empty-block.go 
testdata/empty-block.go:13:2: this block is empty, you can remove it
testdata/empty-block.go:18:19: this block is empty, you can remove it
testdata/empty-block.go:26:9: this block is empty, you can remove it
testdata/empty-block.go:30:26: this block is empty, you can remove it
testdata/empty-block.go:34:6: this block is empty, you can remove it
testdata/empty-block.go:40:2: this block is empty, you can remove it
testdata/empty-block.go:44:2: this block is empty, you can remove it
```
