### PR TITLE
Incorrect handling of token.{LEQ,GEQ} for constant-logical-expr

### DIFF
--- a/rule/constant-logical-expr.go
+++ b/rule/constant-logical-expr.go
@@ -1,9 +1,10 @@
 package rule
 
 import (
-	"github.com/mgechev/revive/lint"
 	"go/ast"
 	"go/token"
+
+	"github.com/mgechev/revive/lint"
 )
 
 // ConstantLogicalExprRule warns on constant logical expressions.
@@ -44,11 +45,13 @@ func (w *lintConstantLogicalExpr) Visit(node ast.Node) ast.Visitor {
 			return w
 		}
 
-		if n.Op == token.EQL {
+		// Handles cases like: a <= b, a == b, a >= b
+		if w.isEqualityOperator(n.Op) {
 			w.newFailure(n, "expression always evaluates to true")
 			return w
 		}
 
+		// Handles cases like: a < b, a > b, a != b
 		if w.isInequalityOperator(n.Op) {
 			w.newFailure(n, "expression always evaluates to false")
 			return w
@@ -69,9 +72,18 @@ func (w *lintConstantLogicalExpr) isOperatorWithLogicalResult(t token.Token) boo
 	return false
 }
 
+func (w *lintConstantLogicalExpr) isEqualityOperator(t token.Token) bool {
+	switch t {
+	case token.EQL, token.LEQ, token.GEQ:
+		return true
+	}
+
+	return false
+}
+
 func (w *lintConstantLogicalExpr) isInequalityOperator(t token.Token) bool {
 	switch t {
-	case token.LSS, token.GTR, token.NEQ, token.LEQ, token.GEQ:
+	case token.LSS, token.GTR, token.NEQ:
 		return true
 	}
 

--- a/rule/constant-logical-expr.go
+++ b/rule/constant-logical-expr.go
@@ -45,13 +45,13 @@ func (w *lintConstantLogicalExpr) Visit(node ast.Node) ast.Visitor {
 			return w
 		}
 
-		// Handles cases like: a <= b, a == b, a >= b
+		// Handles cases like: a <= a, a == a, a >= a
 		if w.isEqualityOperator(n.Op) {
 			w.newFailure(n, "expression always evaluates to true")
 			return w
 		}
 
-		// Handles cases like: a < b, a > b, a != b
+		// Handles cases like: a < a, a > a, a != a
 		if w.isInequalityOperator(n.Op) {
 			w.newFailure(n, "expression always evaluates to false")
 			return w

--- a/testdata/constant-logical-expr.go
+++ b/testdata/constant-logical-expr.go
@@ -1,5 +1,7 @@
 package fixtures
 
+import "fmt"
+
 // from github.com/ugorji/go/codec/helper.go
 func isNaN(f float64) bool { return f != f } // MATCH /expression always evaluates to false/
 
@@ -9,9 +11,9 @@ func foo1(f float64) bool { return foo2(2.) > foo2(2.) } // MATCH /expression al
 
 func foo2(f float64) bool { return f < f } // MATCH /expression always evaluates to false/
 
-func foo3(f float64) bool { return f <= f } // MATCH /expression always evaluates to false/
+func foo3(f float64) bool { return f <= f } // MATCH /expression always evaluates to true/
 
-func foo4(f float64) bool { return f >= f } // MATCH /expression always evaluates to false/
+func foo4(f float64) bool { return f >= f } // MATCH /expression always evaluates to true/
 
 func foo5(f float64) bool { return f == f } // MATCH /expression always evaluates to true/
 


### PR DESCRIPTION
Fixes the implementation for `constant-logical-expr` where logic handling for `token.LEQ` and `token.GEQ` operators is incorrect.

Fixes: #641