### PR TITLE
fix #781: nested-structs errors on an interface func "set" return value

### DIFF
--- a/rule/nested-structs.go
+++ b/rule/nested-structs.go
@@ -37,6 +37,11 @@ type lintNestedStructs struct {
 
 func (l *lintNestedStructs) Visit(n ast.Node) ast.Visitor {
 	switch v := n.(type) {
+	case *ast.TypeSpec:
+		_, isInterface := v.Type.(*ast.InterfaceType)
+		if isInterface {
+			return nil // do not analyze interface declarations
+		}
 	case *ast.FuncDecl:
 		if v.Body != nil {
 			ast.Walk(l, v.Body)

--- a/testdata/nested-structs.go
+++ b/testdata/nested-structs.go
@@ -40,3 +40,8 @@ type Bad struct {
 type issue744 struct {
 	c chan struct{}
 }
+
+// issue 781
+type mySetInterface interface {
+	GetSet() map[string]struct{}
+}


### PR DESCRIPTION
Closes #781 by ignoring interface declarations
