### PR TITLE
Fix file-header.go

### DIFF
--- a/rule/file-header.go
+++ b/rule/file-header.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/mgechev/revive/lint"


### PR DESCRIPTION
Add missing fmt import

---

Unfortunately #595 added a fmt.Sprintf call to rule/file-header.go but didn't add the fmt package to the imports.

This has broken compiling of the revive package.