### PR TITLE
Speedup branch comparison in `identical-branches` rule

### DIFF
--- a/rule/identical-branches.go
+++ b/rule/identical-branches.go
@@ -63,8 +63,10 @@ func (lintIdenticalBranches) identicalBranches(branches []*ast.BlockStmt) bool {
 	}
 
 	ref := gofmt(branches[0])
+	refSize := len(branches[0].List)
 	for i := 1; i < len(branches); i++ {
-		if gofmt(branches[i]) != ref {
+		currentSize := len(branches[i].List)
+		if currentSize != refSize || gofmt(branches[i]) != ref {
 			return false
 		}
 	}


### PR DESCRIPTION
This PR optimizes branch comparison by avoiding unnecessary calls to the expensive `gofmt`
That is done by checking the number of statements on each branch before calling `gofmt`. If branches have not the same number of statements then they are necessarily not identical.