### PR TITLE
add golint's package name MixedCaps rule

### DIFF
--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/mgechev/revive/lint"
 )
+
+var anyCapsRE = regexp.MustCompile(`[A-Z]`)
 
 // VarNamingRule lints given else constructs.
 type VarNamingRule struct {
@@ -55,6 +58,14 @@ func (r *VarNamingRule) Apply(file *lint.File, arguments lint.Arguments) []lint.
 	if strings.Contains(walker.fileAst.Name.Name, "_") && !strings.HasSuffix(walker.fileAst.Name.Name, "_test") {
 		walker.onFailure(lint.Failure{
 			Failure:    "don't use an underscore in package name",
+			Confidence: 1,
+			Node:       walker.fileAst.Name,
+			Category:   "naming",
+		})
+	}
+	if anyCapsRE.MatchString(walker.fileAst.Name.Name) {
+		walker.onFailure(lint.Failure{
+			Failure:    fmt.Sprintf("don't use MixedCaps in package name; %s should be %s", walker.fileAst.Name.Name, strings.ToLower(walker.fileAst.Name.Name)),
 			Confidence: 1,
 			Node:       walker.fileAst.Name,
 			Category:   "naming",

--- a/testdata/golint/pkg-caps.go
+++ b/testdata/golint/pkg-caps.go
@@ -1,0 +1,4 @@
+// MixedCaps package name
+
+// Package PkgName ...
+package PkgName // MATCH /don't use MixedCaps in package name; PkgName should be pkgname/


### PR DESCRIPTION
This adds the implementation of golint's package name MixedCaps check from https://github.com/golang/lint/pull/285 as well as the [same testdata file used in golint, pkg-caps.go](https://github.com/golang/lint/blob/master/testdata/pkg-caps.go). Slightly improves "drop-in replacement for golint" story for golint's `lintNames()` rules.

Closes #796