### PR TITLE
Remove debugging output

### DIFF
--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -136,7 +136,6 @@ func (w *lintRedefinesBuiltinID) Visit(node ast.Node) ast.Visitor {
 
 			if ok, bt := w.isBuiltIn(id.Name); ok {
 				var msg string
-				println(bt, id.Name)
 				switch bt {
 				case "constant or variable":
 					if n.Tok == token.DEFINE {


### PR DESCRIPTION
Noticed during migration from our heavily modified "go-lint" to "revive" that there is an additional line printed. I am unsure that the convention for this project is on this, we do not allow adding such a call.