### PR TITLE
Fix/677

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ build:
 	@go build -ldflags='$(VERSION_FLAGS)'
 
 test:
-	@go test -v ./...
+	@go test -v -race ./...
 

--- a/lint/file.go
+++ b/lint/file.go
@@ -77,7 +77,7 @@ func (f *File) IsUntypedConst(expr ast.Expr) (defType string, ok bool) {
 	// Re-evaluate expr outside its context to see if it's untyped.
 	// (An expr evaluated within, for example, an assignment context will get the type of the LHS.)
 	exprStr := f.Render(expr)
-	tv, err := types.Eval(f.Pkg.fset, f.Pkg.TypesPkg, expr.Pos(), exprStr)
+	tv, err := types.Eval(f.Pkg.fset, f.Pkg.TypesPkg(), expr.Pos(), exprStr)
 	if err != nil {
 		return "", false
 	}

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -81,7 +81,6 @@ func (l *Linter) lintPackage(filenames []string, ruleSet []Rule, config Config, 
 	pkg := &Package{
 		fset:  token.NewFileSet(),
 		files: map[string]*File{},
-		mu:    sync.Mutex{},
 	}
 	for _, filename := range filenames {
 		content, err := l.readFile(filename)

--- a/lint/package.go
+++ b/lint/package.go
@@ -21,7 +21,7 @@ type Package struct {
 	sortable map[string]bool
 	// main is whether this is a "main" package.
 	main int
-	sync.Mutex
+	sync.RWMutex
 }
 
 var newImporter = func(fset *token.FileSet) types.ImporterFrom {
@@ -54,21 +54,24 @@ func (p *Package) IsMain() bool {
 	return false
 }
 
+// TypesPkg yields information on this package
 func (p *Package) TypesPkg() *types.Package {
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 	return p.typesPkg
 }
 
+// TypesInfo yields type information of this package identifiers
 func (p *Package) TypesInfo() *types.Info {
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 	return p.typesInfo
 }
 
+// Sortable yields a map of sortable types in this package
 func (p *Package) Sortable() map[string]bool {
-	p.Lock()
-	defer p.Unlock()
+	p.RLock()
+	defer p.RUnlock()
 	return p.sortable
 }
 

--- a/rule/atomic.go
+++ b/rule/atomic.go
@@ -15,7 +15,7 @@ type AtomicRule struct{}
 func (r *AtomicRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 	walker := atomic{
-		pkgTypesInfo: file.Pkg.TypesInfo,
+		pkgTypesInfo: file.Pkg.TypesInfo(),
 		onFailure: func(failure lint.Failure) {
 			failures = append(failures, failure)
 		},

--- a/rule/atomic.go
+++ b/rule/atomic.go
@@ -13,6 +13,7 @@ type AtomicRule struct{}
 
 // Apply applies the rule to given file.
 func (r *AtomicRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	print("-")
 	var failures []lint.Failure
 	walker := atomic{
 		pkgTypesInfo: file.Pkg.TypesInfo,

--- a/rule/atomic.go
+++ b/rule/atomic.go
@@ -13,7 +13,6 @@ type AtomicRule struct{}
 
 // Apply applies the rule to given file.
 func (r *AtomicRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
-	print("-")
 	var failures []lint.Failure
 	walker := atomic{
 		pkgTypesInfo: file.Pkg.TypesInfo,

--- a/rule/cognitive-complexity.go
+++ b/rule/cognitive-complexity.go
@@ -13,11 +13,10 @@ import (
 // CognitiveComplexityRule lints given else constructs.
 type CognitiveComplexityRule struct {
 	maxComplexity int
-	sync.RWMutex
+	sync.Mutex
 }
 
-// Apply applies the rule to given file.
-func (r *CognitiveComplexityRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *CognitiveComplexityRule) configure(arguments lint.Arguments) {
 	r.Lock()
 	if r.maxComplexity == 0 {
 		checkNumberOfArguments(1, arguments, r.Name())
@@ -29,10 +28,14 @@ func (r *CognitiveComplexityRule) Apply(file *lint.File, arguments lint.Argument
 		r.maxComplexity = int(complexity)
 	}
 	r.Unlock()
+}
+
+// Apply applies the rule to given file.
+func (r *CognitiveComplexityRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+	r.configure(arguments)
 
 	var failures []lint.Failure
 
-	r.RLock()
 	linter := cognitiveComplexityLinter{
 		file:          file,
 		maxComplexity: r.maxComplexity,
@@ -40,7 +43,6 @@ func (r *CognitiveComplexityRule) Apply(file *lint.File, arguments lint.Argument
 			failures = append(failures, failure)
 		},
 	}
-	r.RUnlock()
 
 	linter.lint()
 

--- a/rule/context-as-argument.go
+++ b/rule/context-as-argument.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"strings"
+	"sync"
 
 	"github.com/mgechev/revive/lint"
 )
@@ -11,21 +12,27 @@ import (
 // ContextAsArgumentRule lints given else constructs.
 type ContextAsArgumentRule struct {
 	allowTypesLUT map[string]struct{}
+	sync.Mutex
 }
 
 // Apply applies the rule to given file.
 func (r *ContextAsArgumentRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
+
+	r.Lock()
 	if r.allowTypesLUT == nil {
 		r.allowTypesLUT = getAllowTypesFromArguments(args)
 	}
+	r.Unlock()
 
 	var failures []lint.Failure
+	r.Lock()
 	walker := lintContextArguments{
 		allowTypesLUT: r.allowTypesLUT,
 		onFailure: func(failure lint.Failure) {
 			failures = append(failures, failure)
 		},
 	}
+	r.Unlock()
 
 	ast.Walk(walker, file.AST)
 

--- a/rule/context-keys-type.go
+++ b/rule/context-keys-type.go
@@ -68,7 +68,7 @@ func checkContextKeyType(w lintContextKeyTypes, x *ast.CallExpr) {
 	if len(x.Args) != 3 {
 		return
 	}
-	key := f.Pkg.TypesInfo.Types[x.Args[1]]
+	key := f.Pkg.TypesInfo().Types[x.Args[1]]
 
 	if ktyp, ok := key.Type.(*types.Basic); ok && ktyp.Kind() != types.Invalid {
 		w.onFailure(lint.Failure{

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -126,7 +126,8 @@ func (w *lintExported) lintFuncDoc(fn *ast.FuncDecl) {
 		}
 		switch name {
 		case "Len", "Less", "Swap":
-			if w.file.Pkg.Sortable[recv] {
+			sortables := w.file.Pkg.Sortable()
+			if sortables[recv] {
 				return
 			}
 		}

--- a/rule/file-header.go
+++ b/rule/file-header.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"fmt"
 	"regexp"
+	"sync"
 
 	"github.com/mgechev/revive/lint"
 )
@@ -10,6 +11,7 @@ import (
 // FileHeaderRule lints given else constructs.
 type FileHeaderRule struct {
 	header string
+	sync.Mutex
 }
 
 var (
@@ -17,8 +19,8 @@ var (
 	singleRegexp = regexp.MustCompile("^//")
 )
 
-// Apply applies the rule to given file.
-func (r *FileHeaderRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *FileHeaderRule) configure(arguments lint.Arguments) {
+	r.Lock()
 	if r.header == "" {
 		checkNumberOfArguments(1, arguments, r.Name())
 		var ok bool
@@ -27,6 +29,12 @@ func (r *FileHeaderRule) Apply(file *lint.File, arguments lint.Arguments) []lint
 			panic(fmt.Sprintf("invalid argument for \"file-header\" rule: first argument should be a string, got %T", arguments[0]))
 		}
 	}
+	r.Unlock()
+}
+
+// Apply applies the rule to given file.
+func (r *FileHeaderRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+	r.configure(arguments)
 
 	failure := []lint.Failure{
 		{

--- a/rule/line-length-limit.go
+++ b/rule/line-length-limit.go
@@ -15,11 +15,10 @@ import (
 // LineLengthLimitRule lints given else constructs.
 type LineLengthLimitRule struct {
 	max int
-	sync.RWMutex
+	sync.Mutex
 }
 
-// Apply applies the rule to given file.
-func (r *LineLengthLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *LineLengthLimitRule) configure(arguments lint.Arguments) {
 	r.Lock()
 	if r.max == 0 {
 		checkNumberOfArguments(1, arguments, r.Name())
@@ -32,9 +31,14 @@ func (r *LineLengthLimitRule) Apply(file *lint.File, arguments lint.Arguments) [
 		r.max = int(max)
 	}
 	r.Unlock()
+}
+
+// Apply applies the rule to given file.
+func (r *LineLengthLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+	r.configure(arguments)
 
 	var failures []lint.Failure
-	r.RLock()
+
 	checker := lintLineLengthNum{
 		max:  r.max,
 		file: file,
@@ -42,7 +46,6 @@ func (r *LineLengthLimitRule) Apply(file *lint.File, arguments lint.Arguments) [
 			failures = append(failures, failure)
 		},
 	}
-	r.RUnlock()
 
 	checker.check()
 

--- a/rule/nested-structs.go
+++ b/rule/nested-structs.go
@@ -10,12 +10,8 @@ import (
 type NestedStructs struct{}
 
 // Apply applies the rule to given file.
-func (r *NestedStructs) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (r *NestedStructs) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
-
-	if len(arguments) > 0 {
-		panic(r.Name() + " doesn't take any arguments")
-	}
 
 	walker := &lintNestedStructs{
 		fileAST: file.AST,


### PR DESCRIPTION
Closes #677

The sources of data races were:
1. Concurrent W/R access to rules' configuration
2. Concurrent W/R access to package's type information

Tested with:
- build: `go build -race`
- config.toml
```toml
ignoreGeneratedHeader = false
severity = "warning"
confidence = 1.2
errorCode = 0
warningCode = 0
enableAllRules = true

[rule.unhandled-error]
    arguments=["255"]

[rule.line-length-limit]
    arguments = [200]

[rule.function-result-limit]
    arguments = [200]

[rule.max-public-structs]
    arguments = [200]

[rule.cyclomatic]
    arguments = [200]

[rule.argument-limit]
    arguments = [200]    
[rule.banned-characters]
    arguments = ['#']    


[rule.function-length]
    arguments = [200,200]    


[rule.cognitive-complexity]
    arguments = [200]

[rule.file-header]
    arguments = ["regexp"]    
```

Then:
```
untilfail revive -config config.toml kubernetes/third-party/...
```