### PR TITLE
Bump revive-action to v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,4 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run Revive Action
-      uses: morphy2k/revive-action@v1.4.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: morphy2k/revive-action@v2


### PR DESCRIPTION
I just released a [new major version](https://github.com/morphy2k/revive-action/releases/tag/v2.0.0) which, among other things, fixes the permission issue with PRs.

GitHub recently further restricted the permissions of the token, which severely limits the use when annotations are enabled. I switched to a [new alternative](https://github.com/morphy2k/revive-action/pull/48), this no longer requires direct access to the API.