### PR TITLE
"go get" reference updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. I updated revive `go get -u github.com/mgechev/revive`
+1. I updated revive `go install github.com/mgechev/revive@latest`
 2. I run it with the following flags & configuration file:
 
 ```shell

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -4,14 +4,14 @@ This document explains how to build, test, and develop features for revive.
 
 ## Installation
 
-In order to install all the dependencies run:
+Clone the project:
 
-```bash
-go get -u github.com/mgechev/revive
-cd $GOPATH/src/github.com/mgechev/revive
+```
+git clone git@github.com:mgechev/revive.git
+cd revive
 ```
 
-After that install the dependencies using go modules:
+In order to fetch all the dependencies run:
 
 ```bash
 make install


### PR DESCRIPTION
This PR updates `go get` references in the `bug_report.md` issue template and `DEVELOPING.md` files.

--- 

closes https://github.com/mgechev/revive/issues/737
