### PR TITLE
Fix config initialisation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,12 +4,17 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 
 	"github.com/mgechev/revive/formatter"
 
 	"github.com/BurntSushi/toml"
 	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/rule"
+)
+
+const (
+	defaultConfidence = 0.8
 )
 
 var defaultRules = []lint.Rule{
@@ -129,7 +134,9 @@ func GetLintingRules(config *lint.Config) ([]lint.Rule, error) {
 }
 
 func parseConfig(path string) (*lint.Config, error) {
-	config := &lint.Config{}
+	config := &lint.Config{
+		Confidence: math.Inf(1),
+	}
 	file, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, errors.New("cannot read the config file")
@@ -142,8 +149,7 @@ func parseConfig(path string) (*lint.Config, error) {
 }
 
 func normalizeConfig(config *lint.Config) {
-	const defaultConfidence = 0.8
-	if config.Confidence == 0 {
+	if config.Confidence == math.Inf(1) {
 		config.Confidence = defaultConfidence
 	}
 
@@ -210,7 +216,7 @@ func GetFormatter(formatterName string) (lint.Formatter, error) {
 
 func defaultConfig() *lint.Config {
 	defaultConfig := lint.Config{
-		Confidence: 0.0,
+		Confidence: math.Inf(1),
 		Severity:   lint.SeverityWarning,
 		Rules:      map[string]lint.RuleConfig{},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -4,17 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math"
 
 	"github.com/mgechev/revive/formatter"
 
 	"github.com/BurntSushi/toml"
 	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/rule"
-)
-
-const (
-	defaultConfidence = 0.8
 )
 
 var defaultRules = []lint.Rule{
@@ -86,7 +81,6 @@ var allRules = append([]lint.Rule{
 	&rule.NestedStructs{},
 	&rule.IfReturnRule{},
 	&rule.UselessBreak{},
-	&rule.TimeEqualRule{},
 }, defaultRules...)
 
 var allFormatters = []lint.Formatter{
@@ -133,26 +127,19 @@ func GetLintingRules(config *lint.Config) ([]lint.Rule, error) {
 	return lintingRules, nil
 }
 
-func parseConfig(path string) (*lint.Config, error) {
-	config := &lint.Config{
-		Confidence: math.Inf(1),
-	}
+func parseConfig(path string, config *lint.Config) error {
 	file, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, errors.New("cannot read the config file")
+		return errors.New("cannot read the config file")
 	}
 	_, err = toml.Decode(string(file), config)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse the config file: %v", err)
+		return fmt.Errorf("cannot parse the config file: %v", err)
 	}
-	return config, nil
+	return nil
 }
 
 func normalizeConfig(config *lint.Config) {
-	if config.Confidence == math.Inf(1) {
-		config.Confidence = defaultConfidence
-	}
-
 	if len(config.Rules) == 0 {
 		config.Rules = map[string]lint.RuleConfig{}
 	}
@@ -186,16 +173,23 @@ func normalizeConfig(config *lint.Config) {
 	}
 }
 
+const defaultConfidence = 0.8
+
 // GetConfig yields the configuration
 func GetConfig(configPath string) (*lint.Config, error) {
-	config := defaultConfig()
-	if configPath != "" {
-		var err error
-		config, err = parseConfig(configPath)
+	var config = &lint.Config{}
+	switch {
+	case configPath != "":
+		config.Confidence = defaultConfidence
+		err := parseConfig(configPath, config)
 		if err != nil {
 			return nil, err
 		}
+
+	default: // no configuration provided
+		config = defaultConfig()
 	}
+
 	normalizeConfig(config)
 	return config, nil
 }
@@ -216,7 +210,7 @@ func GetFormatter(formatterName string) (lint.Formatter, error) {
 
 func defaultConfig() *lint.Config {
 	defaultConfig := lint.Config{
-		Confidence: math.Inf(1),
+		Confidence: defaultConfidence,
 		Severity:   lint.SeverityWarning,
 		Rules:      map[string]lint.RuleConfig{},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,7 @@ var allRules = append([]lint.Rule{
 	&rule.NestedStructs{},
 	&rule.IfReturnRule{},
 	&rule.UselessBreak{},
+	&rule.TimeEqualRule{},
 }, defaultRules...)
 
 var allFormatters = []lint.Formatter{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,7 +28,11 @@ func TestGetConfig(t *testing.T) {
 			wantError: "cannot parse the config file",
 		},
 		"default config": {
-			wantConfig: defaultConfig(),
+			wantConfig: func() *lint.Config {
+				c := defaultConfig()
+				normalizeConfig(c)
+				return c
+			}(),
 		},
 	}
 
@@ -40,7 +44,7 @@ func TestGetConfig(t *testing.T) {
 				t.Fatalf("Unexpected error\n\t%v", err)
 			case err != nil && !strings.Contains(err.Error(), tc.wantError):
 				t.Fatalf("Expected error\n\t%q\ngot:\n\t%v", tc.wantError, err)
-			case tc.wantConfig != nil && reflect.DeepEqual(cfg, tc.wantConfig):
+			case tc.wantConfig != nil && !reflect.DeepEqual(cfg, tc.wantConfig):
 				t.Fatalf("Expected config\n\t%+v\ngot:\n\t%+v", tc.wantConfig, cfg)
 			}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,9 +11,10 @@ import (
 
 func TestGetConfig(t *testing.T) {
 	tt := map[string]struct {
-		confPath   string
-		wantConfig *lint.Config
-		wantError  string
+		confPath       string
+		wantConfig     *lint.Config
+		wantError      string
+		wantConfidence float64
 	}{
 		"non-reg issue #470": {
 			confPath:  "testdata/issue-470.toml",
@@ -33,6 +34,15 @@ func TestGetConfig(t *testing.T) {
 				normalizeConfig(c)
 				return c
 			}(),
+			wantConfidence: defaultConfidence,
+		},
+		"config from file issue #585": {
+			confPath:       "testdata/issue-585.toml",
+			wantConfidence: 0.0,
+		},
+		"config from file default confidence issue #585": {
+			confPath:       "testdata/issue-585-defaultConfidence.toml",
+			wantConfidence: defaultConfidence,
 		},
 	}
 
@@ -46,8 +56,9 @@ func TestGetConfig(t *testing.T) {
 				t.Fatalf("Expected error\n\t%q\ngot:\n\t%v", tc.wantError, err)
 			case tc.wantConfig != nil && !reflect.DeepEqual(cfg, tc.wantConfig):
 				t.Fatalf("Expected config\n\t%+v\ngot:\n\t%+v", tc.wantConfig, cfg)
+			case tc.wantConfig != nil && tc.wantConfidence != cfg.Confidence:
+				t.Fatalf("Expected confidence\n\t%+v\ngot:\n\t%+v", tc.wantConfidence, cfg.Confidence)
 			}
-
 		})
 	}
 }
@@ -88,7 +99,6 @@ func TestGetLintingRules(t *testing.T) {
 			case len(rules) != tc.wantRulesCount:
 				t.Fatalf("Expected %v enabled linting rules got: %v", tc.wantRulesCount, len(rules))
 			}
-
 		})
 	}
 }

--- a/config/testdata/issue-585-defaultConfidence.toml
+++ b/config/testdata/issue-585-defaultConfidence.toml
@@ -1,0 +1,4 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+errorCode = 0
+warningCode = 0

--- a/config/testdata/issue-585.toml
+++ b/config/testdata/issue-585.toml
@@ -1,0 +1,5 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.0
+errorCode = 0
+warningCode = 0


### PR DESCRIPTION
Closes #585. Also fixes the "default config" test, which I believe should fail when `reflect.DeepEqual(cfg, tc.wantConfig) == false`.