### PR TITLE
better messages for rules' config errors

### DIFF
--- a/rule/argument-limit.go
+++ b/rule/argument-limit.go
@@ -12,9 +12,7 @@ type ArgumentsLimitRule struct{}
 
 // Apply applies the rule to given file.
 func (r *ArgumentsLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	if len(arguments) != 1 {
-		panic(`invalid configuration for "argument-limit"`)
-	}
+	checkNumberOfArguments(1, arguments, r.Name())
 
 	total, ok := arguments[0].(int64) // Alt. non panicking version
 	if !ok {

--- a/rule/cognitive-complexity.go
+++ b/rule/cognitive-complexity.go
@@ -14,16 +14,14 @@ type CognitiveComplexityRule struct{}
 
 // Apply applies the rule to given file.
 func (r *CognitiveComplexityRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	var failures []lint.Failure
+	checkNumberOfArguments(1, arguments, r.Name())
 
-	const expectedArgumentsCount = 1
-	if len(arguments) < expectedArgumentsCount {
-		panic(fmt.Sprintf("not enough arguments for cognitive-complexity, expected %d, got %d", expectedArgumentsCount, len(arguments)))
-	}
 	complexity, ok := arguments[0].(int64)
 	if !ok {
 		panic(fmt.Sprintf("invalid argument type for cognitive-complexity, expected int64, got %T", arguments[0]))
 	}
+
+	var failures []lint.Failure
 
 	linter := cognitiveComplexityLinter{
 		file:          file,

--- a/rule/cyclomatic.go
+++ b/rule/cyclomatic.go
@@ -15,15 +15,14 @@ type CyclomaticRule struct{}
 
 // Apply applies the rule to given file.
 func (r *CyclomaticRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	var failures []lint.Failure
+	checkNumberOfArguments(1, arguments, r.Name())
 
-	if len(arguments) == 0 {
-		panic("not enough arguments for " + r.Name())
-	}
 	complexity, ok := arguments[0].(int64) // Alt. non panicking version
 	if !ok {
 		panic("invalid argument for cyclomatic complexity")
 	}
+
+	var failures []lint.Failure
 
 	fileAst := file.AST
 	walker := lintCyclomatic{

--- a/rule/file-header.go
+++ b/rule/file-header.go
@@ -16,9 +16,7 @@ var (
 
 // Apply applies the rule to given file.
 func (r *FileHeaderRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	if len(arguments) != 1 {
-		panic(`invalid configuration for "file-header" rule`)
-	}
+	checkNumberOfArguments(1, arguments, r.Name())
 
 	header, ok := arguments[0].(string)
 	if !ok {

--- a/rule/function-result-limit.go
+++ b/rule/function-result-limit.go
@@ -12,9 +12,7 @@ type FunctionResultsLimitRule struct{}
 
 // Apply applies the rule to given file.
 func (r *FunctionResultsLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	if len(arguments) != 1 {
-		panic(`invalid configuration for "function-result-limit"`)
-	}
+	checkNumberOfArguments(1, arguments, r.Name())
 
 	max, ok := arguments[0].(int64) // Alt. non panicking version
 	if !ok {

--- a/rule/line-length-limit.go
+++ b/rule/line-length-limit.go
@@ -16,9 +16,7 @@ type LineLengthLimitRule struct{}
 
 // Apply applies the rule to given file.
 func (r *LineLengthLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	if len(arguments) != 1 {
-		panic(`invalid configuration for "line-length-limit"`)
-	}
+	checkNumberOfArguments(1, arguments, r.Name())
 
 	max, ok := arguments[0].(int64) // Alt. non panicking version
 	if !ok || max < 0 {

--- a/rule/max-public-structs.go
+++ b/rule/max-public-structs.go
@@ -13,10 +13,14 @@ type MaxPublicStructsRule struct{}
 
 // Apply applies the rule to given file.
 func (r *MaxPublicStructsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	var failures []lint.Failure
-	if len(arguments) == 0 {
-		panic("not enough arguments for " + r.Name())
+	checkNumberOfArguments(1, arguments, r.Name())
+
+	max, ok := arguments[0].(int64) // Alt. non panicking version
+	if !ok {
+		panic(`invalid value passed as argument number to the "max-public-structs" rule`)
 	}
+
+	var failures []lint.Failure
 
 	fileAst := file.AST
 	walker := &lintMaxPublicStructs{
@@ -27,11 +31,6 @@ func (r *MaxPublicStructsRule) Apply(file *lint.File, arguments lint.Arguments) 
 	}
 
 	ast.Walk(walker, fileAst)
-
-	max, ok := arguments[0].(int64) // Alt. non panicking version
-	if !ok {
-		panic(`invalid value passed as argument number to the "max-public-structs" rule`)
-	}
 
 	if walker.current > max {
 		walker.onFailure(lint.Failure{

--- a/rule/utils.go
+++ b/rule/utils.go
@@ -190,3 +190,10 @@ func gofmt(x interface{}) string {
 	printer.Fprint(&buf, fs, x)
 	return buf.String()
 }
+
+// checkNumberOfArguments fails if the given number of arguments is not, at least, the expected one
+func checkNumberOfArguments(expected int, args lint.Arguments, ruleName string) {
+	if len(args) < expected {
+		panic(fmt.Sprintf("not enough arguments for %s rule, expected %d, got %d. Please check the rule's documentation", ruleName, expected, len(args)))
+	}
+}


### PR DESCRIPTION
Provides better messages when a rule configuration error arises. 
Related to #561 