### PR TITLE
refactor(cyclomatic): improved message for `cyclomatic` rule

### DIFF
--- a/rule/cyclomatic.go
+++ b/rule/cyclomatic.go
@@ -62,8 +62,9 @@ func (w lintCyclomatic) Visit(_ ast.Node) ast.Visitor {
 				w.onFailure(lint.Failure{
 					Confidence: 1,
 					Category:   "maintenance",
-					Failure:    fmt.Sprintf("function %s has cyclomatic complexity %d", funcName(fn), c),
-					Node:       fn,
+					Failure: fmt.Sprintf("function %s has cyclomatic complexity %d (> max enabled %d)",
+						funcName(fn), c, w.complexity),
+					Node: fn,
 				})
 			}
 		}

--- a/testdata/cyclomatic-2.go
+++ b/testdata/cyclomatic-2.go
@@ -5,7 +5,7 @@ package pkg
 
 import "log"
 
-func f(x int) bool { // MATCH /function f has cyclomatic complexity 4/
+func f(x int) bool { // MATCH /function f has cyclomatic complexity 4 (> max enabled 3)/
 	if x > 0 && true || false {
 		return true
 	} else {

--- a/testdata/cyclomatic.go
+++ b/testdata/cyclomatic.go
@@ -5,7 +5,7 @@ package pkg
 
 import "log"
 
-func f(x int) bool { // MATCH /function f has cyclomatic complexity 4/
+func f(x int) bool { // MATCH /function f has cyclomatic complexity 4 (> max enabled 1)/
 	if x > 0 && true || false {
 		return true
 	} else {
@@ -14,7 +14,7 @@ func f(x int) bool { // MATCH /function f has cyclomatic complexity 4/
 	return false
 }
 
-func g(f func() bool) string { // MATCH /function g has cyclomatic complexity 2/
+func g(f func() bool) string { // MATCH /function g has cyclomatic complexity 2 (> max enabled 1)/
 	if ok := f(); ok {
 		return "it's okay"
 	} else {


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
### Please, describe in details what's your motivation for this PR 
`cyclomatic` and `cognitive-complexity` are quite similar rules, but `cognitive-complexity` currenly showing `max enabled` so programmer don't need to open configs and check whats complexity level is targeted, however `cyclomatic` is missing this information.

### Did you add tests? 
I have updated tests.

### Does your code follows the coding style of the rest of the repository? 
Yes.

<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

### consolidated output of few linters from `golangci-lint` 

```diff
-main.go:17:1: cyclomatic: function j has cyclomatic complexity 3 (revive)
+main.go:17:1: cyclomatic: function j has cyclomatic complexity 3 (> max enabled 1) (revive)
 main.go:17:1: cognitive-complexity: function j has cognitive complexity 2 (> max enabled 1) (revive)
 main.go:17:1: cyclomatic complexity 3 of func `j` is high (> 1) (gocyclo)
 main.go:17:1: cognitive complexity 2 of func `j` is high (> 1) (gocognit)
```
