### PR TITLE
Add version command to show binary build info

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,13 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "unknown"
+)
+
 func fail(err string) {
 	fmt.Fprintln(os.Stderr, err)
 	os.Exit(1)
@@ -173,10 +180,23 @@ func init() {
 		color.NoColor = false
 	}
 
+	// Output build info (version, commit, date and builtBy)
+	if len(os.Args) > 1 && os.Args[1] == "--version" {
+		fmt.Printf(
+			"Current revive version %v commit %v, built @%v by %v.\n",
+			version,
+			commit,
+			date,
+			builtBy,
+		)
+		return
+	}
+
 	flag.Usage = func() {
 		fmt.Println(getBanner())
 		originalUsage()
 	}
+
 	// command line help strings
 	const (
 		configUsage    = "path to the configuration TOML file, defaults to $HOME/revive.toml, if present (i.e. -config myconf.toml)"

--- a/main.go
+++ b/main.go
@@ -139,6 +139,7 @@ var configPath string
 var excludePaths arrayFlags
 var formatterName string
 var help bool
+var versionFlag bool
 
 var originalUsage = flag.Usage
 
@@ -180,18 +181,6 @@ func init() {
 		color.NoColor = false
 	}
 
-	// Output build info (version, commit, date and builtBy)
-	if len(os.Args) > 1 && os.Args[1] == "--version" {
-		fmt.Printf(
-			"Current revive version %v commit %v, built @%v by %v.\n",
-			version,
-			commit,
-			date,
-			builtBy,
-		)
-		return
-	}
-
 	flag.Usage = func() {
 		fmt.Println(getBanner())
 		originalUsage()
@@ -202,6 +191,7 @@ func init() {
 		configUsage    = "path to the configuration TOML file, defaults to $HOME/revive.toml, if present (i.e. -config myconf.toml)"
 		excludeUsage   = "list of globs which specify files to be excluded (i.e. -exclude foo/...)"
 		formatterUsage = "formatter to be used for the output (i.e. -formatter stylish)"
+		versionUsage   = "get revive version"
 	)
 
 	defaultConfigPath := buildDefaultConfigPath()
@@ -209,5 +199,18 @@ func init() {
 	flag.StringVar(&configPath, "config", defaultConfigPath, configUsage)
 	flag.Var(&excludePaths, "exclude", excludeUsage)
 	flag.StringVar(&formatterName, "formatter", "", formatterUsage)
+	flag.BoolVar(&versionFlag, "version", false, versionUsage)
 	flag.Parse()
+
+	// Output build info (version, commit, date and builtBy)
+	if versionFlag {
+		fmt.Printf(
+			"Current revive version %v commit %v, built @%v by %v.\n",
+			version,
+			commit,
+			date,
+			builtBy,
+		)
+		os.Exit(0)
+	}
 }


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->
This PR adds a command to show version. goreleaser already pass these info during build time so [releases](https://github.com/mgechev/revive/releases) will have them by default from now on.

For manual builds, you can provide them:

```zsh
$ go build -v -ldflags="-X 'main.version=v1.0.0' -X 'main.commit=46f65914e3b26f7044ffe6842ecce10b58e2c2aa' -X 'main.date=2021-03-21T21:37:16Z' -X 'main.builtBy=goreleaser'"

$ ./revive --version
Current revive version v1.0.0 commit 46f65914e3b26f7044ffe6842ecce10b58e2c2aa, built @2021-03-21T21:37:16Z by goreleaser.

# If not there, it will be unknown
$ go build
$ ./revive --version
Current revive version dev commit none, built @unknown by unknown.
```

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follows the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

Closes #381
