### PR TITLE
fix documentation about enableAllRules minimal config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ enableAllRules = true
     Disabled = true
 [rule.function-length]
     Disabled = true
+[rule.banned-characters]
+    Disabled = true
 
 # Rule tuning
 [rule.argument-limit]

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -123,7 +123,7 @@ _Configuration_: N/A
 
 _Description_: Checks given banned characters in identifiers(func, var, const). Comments are not checked.
 
-_Configuration_: This rule accepts a slice of strings, the characters to ban.
+_Configuration_: This rule requires a slice of strings, the characters to ban.
 
 Example:
 


### PR DESCRIPTION
An entry was missing in the reference documentation when using enableAllRules

The problem exists since banned-characters was added (#532 #591)

No tests added, only documentation was updated

Closes #729 