### PR TITLE
Format sources w/ gofumpt

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -180,7 +180,7 @@ const defaultConfidence = 0.8
 
 // GetConfig yields the configuration
 func GetConfig(configPath string) (*lint.Config, error) {
-	var config = &lint.Config{}
+	config := &lint.Config{}
 	switch {
 	case configPath != "":
 		config.Confidence = defaultConfidence

--- a/formatter/checkstyle.go
+++ b/formatter/checkstyle.go
@@ -3,8 +3,9 @@ package formatter
 import (
 	"bytes"
 	"encoding/xml"
-	"github.com/mgechev/revive/lint"
 	plainTemplate "text/template"
+
+	"github.com/mgechev/revive/lint"
 )
 
 // Checkstyle is an implementation of the Formatter interface
@@ -29,7 +30,7 @@ type issue struct {
 
 // Format formats the failures gotten from the lint.
 func (f *Checkstyle) Format(failures <-chan lint.Failure, config lint.Config) (string, error) {
-	var issues = map[string][]issue{}
+	issues := map[string][]issue{}
 	for failure := range failures {
 		buf := new(bytes.Buffer)
 		xml.Escape(buf, []byte(failure.Failure))

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -34,8 +34,8 @@ func formatFailure(failure lint.Failure, severity lint.Severity) []string {
 // Format formats the failures gotten from the lint.
 func (f *Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string, error) {
 	var result [][]string
-	var totalErrors = 0
-	var total = 0
+	totalErrors := 0
+	total := 0
 
 	for f := range failures {
 		total++

--- a/lint/file.go
+++ b/lint/file.go
@@ -126,11 +126,13 @@ type enableDisableConfig struct {
 	position int
 }
 
-const directiveRE = `^//[\s]*revive:(enable|disable)(?:-(line|next-line))?(?::([^\s]+))?[\s]*(?: (.+))?$`
-const directivePos = 1
-const modifierPos = 2
-const rulesPos = 3
-const reasonPos = 4
+const (
+	directiveRE  = `^//[\s]*revive:(enable|disable)(?:-(line|next-line))?(?::([^\s]+))?[\s]*(?: (.+))?$`
+	directivePos = 1
+	modifierPos  = 2
+	rulesPos     = 3
+	reasonPos    = 4
+)
 
 var re = regexp.MustCompile(directiveRE)
 

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -159,5 +159,6 @@ func getPositionInvalidFile(filename, s string) FailurePosition {
 			Filename: filename,
 			Line:     line,
 			Column:   column,
-		}}
+		},
+	}
 }

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -23,7 +23,7 @@ type AbstractRule struct {
 }
 
 // ToFailurePosition returns the failure position.
-func ToFailurePosition(start token.Pos, end token.Pos, file *File) FailurePosition {
+func ToFailurePosition(start, end token.Pos, file *File) FailurePosition {
 	return FailurePosition{
 		Start: file.ToPosition(start),
 		End:   file.ToPosition(end),

--- a/rule/add-constant.go
+++ b/rule/add-constant.go
@@ -22,7 +22,7 @@ func newWhiteList() whiteList {
 	return map[string]map[string]bool{kindINT: {}, kindFLOAT: {}, kindSTRING: {}}
 }
 
-func (wl whiteList) add(kind string, list string) {
+func (wl whiteList) add(kind, list string) {
 	elems := strings.Split(list, ",")
 	for _, e := range elems {
 		wl[kind][e] = true
@@ -120,7 +120,6 @@ func (w lintAddConstantRule) Visit(node ast.Node) ast.Visitor {
 	}
 
 	return w
-
 }
 
 func (w lintAddConstantRule) checkStrLit(n *ast.BasicLit) {

--- a/rule/bool-literal-in-expr.go
+++ b/rule/bool-literal-in-expr.go
@@ -63,7 +63,7 @@ func (w *lintBoolLiteral) Visit(node ast.Node) ast.Visitor {
 	return w
 }
 
-func (w lintBoolLiteral) addFailure(node ast.Node, msg string, cat string) {
+func (w lintBoolLiteral) addFailure(node ast.Node, msg, cat string) {
 	w.onFailure(lint.Failure{
 		Confidence: 1,
 		Node:       node,

--- a/rule/call-to-gc.go
+++ b/rule/call-to-gc.go
@@ -16,7 +16,7 @@ func (r *CallToGCRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 		failures = append(failures, failure)
 	}
 
-	var gcTriggeringFunctions = map[string]map[string]bool{
+	gcTriggeringFunctions := map[string]map[string]bool{
 		"runtime": {"GC": true},
 	}
 

--- a/rule/confusing-naming.go
+++ b/rule/confusing-naming.go
@@ -3,7 +3,6 @@ package rule
 import (
 	"fmt"
 	"go/ast"
-
 	"strings"
 	"sync"
 
@@ -71,7 +70,7 @@ func (r *ConfusingNamingRule) Name() string {
 	return "confusing-naming"
 }
 
-//checkMethodName checks if a given method/function name is similar (just case differences) to other method/function of the same struct/file.
+// checkMethodName checks if a given method/function name is similar (just case differences) to other method/function of the same struct/file.
 func checkMethodName(holder string, id *ast.Ident, w *lintConfusingNames) {
 	if id.Name == "init" && holder == defaultStructName {
 		// ignore init functions
@@ -128,7 +127,7 @@ type lintConfusingNames struct {
 
 const defaultStructName = "_" // used to map functions
 
-//getStructName of a function receiver. Defaults to defaultStructName
+// getStructName of a function receiver. Defaults to defaultStructName
 func getStructName(r *ast.FieldList) string {
 	result := defaultStructName
 

--- a/rule/constant-logical-expr.go
+++ b/rule/constant-logical-expr.go
@@ -1,9 +1,10 @@
 package rule
 
 import (
-	"github.com/mgechev/revive/lint"
 	"go/ast"
 	"go/token"
+
+	"github.com/mgechev/revive/lint"
 )
 
 // ConstantLogicalExprRule warns on constant logical expressions.

--- a/rule/context-as-argument.go
+++ b/rule/context-as-argument.go
@@ -15,7 +15,6 @@ type ContextAsArgumentRule struct {
 
 // Apply applies the rule to given file.
 func (r *ContextAsArgumentRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
-
 	if r.allowTypesLUT == nil {
 		r.allowTypesLUT = getAllowTypesFromArguments(args)
 	}

--- a/rule/deep-exit.go
+++ b/rule/deep-exit.go
@@ -17,7 +17,7 @@ func (r *DeepExitRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 		failures = append(failures, failure)
 	}
 
-	var exitFunctions = map[string]map[string]bool{
+	exitFunctions := map[string]map[string]bool{
 		"os":      {"Exit": true},
 		"syscall": {"Exit": true},
 		"log": {

--- a/rule/defer.go
+++ b/rule/defer.go
@@ -122,11 +122,12 @@ func (w lintDeferRule) visitSubtree(n ast.Node, inADefer, inALoop, inAFuncLit bo
 		inADefer:   inADefer,
 		inALoop:    inALoop,
 		inAFuncLit: inAFuncLit,
-		allow:      w.allow}
+		allow:      w.allow,
+	}
 	ast.Walk(nw, n)
 }
 
-func (w lintDeferRule) newFailure(msg string, node ast.Node, confidence float64, cat string, subcase string) {
+func (w lintDeferRule) newFailure(msg string, node ast.Node, confidence float64, cat, subcase string) {
 	if !w.allow[subcase] {
 		return
 	}

--- a/rule/error-strings.go
+++ b/rule/error-strings.go
@@ -17,7 +17,7 @@ type ErrorStringsRule struct{}
 func (r *ErrorStringsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	var errorFunctions = map[string]map[string]struct{}{
+	errorFunctions := map[string]map[string]struct{}{
 		"fmt": {
 			"Errorf": {},
 		},

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -61,7 +61,7 @@ func (r *ExportedRule) Name() string {
 	return "exported"
 }
 
-func (r *ExportedRule) getConf(args lint.Arguments) (checkPrivateReceivers bool, disableStutteringCheck bool, sayRepetitiveInsteadOfStutters bool) {
+func (r *ExportedRule) getConf(args lint.Arguments) (checkPrivateReceivers, disableStutteringCheck, sayRepetitiveInsteadOfStutters bool) {
 	// if any, we expect a slice of strings as configuration
 	if len(args) < 1 {
 		return

--- a/rule/flag-param.go
+++ b/rule/flag-param.go
@@ -2,8 +2,9 @@ package rule
 
 import (
 	"fmt"
-	"github.com/mgechev/revive/lint"
 	"go/ast"
+
+	"github.com/mgechev/revive/lint"
 )
 
 // FlagParamRule lints given else constructs.

--- a/rule/function-length.go
+++ b/rule/function-length.go
@@ -43,7 +43,7 @@ func (r *FunctionLength) Name() string {
 	return "function-length"
 }
 
-func (r *FunctionLength) parseArguments(arguments lint.Arguments) (maxStmt int64, maxLines int64) {
+func (r *FunctionLength) parseArguments(arguments lint.Arguments) (maxStmt, maxLines int64) {
 	if len(arguments) != 2 {
 		panic(fmt.Sprintf(`invalid configuration for "function-length" rule, expected 2 arguments but got %d`, len(arguments)))
 	}

--- a/rule/max-public-structs.go
+++ b/rule/max-public-structs.go
@@ -2,7 +2,6 @@ package rule
 
 import (
 	"go/ast"
-
 	"strings"
 
 	"github.com/mgechev/revive/lint"

--- a/rule/range-val-in-closure.go
+++ b/rule/range-val-in-closure.go
@@ -35,7 +35,6 @@ type rangeValInClosure struct {
 }
 
 func (w rangeValInClosure) Visit(node ast.Node) ast.Visitor {
-
 	// Find the variables updated by the loop statement.
 	var vars []*ast.Ident
 	addVar := func(expr ast.Expr) {

--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -2,9 +2,10 @@ package rule
 
 import (
 	"fmt"
-	"github.com/mgechev/revive/lint"
 	"go/ast"
 	"go/token"
+
+	"github.com/mgechev/revive/lint"
 )
 
 // RedefinesBuiltinIDRule warns when a builtin identifier is shadowed.
@@ -14,14 +15,14 @@ type RedefinesBuiltinIDRule struct{}
 func (r *RedefinesBuiltinIDRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	var builtInConstAndVars = map[string]bool{
+	builtInConstAndVars := map[string]bool{
 		"true":  true,
 		"false": true,
 		"iota":  true,
 		"nil":   true,
 	}
 
-	var builtFunctions = map[string]bool{
+	builtFunctions := map[string]bool{
 		"append":  true,
 		"cap":     true,
 		"close":   true,
@@ -39,7 +40,7 @@ func (r *RedefinesBuiltinIDRule) Apply(file *lint.File, _ lint.Arguments) []lint
 		"recover": true,
 	}
 
-	var builtInTypes = map[string]bool{
+	builtInTypes := map[string]bool{
 		"ComplexType": true,
 		"FloatType":   true,
 		"IntegerType": true,

--- a/rule/string-format.go
+++ b/rule/string-format.go
@@ -276,7 +276,8 @@ func (rule stringFormatSubrule) lintMessage(s string, node ast.Node) {
 	rule.parent.onFailure(lint.Failure{
 		Confidence: 1,
 		Failure:    failure,
-		Node:       node})
+		Node:       node,
+	})
 }
 
 // #endregion

--- a/rule/struct-tag.go
+++ b/rule/struct-tag.go
@@ -53,7 +53,6 @@ func (w lintStructTagRule) Visit(node ast.Node) ast.Visitor {
 	}
 
 	return w
-
 }
 
 // checkTaggedField checks the tag of the given field.

--- a/rule/superfluous-else.go
+++ b/rule/superfluous-else.go
@@ -18,7 +18,7 @@ func (r *SuperfluousElseRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 		failures = append(failures, failure)
 	}
 
-	var branchingFunctions = map[string]map[string]bool{
+	branchingFunctions := map[string]map[string]bool{
 		"os": {"Exit": true},
 		"log": {
 			"Fatal":   true,

--- a/rule/unreachable-code.go
+++ b/rule/unreachable-code.go
@@ -16,7 +16,7 @@ func (r *UnreachableCodeRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 		failures = append(failures, failure)
 	}
 
-	var branchingFunctions = map[string]map[string]bool{
+	branchingFunctions := map[string]map[string]bool{
 		"os": {"Exit": true},
 		"log": {
 			"Fatal":   true,


### PR DESCRIPTION
Format sources w/ gofumpt, i.e., no change to tests, testdata, etc., where formatting could've been a problem. Safe to merge.