### PR TITLE
adds "exclude" knob in configuration

### DIFF
--- a/lint/config.go
+++ b/lint/config.go
@@ -29,4 +29,5 @@ type Config struct {
 	ErrorCode             int              `toml:"errorCode"`
 	WarningCode           int              `toml:"warningCode"`
 	Directives            DirectivesConfig `toml:"directive"`
+	Exclude               []string         `toml:"exclude"`
 }

--- a/main.go
+++ b/main.go
@@ -29,6 +29,11 @@ func main() {
 	if err != nil {
 		fail(err.Error())
 	}
+
+	if len(excludePaths) == 0 { // if no excludes were set in the command line
+		excludePaths = conf.Exclude // use those from the configuration
+	}
+
 	packages, err := getPackages(excludePaths)
 	if err != nil {
 		fail(err.Error())


### PR DESCRIPTION
Closes #244 by adding an `exclude` field in the configuration. This field accepts an array of paths to exclude from the analysis. Path syntax is the same of that of the `-exclude` command line flag; for example the configuration

```toml
ignoreGeneratedHeader = false
severity = "warning"
confidence = 0.8
errorCode = 0
warningCode = 0
exclude = [
  "rule/...",
  "testdata/..."
]
``` 
will exclude the same files as if we execute `revive` with the following command line
```
revive -exclude rule/... -exclude testdata/... 
```

Excluding paths through command line flags overrides the configuration.