### PR TITLE
fix(var-naming): set node to package name for underscore in package name

### DIFF
--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -56,7 +56,7 @@ func (r *VarNamingRule) Apply(file *lint.File, arguments lint.Arguments) []lint.
 		walker.onFailure(lint.Failure{
 			Failure:    "don't use an underscore in package name",
 			Confidence: 1,
-			Node:       walker.fileAst,
+			Node:       walker.fileAst.Name,
 			Category:   "naming",
 		})
 	}


### PR DESCRIPTION
Setting the entire file AST as the node causes golangci-lint to print the entire file source as the context, and line and column numbers set to 1. Point to the package name node instead.

Closes #688
