### PR TITLE
Allow to customize user functions in rule `error-strings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ enableAllRules = true
     Arguments = [7]
 [rule.function-result-limit]
     Arguments = [3]
+[rule.error-strings]
+    Arguments = ["mypackage.Error"]
 ```
 
 ### Default Configuration
@@ -411,78 +413,78 @@ warningCode = 0
 
 List of all available rules. The rules ported from `golint` are left unchanged and indicated in the `golint` column.
 
-| Name                  | Config | Description                                                      | `golint` | Typed |
-| --------------------- | :----: | :--------------------------------------------------------------- | :------: | :---: |
-| [`context-keys-type`](./RULES_DESCRIPTIONS.md#context-key-types)   |  n/a   | Disallows the usage of basic types in `context.WithValue`.       |   yes    |  yes  |
-| [`time-equal`](./RULES_DESCRIPTIONS.md#time-equal)         |  n/a   | Suggests to use `time.Time.Equal` instead of `==` and `!=` for equality check time.                 |   no    |  yes  |
-| [`time-naming`](./RULES_DESCRIPTIONS.md#time-naming)         |  n/a   | Conventions around the naming of time variables.                 |   yes    |  yes  |
-| [`var-declaration`](./RULES_DESCRIPTIONS.md#var-declaration)     |  n/a   | Reduces redundancies around variable declaration.                |   yes    |  yes  |
-| [`unexported-return`](./RULES_DESCRIPTIONS.md#unexported-return)   |  n/a   | Warns when a public return is from unexported type.              |   yes    |  yes  |
-| [`errorf`](./RULES_DESCRIPTIONS.md#errorf)              |  n/a   | Should replace `errors.New(fmt.Sprintf())` with `fmt.Errorf()`   |   yes    |  yes  |
-| [`blank-imports`](./RULES_DESCRIPTIONS.md#blank-imports)       |  n/a   | Disallows blank imports                                          |   yes    |  no   |
-| [`context-as-argument`](./RULES_DESCRIPTIONS.md#context-as-argument) |  n/a   | `context.Context` should be the first argument of a function.    |   yes    |  no   |
-| [`dot-imports`](./RULES_DESCRIPTIONS.md#dot-imports)         |  n/a   | Forbids `.` imports.                                             |   yes    |  no   |
-| [`error-return`](./RULES_DESCRIPTIONS.md#error-return)        |  n/a   | The error return parameter should be last.                       |   yes    |  no   |
-| [`error-strings`](./RULES_DESCRIPTIONS.md#error-strings)       |  n/a   | Conventions around error strings.                                |   yes    |  no   |
-| [`error-naming`](./RULES_DESCRIPTIONS.md#error-naming)        |  n/a   | Naming of error variables.                                       |   yes    |  no   |
-| [`exported`](./RULES_DESCRIPTIONS.md#exported)            |  []string   | Naming and commenting conventions on exported symbols.           |   yes    |  no   |
-| [`if-return`](./RULES_DESCRIPTIONS.md#if-return)           |  n/a   | Redundant if when returning an error.                            |   no    |  no   |
-| [`increment-decrement`](./RULES_DESCRIPTIONS.md#increment-decrement) |  n/a   | Use `i++` and `i--` instead of `i += 1` and `i -= 1`.            |   yes    |  no   |
-| [`var-naming`](./RULES_DESCRIPTIONS.md#var-naming)          |  whitelist & blacklist of initialisms   | Naming rules.                                                    |   yes    |  no   |
-| [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |  n/a   | Package commenting conventions.                                  |   yes    |  no   |
-| [`range`](./RULES_DESCRIPTIONS.md#range)               |  n/a   | Prevents redundant variables when iterating over a collection.   |   yes    |  no   |
-| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  n/a   | Conventions around the naming of receivers.                      |   yes    |  no   |
-| [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |  n/a   | Prevents redundant else statements.                              |   yes    |  no   |
-| [`argument-limit`](./RULES_DESCRIPTIONS.md#argument-limit)      |  int   | Specifies the maximum number of arguments a function can receive |    no    |  no   |
-| [`cyclomatic`](./RULES_DESCRIPTIONS.md#cyclomatic)          |  int   | Sets restriction for maximum Cyclomatic complexity.              |    no    |  no   |
-| [`max-public-structs`](./RULES_DESCRIPTIONS.md#max-public-structs)  |  int   | The maximum number of public structs in a file.                  |    no    |  no   |
-| [`file-header`](./RULES_DESCRIPTIONS.md#file-header)         | string | Header which each file should have.                              |    no    |  no   |
-| [`empty-block`](./RULES_DESCRIPTIONS.md#empty-block)         |  n/a   | Warns on empty code blocks                                       |    no    |  yes   |
-| [`superfluous-else`](./RULES_DESCRIPTIONS.md#superfluous-else)    |  n/a   | Prevents redundant else statements (extends [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)) |    no    |  no   |
-| [`confusing-naming`](./RULES_DESCRIPTIONS.md#confusing-naming)    |  n/a   | Warns on methods with names that differ only by capitalization   |    no    |  no   |
-| [`get-return`](./RULES_DESCRIPTIONS.md#get-return)          |  n/a   | Warns on getters that do not yield any result                    |    no    |  no   |
-| [`modifies-parameter`](./RULES_DESCRIPTIONS.md#modifies-parameter)  |  n/a   | Warns on assignments to function parameters                      |    no    |  no   |
-| [`confusing-results`](./RULES_DESCRIPTIONS.md#confusing-results)   |  n/a   | Suggests to name potentially confusing function results          |    no    |  no   |
-| [`deep-exit`](./RULES_DESCRIPTIONS.md#deep-exit)           |  n/a   | Looks for program exits in funcs other than `main()` or `init()` |    no    |  no   |
-| [`unused-parameter`](./RULES_DESCRIPTIONS.md#unused-parameter)    |  n/a   | Suggests to rename or remove unused function parameters          |    no    |  no   |
-| [`unreachable-code`](./RULES_DESCRIPTIONS.md#unreachable-code)    |  n/a   | Warns on unreachable code                                        |    no    |  no   |
-| [`add-constant`](./RULES_DESCRIPTIONS.md#add-constant)        |  map   | Suggests using constant for magic numbers and string literals    |    no    |  no   |
-| [`flag-parameter`](./RULES_DESCRIPTIONS.md#flag-parameter)      |  n/a   | Warns on boolean parameters that create a control coupling       |    no    |  no   |
-| [`unnecessary-stmt`](./RULES_DESCRIPTIONS.md#unnecessary-stmt)    |  n/a   | Suggests removing or simplifying unnecessary statements          |    no    |  no   |
-| [`struct-tag`](./RULES_DESCRIPTIONS.md#struct-tag)          |  n/a   | Checks common struct tags like `json`,`xml`,`yaml`               |    no    |  no   |
-| [`modifies-value-receiver`](./RULES_DESCRIPTIONS.md#modifies-value-receiver) |  n/a   | Warns on assignments to value-passed method receivers        |    no    |  yes  |
-| [`constant-logical-expr`](./RULES_DESCRIPTIONS.md#constant-logical-expr)   |  n/a   | Warns on constant logical expressions                        |    no    |  no   |
-| [`bool-literal-in-expr`](./RULES_DESCRIPTIONS.md#bool-literal-in-expr)|  n/a   | Suggests removing Boolean literals from logic expressions        |    no    |  no   |
-| [`redefines-builtin-id`](./RULES_DESCRIPTIONS.md#redefines-builtin-id)|  n/a   | Warns on redefinitions of builtin identifiers                    |    no    |  no   |
-| [`function-result-limit`](./RULES_DESCRIPTIONS.md#function-result-limit) |  int | Specifies the maximum number of results a function can return    |    no    |  no   |
-| [`imports-blacklist`](./RULES_DESCRIPTIONS.md#imports-blacklist)   | []string | Disallows importing the specified packages                     |    no    |  no   |
-| [`range-val-in-closure`](./RULES_DESCRIPTIONS.md#range-val-in-closure)|  n/a   | Warns if range value is used in a closure dispatched as goroutine|    no    |  no   |
-| [`range-val-address`](./RULES_DESCRIPTIONS.md#range-val-address)|  n/a   | Warns if address of range value is used dangerously |    no    |  yes   |
-| [`waitgroup-by-value`](./RULES_DESCRIPTIONS.md#waitgroup-by-value)  |  n/a   | Warns on functions taking sync.WaitGroup as a by-value parameter |    no    |  no   |
-| [`atomic`](./RULES_DESCRIPTIONS.md#atomic)              |  n/a   | Check for common mistaken usages of the `sync/atomic` package    |    no    |  no   |
-| [`empty-lines`](./RULES_DESCRIPTIONS.md#empty-lines)   | n/a | Warns when there are heading or trailing newlines in a block              |    no    |  no   |
-| [`line-length-limit`](./RULES_DESCRIPTIONS.md#line-length-limit)   | int    | Specifies the maximum number of characters in a line             |    no    |  no   |
-| [`call-to-gc`](./RULES_DESCRIPTIONS.md#call-to-gc)   | n/a    | Warns on explicit call to the garbage collector    |    no    |  no   |
-| [`duplicated-imports`](./RULES_DESCRIPTIONS.md#duplicated-imports) | n/a  | Looks for packages that are imported two or more times   |    no    |  no   |
-| [`import-shadowing`](./RULES_DESCRIPTIONS.md#import-shadowing)   | n/a    | Spots identifiers that shadow an import    |    no    |  no   |
-| [`bare-return`](./RULES_DESCRIPTIONS.md#bare-return) | n/a  | Warns on bare returns   |    no    |  no   |
-| [`unused-receiver`](./RULES_DESCRIPTIONS.md#unused-receiver)   | n/a    | Suggests to rename or remove unused method receivers    |    no    |  no   |
-| [`unhandled-error`](./RULES_DESCRIPTIONS.md#unhandled-error)   | []string   | Warns on unhandled errors returned by funcion calls    |    no    |  yes   |
-| [`cognitive-complexity`](./RULES_DESCRIPTIONS.md#cognitive-complexity)          |  int   | Sets restriction for maximum Cognitive complexity.              |    no    |  no   |
-| [`string-of-int`](./RULES_DESCRIPTIONS.md#string-of-int)          |  n/a   | Warns on suspicious casts from int to string            |    no    |  yes   |
-| [`string-format`](./RULES_DESCRIPTIONS.md#string-format)          |  map   | Warns on specific string literals that fail one or more user-configured regular expressions            |    no    |  no   |
-| [`early-return`](./RULES_DESCRIPTIONS.md#early-return)          |  n/a   | Spots if-then-else statements that can be refactored to simplify code reading            |    no    |  no   |
-| [`unconditional-recursion`](./RULES_DESCRIPTIONS.md#unconditional-recursion)          |  n/a   | Warns on function calls that will lead to (direct) infinite recursion |    no    |  no   |
-| [`identical-branches`](./RULES_DESCRIPTIONS.md#identical-branches)          |  n/a   | Spots if-then-else statements with identical `then` and `else` branches       |    no    |  no   |
-| [`defer`](./RULES_DESCRIPTIONS.md#defer)          |  map   |  Warns on some [defer gotchas](https://blog.learngoprogramming.com/5-gotchas-of-defer-in-go-golang-part-iii-36a1ab3d6ef1)       |    no    |  no   |
-| [`unexported-naming`](./RULES_DESCRIPTIONS.md#unexported-naming)          |  n/a   |  Warns on wrongly named un-exported symbols       |    no    |  no   |
-| [`function-length`](./RULES_DESCRIPTIONS.md#function-length)          |  n/a   |  Warns on functions exceeding the statements or lines max |    no    |  no   |
-| [`nested-structs`](./RULES_DESCRIPTIONS.md#nested-structs)          |  n/a   |  Warns on structs within structs |    no    |  no   |
-| [`useless-break`](./RULES_DESCRIPTIONS.md#useless-break)          |  n/a   |  Warns on useless `break` statements in case clauses |    no    |  no   |
-| [`banned-characters`](./RULES_DESCRIPTIONS.md#banned-characters)          |  n/a   |  Checks banned characters in identifiers |    no    |  no   |
-| [`optimize-operands-order`](./RULES_DESCRIPTIONS.md#optimize-operands-order)          |  n/a   |  Checks inefficient conditional expressions |    no    |  no   |
-| [`use-any`](./RULES_DESCRIPTIONS.md#use-any)          |  n/a   |  Proposes to replace `interface{}` with its alias `any` |    no    |  no   |
-| [`datarace`](./RULES_DESCRIPTIONS.md#datarace)          |  n/a   |  Spots potential dataraces |    no    |  no   |
+| Name                  |                Config                | Description                                                      | `golint` | Typed |
+| --------------------- |:------------------------------------:| :--------------------------------------------------------------- | :------: | :---: |
+| [`context-keys-type`](./RULES_DESCRIPTIONS.md#context-key-types)   |                 n/a                  | Disallows the usage of basic types in `context.WithValue`.       |   yes    |  yes  |
+| [`time-equal`](./RULES_DESCRIPTIONS.md#time-equal)         |                 n/a                  | Suggests to use `time.Time.Equal` instead of `==` and `!=` for equality check time.                 |   no    |  yes  |
+| [`time-naming`](./RULES_DESCRIPTIONS.md#time-naming)         |                 n/a                  | Conventions around the naming of time variables.                 |   yes    |  yes  |
+| [`var-declaration`](./RULES_DESCRIPTIONS.md#var-declaration)     |                 n/a                  | Reduces redundancies around variable declaration.                |   yes    |  yes  |
+| [`unexported-return`](./RULES_DESCRIPTIONS.md#unexported-return)   |                 n/a                  | Warns when a public return is from unexported type.              |   yes    |  yes  |
+| [`errorf`](./RULES_DESCRIPTIONS.md#errorf)              |                 n/a                  | Should replace `errors.New(fmt.Sprintf())` with `fmt.Errorf()`   |   yes    |  yes  |
+| [`blank-imports`](./RULES_DESCRIPTIONS.md#blank-imports)       |                 n/a                  | Disallows blank imports                                          |   yes    |  no   |
+| [`context-as-argument`](./RULES_DESCRIPTIONS.md#context-as-argument) |                 n/a                  | `context.Context` should be the first argument of a function.    |   yes    |  no   |
+| [`dot-imports`](./RULES_DESCRIPTIONS.md#dot-imports)         |                 n/a                  | Forbids `.` imports.                                             |   yes    |  no   |
+| [`error-return`](./RULES_DESCRIPTIONS.md#error-return)        |                 n/a                  | The error return parameter should be last.                       |   yes    |  no   |
+| [`error-strings`](./RULES_DESCRIPTIONS.md#error-strings)       |               []string               | Conventions around error strings.                                |   yes    |  no   |
+| [`error-naming`](./RULES_DESCRIPTIONS.md#error-naming)        |                 n/a                  | Naming of error variables.                                       |   yes    |  no   |
+| [`exported`](./RULES_DESCRIPTIONS.md#exported)            |               []string               | Naming and commenting conventions on exported symbols.           |   yes    |  no   |
+| [`if-return`](./RULES_DESCRIPTIONS.md#if-return)           |                 n/a                  | Redundant if when returning an error.                            |   no    |  no   |
+| [`increment-decrement`](./RULES_DESCRIPTIONS.md#increment-decrement) |                 n/a                  | Use `i++` and `i--` instead of `i += 1` and `i -= 1`.            |   yes    |  no   |
+| [`var-naming`](./RULES_DESCRIPTIONS.md#var-naming)          | whitelist & blacklist of initialisms | Naming rules.                                                    |   yes    |  no   |
+| [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |                 n/a                  | Package commenting conventions.                                  |   yes    |  no   |
+| [`range`](./RULES_DESCRIPTIONS.md#range)               |                 n/a                  | Prevents redundant variables when iterating over a collection.   |   yes    |  no   |
+| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |                 n/a                  | Conventions around the naming of receivers.                      |   yes    |  no   |
+| [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |                 n/a                  | Prevents redundant else statements.                              |   yes    |  no   |
+| [`argument-limit`](./RULES_DESCRIPTIONS.md#argument-limit)      |                 int                  | Specifies the maximum number of arguments a function can receive |    no    |  no   |
+| [`cyclomatic`](./RULES_DESCRIPTIONS.md#cyclomatic)          |                 int                  | Sets restriction for maximum Cyclomatic complexity.              |    no    |  no   |
+| [`max-public-structs`](./RULES_DESCRIPTIONS.md#max-public-structs)  |                 int                  | The maximum number of public structs in a file.                  |    no    |  no   |
+| [`file-header`](./RULES_DESCRIPTIONS.md#file-header)         |                string                | Header which each file should have.                              |    no    |  no   |
+| [`empty-block`](./RULES_DESCRIPTIONS.md#empty-block)         |                 n/a                  | Warns on empty code blocks                                       |    no    |  yes   |
+| [`superfluous-else`](./RULES_DESCRIPTIONS.md#superfluous-else)    |                 n/a                  | Prevents redundant else statements (extends [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)) |    no    |  no   |
+| [`confusing-naming`](./RULES_DESCRIPTIONS.md#confusing-naming)    |                 n/a                  | Warns on methods with names that differ only by capitalization   |    no    |  no   |
+| [`get-return`](./RULES_DESCRIPTIONS.md#get-return)          |                 n/a                  | Warns on getters that do not yield any result                    |    no    |  no   |
+| [`modifies-parameter`](./RULES_DESCRIPTIONS.md#modifies-parameter)  |                 n/a                  | Warns on assignments to function parameters                      |    no    |  no   |
+| [`confusing-results`](./RULES_DESCRIPTIONS.md#confusing-results)   |                 n/a                  | Suggests to name potentially confusing function results          |    no    |  no   |
+| [`deep-exit`](./RULES_DESCRIPTIONS.md#deep-exit)           |                 n/a                  | Looks for program exits in funcs other than `main()` or `init()` |    no    |  no   |
+| [`unused-parameter`](./RULES_DESCRIPTIONS.md#unused-parameter)    |                 n/a                  | Suggests to rename or remove unused function parameters          |    no    |  no   |
+| [`unreachable-code`](./RULES_DESCRIPTIONS.md#unreachable-code)    |                 n/a                  | Warns on unreachable code                                        |    no    |  no   |
+| [`add-constant`](./RULES_DESCRIPTIONS.md#add-constant)        |                 map                  | Suggests using constant for magic numbers and string literals    |    no    |  no   |
+| [`flag-parameter`](./RULES_DESCRIPTIONS.md#flag-parameter)      |                 n/a                  | Warns on boolean parameters that create a control coupling       |    no    |  no   |
+| [`unnecessary-stmt`](./RULES_DESCRIPTIONS.md#unnecessary-stmt)    |                 n/a                  | Suggests removing or simplifying unnecessary statements          |    no    |  no   |
+| [`struct-tag`](./RULES_DESCRIPTIONS.md#struct-tag)          |                 n/a                  | Checks common struct tags like `json`,`xml`,`yaml`               |    no    |  no   |
+| [`modifies-value-receiver`](./RULES_DESCRIPTIONS.md#modifies-value-receiver) |                 n/a                  | Warns on assignments to value-passed method receivers        |    no    |  yes  |
+| [`constant-logical-expr`](./RULES_DESCRIPTIONS.md#constant-logical-expr)   |                 n/a                  | Warns on constant logical expressions                        |    no    |  no   |
+| [`bool-literal-in-expr`](./RULES_DESCRIPTIONS.md#bool-literal-in-expr)|                 n/a                  | Suggests removing Boolean literals from logic expressions        |    no    |  no   |
+| [`redefines-builtin-id`](./RULES_DESCRIPTIONS.md#redefines-builtin-id)|                 n/a                  | Warns on redefinitions of builtin identifiers                    |    no    |  no   |
+| [`function-result-limit`](./RULES_DESCRIPTIONS.md#function-result-limit) |                 int                  | Specifies the maximum number of results a function can return    |    no    |  no   |
+| [`imports-blacklist`](./RULES_DESCRIPTIONS.md#imports-blacklist)   |               []string               | Disallows importing the specified packages                     |    no    |  no   |
+| [`range-val-in-closure`](./RULES_DESCRIPTIONS.md#range-val-in-closure)|                 n/a                  | Warns if range value is used in a closure dispatched as goroutine|    no    |  no   |
+| [`range-val-address`](./RULES_DESCRIPTIONS.md#range-val-address)|                 n/a                  | Warns if address of range value is used dangerously |    no    |  yes   |
+| [`waitgroup-by-value`](./RULES_DESCRIPTIONS.md#waitgroup-by-value)  |                 n/a                  | Warns on functions taking sync.WaitGroup as a by-value parameter |    no    |  no   |
+| [`atomic`](./RULES_DESCRIPTIONS.md#atomic)              |                 n/a                  | Check for common mistaken usages of the `sync/atomic` package    |    no    |  no   |
+| [`empty-lines`](./RULES_DESCRIPTIONS.md#empty-lines)   |                 n/a                  | Warns when there are heading or trailing newlines in a block              |    no    |  no   |
+| [`line-length-limit`](./RULES_DESCRIPTIONS.md#line-length-limit)   |                 int                  | Specifies the maximum number of characters in a line             |    no    |  no   |
+| [`call-to-gc`](./RULES_DESCRIPTIONS.md#call-to-gc)   |                 n/a                  | Warns on explicit call to the garbage collector    |    no    |  no   |
+| [`duplicated-imports`](./RULES_DESCRIPTIONS.md#duplicated-imports) |                 n/a                  | Looks for packages that are imported two or more times   |    no    |  no   |
+| [`import-shadowing`](./RULES_DESCRIPTIONS.md#import-shadowing)   |                 n/a                  | Spots identifiers that shadow an import    |    no    |  no   |
+| [`bare-return`](./RULES_DESCRIPTIONS.md#bare-return) |                 n/a                  | Warns on bare returns   |    no    |  no   |
+| [`unused-receiver`](./RULES_DESCRIPTIONS.md#unused-receiver)   |                 n/a                  | Suggests to rename or remove unused method receivers    |    no    |  no   |
+| [`unhandled-error`](./RULES_DESCRIPTIONS.md#unhandled-error)   |               []string               | Warns on unhandled errors returned by funcion calls    |    no    |  yes   |
+| [`cognitive-complexity`](./RULES_DESCRIPTIONS.md#cognitive-complexity)          |                 int                  | Sets restriction for maximum Cognitive complexity.              |    no    |  no   |
+| [`string-of-int`](./RULES_DESCRIPTIONS.md#string-of-int)          |                 n/a                  | Warns on suspicious casts from int to string            |    no    |  yes   |
+| [`string-format`](./RULES_DESCRIPTIONS.md#string-format)          |                 map                  | Warns on specific string literals that fail one or more user-configured regular expressions            |    no    |  no   |
+| [`early-return`](./RULES_DESCRIPTIONS.md#early-return)          |                 n/a                  | Spots if-then-else statements that can be refactored to simplify code reading            |    no    |  no   |
+| [`unconditional-recursion`](./RULES_DESCRIPTIONS.md#unconditional-recursion)          |                 n/a                  | Warns on function calls that will lead to (direct) infinite recursion |    no    |  no   |
+| [`identical-branches`](./RULES_DESCRIPTIONS.md#identical-branches)          |                 n/a                  | Spots if-then-else statements with identical `then` and `else` branches       |    no    |  no   |
+| [`defer`](./RULES_DESCRIPTIONS.md#defer)          |                 map                  |  Warns on some [defer gotchas](https://blog.learngoprogramming.com/5-gotchas-of-defer-in-go-golang-part-iii-36a1ab3d6ef1)       |    no    |  no   |
+| [`unexported-naming`](./RULES_DESCRIPTIONS.md#unexported-naming)          |                 n/a                  |  Warns on wrongly named un-exported symbols       |    no    |  no   |
+| [`function-length`](./RULES_DESCRIPTIONS.md#function-length)          |                 n/a                  |  Warns on functions exceeding the statements or lines max |    no    |  no   |
+| [`nested-structs`](./RULES_DESCRIPTIONS.md#nested-structs)          |                 n/a                  |  Warns on structs within structs |    no    |  no   |
+| [`useless-break`](./RULES_DESCRIPTIONS.md#useless-break)          |                 n/a                  |  Warns on useless `break` statements in case clauses |    no    |  no   |
+| [`banned-characters`](./RULES_DESCRIPTIONS.md#banned-characters)          |                 n/a                  |  Checks banned characters in identifiers |    no    |  no   |
+| [`optimize-operands-order`](./RULES_DESCRIPTIONS.md#optimize-operands-order)          |                 n/a                  |  Checks inefficient conditional expressions |    no    |  no   |
+| [`use-any`](./RULES_DESCRIPTIONS.md#use-any)          |                 n/a                  |  Proposes to replace `interface{}` with its alias `any` |    no    |  no   |
+| [`datarace`](./RULES_DESCRIPTIONS.md#datarace)          |                 n/a                  |  Spots potential dataraces |    no    |  no   |
 
 ## Configurable rules
 

--- a/README.md
+++ b/README.md
@@ -412,79 +412,78 @@ warningCode = 0
 ## Available Rules
 
 List of all available rules. The rules ported from `golint` are left unchanged and indicated in the `golint` column.
-
-| Name                  |                Config                | Description                                                      | `golint` | Typed |
-| --------------------- |:------------------------------------:| :--------------------------------------------------------------- | :------: | :---: |
-| [`context-keys-type`](./RULES_DESCRIPTIONS.md#context-key-types)   |                 n/a                  | Disallows the usage of basic types in `context.WithValue`.       |   yes    |  yes  |
-| [`time-equal`](./RULES_DESCRIPTIONS.md#time-equal)         |                 n/a                  | Suggests to use `time.Time.Equal` instead of `==` and `!=` for equality check time.                 |   no    |  yes  |
-| [`time-naming`](./RULES_DESCRIPTIONS.md#time-naming)         |                 n/a                  | Conventions around the naming of time variables.                 |   yes    |  yes  |
-| [`var-declaration`](./RULES_DESCRIPTIONS.md#var-declaration)     |                 n/a                  | Reduces redundancies around variable declaration.                |   yes    |  yes  |
-| [`unexported-return`](./RULES_DESCRIPTIONS.md#unexported-return)   |                 n/a                  | Warns when a public return is from unexported type.              |   yes    |  yes  |
-| [`errorf`](./RULES_DESCRIPTIONS.md#errorf)              |                 n/a                  | Should replace `errors.New(fmt.Sprintf())` with `fmt.Errorf()`   |   yes    |  yes  |
-| [`blank-imports`](./RULES_DESCRIPTIONS.md#blank-imports)       |                 n/a                  | Disallows blank imports                                          |   yes    |  no   |
-| [`context-as-argument`](./RULES_DESCRIPTIONS.md#context-as-argument) |                 n/a                  | `context.Context` should be the first argument of a function.    |   yes    |  no   |
-| [`dot-imports`](./RULES_DESCRIPTIONS.md#dot-imports)         |                 n/a                  | Forbids `.` imports.                                             |   yes    |  no   |
-| [`error-return`](./RULES_DESCRIPTIONS.md#error-return)        |                 n/a                  | The error return parameter should be last.                       |   yes    |  no   |
-| [`error-strings`](./RULES_DESCRIPTIONS.md#error-strings)       |               []string               | Conventions around error strings.                                |   yes    |  no   |
-| [`error-naming`](./RULES_DESCRIPTIONS.md#error-naming)        |                 n/a                  | Naming of error variables.                                       |   yes    |  no   |
-| [`exported`](./RULES_DESCRIPTIONS.md#exported)            |               []string               | Naming and commenting conventions on exported symbols.           |   yes    |  no   |
-| [`if-return`](./RULES_DESCRIPTIONS.md#if-return)           |                 n/a                  | Redundant if when returning an error.                            |   no    |  no   |
-| [`increment-decrement`](./RULES_DESCRIPTIONS.md#increment-decrement) |                 n/a                  | Use `i++` and `i--` instead of `i += 1` and `i -= 1`.            |   yes    |  no   |
-| [`var-naming`](./RULES_DESCRIPTIONS.md#var-naming)          | whitelist & blacklist of initialisms | Naming rules.                                                    |   yes    |  no   |
-| [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |                 n/a                  | Package commenting conventions.                                  |   yes    |  no   |
-| [`range`](./RULES_DESCRIPTIONS.md#range)               |                 n/a                  | Prevents redundant variables when iterating over a collection.   |   yes    |  no   |
-| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |                 n/a                  | Conventions around the naming of receivers.                      |   yes    |  no   |
-| [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |                 n/a                  | Prevents redundant else statements.                              |   yes    |  no   |
-| [`argument-limit`](./RULES_DESCRIPTIONS.md#argument-limit)      |                 int                  | Specifies the maximum number of arguments a function can receive |    no    |  no   |
-| [`cyclomatic`](./RULES_DESCRIPTIONS.md#cyclomatic)          |                 int                  | Sets restriction for maximum Cyclomatic complexity.              |    no    |  no   |
-| [`max-public-structs`](./RULES_DESCRIPTIONS.md#max-public-structs)  |                 int                  | The maximum number of public structs in a file.                  |    no    |  no   |
-| [`file-header`](./RULES_DESCRIPTIONS.md#file-header)         |                string                | Header which each file should have.                              |    no    |  no   |
-| [`empty-block`](./RULES_DESCRIPTIONS.md#empty-block)         |                 n/a                  | Warns on empty code blocks                                       |    no    |  yes   |
-| [`superfluous-else`](./RULES_DESCRIPTIONS.md#superfluous-else)    |                 n/a                  | Prevents redundant else statements (extends [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)) |    no    |  no   |
-| [`confusing-naming`](./RULES_DESCRIPTIONS.md#confusing-naming)    |                 n/a                  | Warns on methods with names that differ only by capitalization   |    no    |  no   |
-| [`get-return`](./RULES_DESCRIPTIONS.md#get-return)          |                 n/a                  | Warns on getters that do not yield any result                    |    no    |  no   |
-| [`modifies-parameter`](./RULES_DESCRIPTIONS.md#modifies-parameter)  |                 n/a                  | Warns on assignments to function parameters                      |    no    |  no   |
-| [`confusing-results`](./RULES_DESCRIPTIONS.md#confusing-results)   |                 n/a                  | Suggests to name potentially confusing function results          |    no    |  no   |
-| [`deep-exit`](./RULES_DESCRIPTIONS.md#deep-exit)           |                 n/a                  | Looks for program exits in funcs other than `main()` or `init()` |    no    |  no   |
-| [`unused-parameter`](./RULES_DESCRIPTIONS.md#unused-parameter)    |                 n/a                  | Suggests to rename or remove unused function parameters          |    no    |  no   |
-| [`unreachable-code`](./RULES_DESCRIPTIONS.md#unreachable-code)    |                 n/a                  | Warns on unreachable code                                        |    no    |  no   |
-| [`add-constant`](./RULES_DESCRIPTIONS.md#add-constant)        |                 map                  | Suggests using constant for magic numbers and string literals    |    no    |  no   |
-| [`flag-parameter`](./RULES_DESCRIPTIONS.md#flag-parameter)      |                 n/a                  | Warns on boolean parameters that create a control coupling       |    no    |  no   |
-| [`unnecessary-stmt`](./RULES_DESCRIPTIONS.md#unnecessary-stmt)    |                 n/a                  | Suggests removing or simplifying unnecessary statements          |    no    |  no   |
-| [`struct-tag`](./RULES_DESCRIPTIONS.md#struct-tag)          |                 n/a                  | Checks common struct tags like `json`,`xml`,`yaml`               |    no    |  no   |
-| [`modifies-value-receiver`](./RULES_DESCRIPTIONS.md#modifies-value-receiver) |                 n/a                  | Warns on assignments to value-passed method receivers        |    no    |  yes  |
-| [`constant-logical-expr`](./RULES_DESCRIPTIONS.md#constant-logical-expr)   |                 n/a                  | Warns on constant logical expressions                        |    no    |  no   |
-| [`bool-literal-in-expr`](./RULES_DESCRIPTIONS.md#bool-literal-in-expr)|                 n/a                  | Suggests removing Boolean literals from logic expressions        |    no    |  no   |
-| [`redefines-builtin-id`](./RULES_DESCRIPTIONS.md#redefines-builtin-id)|                 n/a                  | Warns on redefinitions of builtin identifiers                    |    no    |  no   |
-| [`function-result-limit`](./RULES_DESCRIPTIONS.md#function-result-limit) |                 int                  | Specifies the maximum number of results a function can return    |    no    |  no   |
-| [`imports-blacklist`](./RULES_DESCRIPTIONS.md#imports-blacklist)   |               []string               | Disallows importing the specified packages                     |    no    |  no   |
-| [`range-val-in-closure`](./RULES_DESCRIPTIONS.md#range-val-in-closure)|                 n/a                  | Warns if range value is used in a closure dispatched as goroutine|    no    |  no   |
-| [`range-val-address`](./RULES_DESCRIPTIONS.md#range-val-address)|                 n/a                  | Warns if address of range value is used dangerously |    no    |  yes   |
-| [`waitgroup-by-value`](./RULES_DESCRIPTIONS.md#waitgroup-by-value)  |                 n/a                  | Warns on functions taking sync.WaitGroup as a by-value parameter |    no    |  no   |
-| [`atomic`](./RULES_DESCRIPTIONS.md#atomic)              |                 n/a                  | Check for common mistaken usages of the `sync/atomic` package    |    no    |  no   |
-| [`empty-lines`](./RULES_DESCRIPTIONS.md#empty-lines)   |                 n/a                  | Warns when there are heading or trailing newlines in a block              |    no    |  no   |
-| [`line-length-limit`](./RULES_DESCRIPTIONS.md#line-length-limit)   |                 int                  | Specifies the maximum number of characters in a line             |    no    |  no   |
-| [`call-to-gc`](./RULES_DESCRIPTIONS.md#call-to-gc)   |                 n/a                  | Warns on explicit call to the garbage collector    |    no    |  no   |
-| [`duplicated-imports`](./RULES_DESCRIPTIONS.md#duplicated-imports) |                 n/a                  | Looks for packages that are imported two or more times   |    no    |  no   |
-| [`import-shadowing`](./RULES_DESCRIPTIONS.md#import-shadowing)   |                 n/a                  | Spots identifiers that shadow an import    |    no    |  no   |
-| [`bare-return`](./RULES_DESCRIPTIONS.md#bare-return) |                 n/a                  | Warns on bare returns   |    no    |  no   |
-| [`unused-receiver`](./RULES_DESCRIPTIONS.md#unused-receiver)   |                 n/a                  | Suggests to rename or remove unused method receivers    |    no    |  no   |
-| [`unhandled-error`](./RULES_DESCRIPTIONS.md#unhandled-error)   |               []string               | Warns on unhandled errors returned by funcion calls    |    no    |  yes   |
-| [`cognitive-complexity`](./RULES_DESCRIPTIONS.md#cognitive-complexity)          |                 int                  | Sets restriction for maximum Cognitive complexity.              |    no    |  no   |
-| [`string-of-int`](./RULES_DESCRIPTIONS.md#string-of-int)          |                 n/a                  | Warns on suspicious casts from int to string            |    no    |  yes   |
-| [`string-format`](./RULES_DESCRIPTIONS.md#string-format)          |                 map                  | Warns on specific string literals that fail one or more user-configured regular expressions            |    no    |  no   |
-| [`early-return`](./RULES_DESCRIPTIONS.md#early-return)          |                 n/a                  | Spots if-then-else statements that can be refactored to simplify code reading            |    no    |  no   |
-| [`unconditional-recursion`](./RULES_DESCRIPTIONS.md#unconditional-recursion)          |                 n/a                  | Warns on function calls that will lead to (direct) infinite recursion |    no    |  no   |
-| [`identical-branches`](./RULES_DESCRIPTIONS.md#identical-branches)          |                 n/a                  | Spots if-then-else statements with identical `then` and `else` branches       |    no    |  no   |
-| [`defer`](./RULES_DESCRIPTIONS.md#defer)          |                 map                  |  Warns on some [defer gotchas](https://blog.learngoprogramming.com/5-gotchas-of-defer-in-go-golang-part-iii-36a1ab3d6ef1)       |    no    |  no   |
-| [`unexported-naming`](./RULES_DESCRIPTIONS.md#unexported-naming)          |                 n/a                  |  Warns on wrongly named un-exported symbols       |    no    |  no   |
-| [`function-length`](./RULES_DESCRIPTIONS.md#function-length)          |                 n/a                  |  Warns on functions exceeding the statements or lines max |    no    |  no   |
-| [`nested-structs`](./RULES_DESCRIPTIONS.md#nested-structs)          |                 n/a                  |  Warns on structs within structs |    no    |  no   |
-| [`useless-break`](./RULES_DESCRIPTIONS.md#useless-break)          |                 n/a                  |  Warns on useless `break` statements in case clauses |    no    |  no   |
-| [`banned-characters`](./RULES_DESCRIPTIONS.md#banned-characters)          |                 n/a                  |  Checks banned characters in identifiers |    no    |  no   |
-| [`optimize-operands-order`](./RULES_DESCRIPTIONS.md#optimize-operands-order)          |                 n/a                  |  Checks inefficient conditional expressions |    no    |  no   |
-| [`use-any`](./RULES_DESCRIPTIONS.md#use-any)          |                 n/a                  |  Proposes to replace `interface{}` with its alias `any` |    no    |  no   |
-| [`datarace`](./RULES_DESCRIPTIONS.md#datarace)          |                 n/a                  |  Spots potential dataraces |    no    |  no   |
+| Name                  | Config | Description                                                      | `golint` | Typed |
+| --------------------- | :----: | :--------------------------------------------------------------- | :------: | :---: |
+| [`context-keys-type`](./RULES_DESCRIPTIONS.md#context-key-types)   |  n/a   | Disallows the usage of basic types in `context.WithValue`.       |   yes    |  yes  |
+| [`time-equal`](./RULES_DESCRIPTIONS.md#time-equal)         |  n/a   | Suggests to use `time.Time.Equal` instead of `==` and `!=` for equality check time.                 |   no    |  yes  |
+| [`time-naming`](./RULES_DESCRIPTIONS.md#time-naming)         |  n/a   | Conventions around the naming of time variables.                 |   yes    |  yes  |
+| [`var-declaration`](./RULES_DESCRIPTIONS.md#var-declaration)     |  n/a   | Reduces redundancies around variable declaration.                |   yes    |  yes  |
+| [`unexported-return`](./RULES_DESCRIPTIONS.md#unexported-return)   |  n/a   | Warns when a public return is from unexported type.              |   yes    |  yes  |
+| [`errorf`](./RULES_DESCRIPTIONS.md#errorf)              |  n/a   | Should replace `errors.New(fmt.Sprintf())` with `fmt.Errorf()`   |   yes    |  yes  |
+| [`blank-imports`](./RULES_DESCRIPTIONS.md#blank-imports)       |  n/a   | Disallows blank imports                                          |   yes    |  no   |
+| [`context-as-argument`](./RULES_DESCRIPTIONS.md#context-as-argument) |  n/a   | `context.Context` should be the first argument of a function.    |   yes    |  no   |
+| [`dot-imports`](./RULES_DESCRIPTIONS.md#dot-imports)         |  n/a   | Forbids `.` imports.                                             |   yes    |  no   |
+| [`error-return`](./RULES_DESCRIPTIONS.md#error-return)        |  n/a   | The error return parameter should be last.                       |   yes    |  no   |
+| [`error-strings`](./RULES_DESCRIPTIONS.md#error-strings)       |  []string   | Conventions around error strings.                                |   yes    |  no   |
+| [`error-naming`](./RULES_DESCRIPTIONS.md#error-naming)        |  n/a   | Naming of error variables.                                       |   yes    |  no   |
+| [`exported`](./RULES_DESCRIPTIONS.md#exported)            |  []string   | Naming and commenting conventions on exported symbols.           |   yes    |  no   |
+| [`if-return`](./RULES_DESCRIPTIONS.md#if-return)           |  n/a   | Redundant if when returning an error.                            |   no    |  no   |
+| [`increment-decrement`](./RULES_DESCRIPTIONS.md#increment-decrement) |  n/a   | Use `i++` and `i--` instead of `i += 1` and `i -= 1`.            |   yes    |  no   |
+| [`var-naming`](./RULES_DESCRIPTIONS.md#var-naming)          |  whitelist & blacklist of initialisms   | Naming rules.                                                    |   yes    |  no   |
+| [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |  n/a   | Package commenting conventions.                                  |   yes    |  no   |
+| [`range`](./RULES_DESCRIPTIONS.md#range)               |  n/a   | Prevents redundant variables when iterating over a collection.   |   yes    |  no   |
+| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  n/a   | Conventions around the naming of receivers.                      |   yes    |  no   |
+| [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |  n/a   | Prevents redundant else statements.                              |   yes    |  no   |
+| [`argument-limit`](./RULES_DESCRIPTIONS.md#argument-limit)      |  int   | Specifies the maximum number of arguments a function can receive |    no    |  no   |
+| [`cyclomatic`](./RULES_DESCRIPTIONS.md#cyclomatic)          |  int   | Sets restriction for maximum Cyclomatic complexity.              |    no    |  no   |
+| [`max-public-structs`](./RULES_DESCRIPTIONS.md#max-public-structs)  |  int   | The maximum number of public structs in a file.                  |    no    |  no   |
+| [`file-header`](./RULES_DESCRIPTIONS.md#file-header)         | string | Header which each file should have.                              |    no    |  no   |
+| [`empty-block`](./RULES_DESCRIPTIONS.md#empty-block)         |  n/a   | Warns on empty code blocks                                       |    no    |  yes   |
+| [`superfluous-else`](./RULES_DESCRIPTIONS.md#superfluous-else)    |  n/a   | Prevents redundant else statements (extends [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)) |    no    |  no   |
+| [`confusing-naming`](./RULES_DESCRIPTIONS.md#confusing-naming)    |  n/a   | Warns on methods with names that differ only by capitalization   |    no    |  no   |
+| [`get-return`](./RULES_DESCRIPTIONS.md#get-return)          |  n/a   | Warns on getters that do not yield any result                    |    no    |  no   |
+| [`modifies-parameter`](./RULES_DESCRIPTIONS.md#modifies-parameter)  |  n/a   | Warns on assignments to function parameters                      |    no    |  no   |
+| [`confusing-results`](./RULES_DESCRIPTIONS.md#confusing-results)   |  n/a   | Suggests to name potentially confusing function results          |    no    |  no   |
+| [`deep-exit`](./RULES_DESCRIPTIONS.md#deep-exit)           |  n/a   | Looks for program exits in funcs other than `main()` or `init()` |    no    |  no   |
+| [`unused-parameter`](./RULES_DESCRIPTIONS.md#unused-parameter)    |  n/a   | Suggests to rename or remove unused function parameters          |    no    |  no   |
+| [`unreachable-code`](./RULES_DESCRIPTIONS.md#unreachable-code)    |  n/a   | Warns on unreachable code                                        |    no    |  no   |
+| [`add-constant`](./RULES_DESCRIPTIONS.md#add-constant)        |  map   | Suggests using constant for magic numbers and string literals    |    no    |  no   |
+| [`flag-parameter`](./RULES_DESCRIPTIONS.md#flag-parameter)      |  n/a   | Warns on boolean parameters that create a control coupling       |    no    |  no   |
+| [`unnecessary-stmt`](./RULES_DESCRIPTIONS.md#unnecessary-stmt)    |  n/a   | Suggests removing or simplifying unnecessary statements          |    no    |  no   |
+| [`struct-tag`](./RULES_DESCRIPTIONS.md#struct-tag)          |  n/a   | Checks common struct tags like `json`,`xml`,`yaml`               |    no    |  no   |
+| [`modifies-value-receiver`](./RULES_DESCRIPTIONS.md#modifies-value-receiver) |  n/a   | Warns on assignments to value-passed method receivers        |    no    |  yes  |
+| [`constant-logical-expr`](./RULES_DESCRIPTIONS.md#constant-logical-expr)   |  n/a   | Warns on constant logical expressions                        |    no    |  no   |
+| [`bool-literal-in-expr`](./RULES_DESCRIPTIONS.md#bool-literal-in-expr)|  n/a   | Suggests removing Boolean literals from logic expressions        |    no    |  no   |
+| [`redefines-builtin-id`](./RULES_DESCRIPTIONS.md#redefines-builtin-id)|  n/a   | Warns on redefinitions of builtin identifiers                    |    no    |  no   |
+| [`function-result-limit`](./RULES_DESCRIPTIONS.md#function-result-limit) |  int | Specifies the maximum number of results a function can return    |    no    |  no   |
+| [`imports-blacklist`](./RULES_DESCRIPTIONS.md#imports-blacklist)   | []string | Disallows importing the specified packages                     |    no    |  no   |
+| [`range-val-in-closure`](./RULES_DESCRIPTIONS.md#range-val-in-closure)|  n/a   | Warns if range value is used in a closure dispatched as goroutine|    no    |  no   |
+| [`range-val-address`](./RULES_DESCRIPTIONS.md#range-val-address)|  n/a   | Warns if address of range value is used dangerously |    no    |  yes   |
+| [`waitgroup-by-value`](./RULES_DESCRIPTIONS.md#waitgroup-by-value)  |  n/a   | Warns on functions taking sync.WaitGroup as a by-value parameter |    no    |  no   |
+| [`atomic`](./RULES_DESCRIPTIONS.md#atomic)              |  n/a   | Check for common mistaken usages of the `sync/atomic` package    |    no    |  no   |
+| [`empty-lines`](./RULES_DESCRIPTIONS.md#empty-lines)   | n/a | Warns when there are heading or trailing newlines in a block              |    no    |  no   |
+| [`line-length-limit`](./RULES_DESCRIPTIONS.md#line-length-limit)   | int    | Specifies the maximum number of characters in a line             |    no    |  no   |
+| [`call-to-gc`](./RULES_DESCRIPTIONS.md#call-to-gc)   | n/a    | Warns on explicit call to the garbage collector    |    no    |  no   |
+| [`duplicated-imports`](./RULES_DESCRIPTIONS.md#duplicated-imports) | n/a  | Looks for packages that are imported two or more times   |    no    |  no   |
+| [`import-shadowing`](./RULES_DESCRIPTIONS.md#import-shadowing)   | n/a    | Spots identifiers that shadow an import    |    no    |  no   |
+| [`bare-return`](./RULES_DESCRIPTIONS.md#bare-return) | n/a  | Warns on bare returns   |    no    |  no   |
+| [`unused-receiver`](./RULES_DESCRIPTIONS.md#unused-receiver)   | n/a    | Suggests to rename or remove unused method receivers    |    no    |  no   |
+| [`unhandled-error`](./RULES_DESCRIPTIONS.md#unhandled-error)   | []string   | Warns on unhandled errors returned by funcion calls    |    no    |  yes   |
+| [`cognitive-complexity`](./RULES_DESCRIPTIONS.md#cognitive-complexity)          |  int   | Sets restriction for maximum Cognitive complexity.              |    no    |  no   |
+| [`string-of-int`](./RULES_DESCRIPTIONS.md#string-of-int)          |  n/a   | Warns on suspicious casts from int to string            |    no    |  yes   |
+| [`string-format`](./RULES_DESCRIPTIONS.md#string-format)          |  map   | Warns on specific string literals that fail one or more user-configured regular expressions            |    no    |  no   |
+| [`early-return`](./RULES_DESCRIPTIONS.md#early-return)          |  n/a   | Spots if-then-else statements that can be refactored to simplify code reading            |    no    |  no   |
+| [`unconditional-recursion`](./RULES_DESCRIPTIONS.md#unconditional-recursion)          |  n/a   | Warns on function calls that will lead to (direct) infinite recursion |    no    |  no   |
+| [`identical-branches`](./RULES_DESCRIPTIONS.md#identical-branches)          |  n/a   | Spots if-then-else statements with identical `then` and `else` branches       |    no    |  no   |
+| [`defer`](./RULES_DESCRIPTIONS.md#defer)          |  map   |  Warns on some [defer gotchas](https://blog.learngoprogramming.com/5-gotchas-of-defer-in-go-golang-part-iii-36a1ab3d6ef1)       |    no    |  no   |
+| [`unexported-naming`](./RULES_DESCRIPTIONS.md#unexported-naming)          |  n/a   |  Warns on wrongly named un-exported symbols       |    no    |  no   |
+| [`function-length`](./RULES_DESCRIPTIONS.md#function-length)          |  n/a   |  Warns on functions exceeding the statements or lines max |    no    |  no   |
+| [`nested-structs`](./RULES_DESCRIPTIONS.md#nested-structs)          |  n/a   |  Warns on structs within structs |    no    |  no   |
+| [`useless-break`](./RULES_DESCRIPTIONS.md#useless-break)          |  n/a   |  Warns on useless `break` statements in case clauses |    no    |  no   |
+| [`banned-characters`](./RULES_DESCRIPTIONS.md#banned-characters)          |  n/a   |  Checks banned characters in identifiers |    no    |  no   |
+| [`optimize-operands-order`](./RULES_DESCRIPTIONS.md#optimize-operands-order)          |  n/a   |  Checks inefficient conditional expressions |    no    |  no   |
+| [`use-any`](./RULES_DESCRIPTIONS.md#use-any)          |  n/a   |  Proposes to replace `interface{}` with its alias `any` |    no    |  no   |
+| [`datarace`](./RULES_DESCRIPTIONS.md#datarace)          |  n/a   |  Spots potential dataraces |    no    |  no   |
 
 ## Configurable rules
 

--- a/test/error-strings-custom-functions_test.go
+++ b/test/error-strings-custom-functions_test.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
+)
+
+func TestErrorStringsWithCustomFunctions(t *testing.T) {
+	args := []interface{}{"pkgErrors.Wrap"}
+	testRule(t, "error-strings-with-custom-functions", &rule.ErrorStringsRule{}, &lint.RuleConfig{
+		Arguments: args,
+	})
+}

--- a/testdata/error-strings-with-custom-functions.go
+++ b/testdata/error-strings-with-custom-functions.go
@@ -1,0 +1,12 @@
+package fixtures
+
+import (
+	pkgErrors "github.com/pkg/errors"
+)
+
+// Check for the error strings themselves.
+
+func errorsStrings(x int) error {
+	var err error
+	return pkgErrors.Wrap(err, "This %d is too low") // MATCH /error strings should not be capitalized or end with punctuation or a newline/
+}


### PR DESCRIPTION
**Please, describe in details what's your motivation for this PR**
As mentioned in #697, we may use other error packages instead of builtin or pkg
and also want to lint those error messages with `revive`, so it will be good to
allow to customize the function name.

### CHECKLIST
- [x] Did you add tests?
- [x] Does your code follows the coding style of the rest of the repository?
- [ ] Does the Travis build passes?

Closes #697 
