### PR TITLE
Add Unwrap to common methods

### DIFF
--- a/rule/utils.go
+++ b/rule/utils.go
@@ -29,6 +29,7 @@ var commonMethods = map[string]bool{
 	"ServeHTTP": true,
 	"String":    true,
 	"Write":     true,
+	"Unwrap":    true,
 }
 
 func receiverType(fn *ast.FuncDecl) string {


### PR DESCRIPTION
<!-- ### CHECKLIST ### -->
This adds Unwrap to the "common methods" list as was done in https://go-review.googlesource.com/c/lint/+/221610 (PR https://github.com/golang/lint/pull/487).

<!-- ### FOOTER (OPTIONAL) ### -->
Closes #546.