### PR TITLE
Bump revive-action from 1.3.3 to 1.4.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.14
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run Revive Action
-      uses: morphy2k/revive-action@v1.3.3
+      uses: morphy2k/revive-action@v1.4.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
I made a stupid mistake! In an old version of [revive-action](https://github.com/morphy2k/revive-action) I have specified in the docker file to install the annotation binary via `go get` command without specifying a version. This now causes the old version to install the new incompatible binary.

This has been fixed in the latest version.

Big sorry!

**Edit:** In the meantime I have found a temporary solution and implemented it. The application uses a fallback value instead of exiting with an error.