### PR TITLE
fix 525

### DIFF
--- a/rule/context-as-argument.go
+++ b/rule/context-as-argument.go
@@ -45,16 +45,19 @@ func (w lintContextArguments) Visit(n ast.Node) ast.Visitor {
 	}
 	// A context.Context should be the first parameter of a function.
 	// Flag any that show up after the first.
+	previousArgIsCtx := isPkgDot(fn.Type.Params.List[0].Type, "context", "Context")
 	for _, arg := range fn.Type.Params.List[1:] {
-		if isPkgDot(arg.Type, "context", "Context") {
+		argIsCtx := isPkgDot(arg.Type, "context", "Context")
+		if argIsCtx && !previousArgIsCtx {
 			w.onFailure(lint.Failure{
-				Node:       fn,
+				Node:       arg,
 				Category:   "arg-order",
 				Failure:    "context.Context should be the first parameter of a function",
 				Confidence: 0.9,
 			})
 			break // only flag one
 		}
+		previousArgIsCtx = argIsCtx
 	}
 	return w
 }

--- a/testdata/golint/context-as-argument.go
+++ b/testdata/golint/context-as-argument.go
@@ -22,3 +22,7 @@ func y(s string, ctx context.Context) { // MATCH /context.Context should be the 
 // An invalid context.Context location with more than 2 args
 func y(s string, r int, ctx context.Context, x int) { // MATCH /context.Context should be the first parameter of a function/
 }
+
+func y(ctx1 context.Context, ctx2 context.Context, x int) {}
+
+func y(ctx1 context.Context, ctx2 context.Context, x int, ctx3 context.Context) {} // MATCH /context.Context should be the first parameter of a function/


### PR DESCRIPTION
Closes #525 

:warning: The rule `context-as-argument` is a rule that comes from, the defunct, `go-lint`. Therefore fixing this bug will make `revive` to behave slightly different from `go-lint`

(The failure message might also deserve to be adapted because now the rule checks that the _n_ parameters of type `context.Context` must be the _first n_ parameters of the function)