### PR TITLE
fix #744: `chan struct{}` triggers nested-structs error

### DIFF
--- a/rule/nested-structs.go
+++ b/rule/nested-structs.go
@@ -43,6 +43,11 @@ func (l *lintNestedStructs) Visit(n ast.Node) ast.Visitor {
 		}
 		return nil
 	case *ast.Field:
+		_, isChannelField := v.Type.(*ast.ChanType)
+		if isChannelField {
+			return nil
+		}
+
 		filter := func(n ast.Node) bool {
 			switch n.(type) {
 			case *ast.StructType:

--- a/testdata/nested-structs.go
+++ b/testdata/nested-structs.go
@@ -35,3 +35,8 @@ func fred() interface{} {
 type Bad struct {
 	Field []struct{} // MATCH /no nested structs are allowed/
 }
+
+// issue744
+type issue744 struct {
+	c chan struct{}
+}


### PR DESCRIPTION
Closes #744 
