### PR TITLE
Run revive over a invalid go source file (#364)

### DIFF
--- a/lint/file.go
+++ b/lint/file.go
@@ -47,7 +47,7 @@ func (f *File) ToPosition(pos token.Pos) token.Position {
 	return f.Pkg.fset.Position(pos)
 }
 
-// Render renters a node.
+// Render renders a node.
 func (f *File) Render(x interface{}) string {
 	var buf bytes.Buffer
 	if err := printer.Fprint(&buf, f.Pkg.fset, x); err != nil {
@@ -74,7 +74,7 @@ var basicTypeKinds = map[types.BasicKind]string{
 // and indicates what its default type is.
 // scope may be nil.
 func (f *File) IsUntypedConst(expr ast.Expr) (defType string, ok bool) {
-	// Re-evaluate expr outside of its context to see if it's untyped.
+	// Re-evaluate expr outside its context to see if it's untyped.
 	// (An expr evaluated within, for example, an assignment context will get the type of the LHS.)
 	exprStr := f.Render(expr)
 	tv, err := types.Eval(f.Pkg.fset, f.Pkg.TypesPkg, expr.Pos(), exprStr)
@@ -206,9 +206,9 @@ func (f *File) disabledIntervals(rules []Rule, mustSpecifyDisableReason bool, fa
 			if len(match) == 0 {
 				continue
 			}
-
 			ruleNames := []string{}
 			tempNames := strings.Split(match[rulesPos], ",")
+
 			for _, name := range tempNames {
 				name = strings.Trim(name, "\n")
 				if len(name) > 0 {

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"go/token"
 	"os"
+	"regexp"
+	"strconv"
 	"sync"
 )
 
@@ -64,13 +66,14 @@ func (l *Linter) lintPackage(filenames []string, ruleSet []Rule, config Config, 
 		if err != nil {
 			return err
 		}
-		if isGenerated(content) && !config.IgnoreGeneratedHeader {
+		if !config.IgnoreGeneratedHeader && isGenerated(content) {
 			continue
 		}
 
 		file, err := NewFile(filename, content, pkg)
 		if err != nil {
-			return err
+			addInvalidFileFailure(filename, err.Error(), failures)
+			continue
 		}
 		pkg.files[filename] = file
 	}
@@ -96,4 +99,43 @@ func isGenerated(src []byte) bool {
 		}
 	}
 	return false
+}
+
+// addInvalidFileFailure adds a failure for an invalid formatted file
+func addInvalidFileFailure(filename, errStr string, failures chan Failure) {
+	position := getPositionInvalidFile(filename, errStr)
+	failures <- Failure{
+		Confidence: 1,
+		Failure:    fmt.Sprintf("invalid file %s: %v", filename, errStr),
+		Category:   "validity",
+		Position:   position,
+	}
+}
+
+// errPosRegexp matches with an NewFile error message
+// i.e. :  corrupted.go:10:4: expected '}', found 'EOF
+// first group matches the line and the second group, the column
+var errPosRegexp = regexp.MustCompile(".*:(\\d*):(\\d*):.*$")
+
+// getPositionInvalidFile gets the position of the error in an invalid file
+func getPositionInvalidFile(filename, s string) FailurePosition {
+	pos := errPosRegexp.FindStringSubmatch(s)
+	if len(pos) < 3 {
+		return FailurePosition{}
+	}
+	line, err := strconv.Atoi(pos[1])
+	if err != nil {
+		return FailurePosition{}
+	}
+	column, err := strconv.Atoi(pos[2])
+	if err != nil {
+		return FailurePosition{}
+	}
+
+	return FailurePosition{
+		Start: token.Position{
+			Filename: filename,
+			Line:     line,
+			Column:   column,
+		}}
 }


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->


<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
# Description
Make the revive analysis continue even a go file is invalid.

<!-- Did you add tests? -->
# Tests
I did not add UT. This package dies not hold tests ?
I tested it on a repository, here is an extract from the output.

```
pkg/controllers/idlingresource_controller.go
  (59, 1)    https://revive.run/r#exported           exported method IdlingResourceReconciler.Reconcile should have comment or be unexported           

  (0, 0)  https://revive.run/r#no-rule  invalid file corrupted.go: corrupted.go:10:4: expected '}', found 'EOF'  

pkg/version/version.go
  (4, 2)   https://revive.run/r#exported  exported var Revision should have comment or be unexported                                                        
  (11, 6)  https://revive.run/r#exported  exported type VersionInfos should have comment or be unexported                                                   
  ```

<!-- Does your code follows the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

# Questions
1. Should the package appear ?
2. Do you think that (0,0) position is easthetic ?

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
