### PR TITLE
Avoids missing version description when using go install

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,5 +238,6 @@ func init() {
 		}
 
 		fmt.Printf("Version:\t%s\n%s", version, buildInfo)
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
As an addition to #593, I have added a second form of version description to avoid missing when using go install.

The go install command is not able to retrieve the flags (commit, date and builtBy) unless they are explicitly stated in the release code. But we can get the version, which can be useful when is requested for the latest version.

Closes #560
