### PR TITLE
fix(unused-parameter): Skip param idents which are struct fields

### DIFF
--- a/rule/unused-param.go
+++ b/rule/unused-param.go
@@ -53,7 +53,7 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 			return nil // skip, is a function prototype
 		}
 
-		structFields := map[*ast.Object]bool{}
+		structFields := map[*ast.Ident]bool{}
 
 		// inspect the func body looking for references to parameters
 		// except struct field keys.
@@ -72,7 +72,7 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 					for _, e := range lit.Elts {
 						if kv, ok := e.(*ast.KeyValueExpr); ok {
 							if ident, ok := kv.Key.(*ast.Ident); ok {
-								structFields[ident.Obj] = true
+								structFields[ident] = true
 							}
 						}
 					}
@@ -84,7 +84,7 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 				return false
 			}
 
-			if params[ident.Obj] && !structFields[ident.Obj] {
+			if params[ident.Obj] && !structFields[ident] {
 				params[ident.Obj] = false // mark as used
 			}
 

--- a/testdata/unused-param.go
+++ b/testdata/unused-param.go
@@ -127,6 +127,17 @@ func f12(unused string) {
 	}
 }
 
+func f13(unused string) {
+	_ = struct {
+		unused string
+	}{
+		unused: "",
+	}
+	_ = mapType{
+		unused: nil,
+	}
+}
+
 func getCompareFailCause(n *node, which int, prevValue string, prevIndex uint64) string {
 	switch which {
 	case CompareIndexNotMatch:

--- a/testdata/unused-param.go
+++ b/testdata/unused-param.go
@@ -90,6 +90,43 @@ func f7(pl int) {
 	}
 }
 
+func f8(unused string) { // MATCH /parameter 'unused' seems to be unused, consider removing or renaming it as _/
+	_ = struct {
+		unused string
+	}{}
+}
+
+type structType struct {
+	unused string
+}
+
+func f9(unused string) { // MATCH /parameter 'unused' seems to be unused, consider removing or renaming it as _/
+	r := structType{}
+	r.unused = ""
+}
+
+func f10(unused string) { // MATCH /parameter 'unused' seems to be unused, consider removing or renaming it as _/
+	_ = structType{
+		unused: "",
+	}
+}
+
+func f11(unused string) { // MATCH /parameter 'unused' seems to be unused, consider removing or renaming it as _/
+	_ = struct {
+		unused string
+	}{
+		unused: "",
+	}
+}
+
+type mapType map[string]interface{}
+
+func f12(unused string) {
+	_ = mapType{
+		unused: nil,
+	}
+}
+
 func getCompareFailCause(n *node, which int, prevValue string, prevIndex uint64) string {
 	switch which {
 	case CompareIndexNotMatch:


### PR DESCRIPTION
Closes #721

This requires adding a call to `TypeCheck()` because the type may be defined after its usage or in another file in the same package. For anonymous structs, the type definition always appears before initialization in the AST.