### PR TITLE
fix: typo in error message when failed to get lint rules

### DIFF
--- a/revivelib/core.go
+++ b/revivelib/core.go
@@ -52,7 +52,7 @@ func New(
 
 	lintingRules, err := config.GetLintingRules(conf, extraRuleInstances)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing revive - gettint lint rules")
+		return nil, errors.Wrap(err, "initializing revive - getting lint rules")
 	}
 
 	logger.Println("Config loaded")


### PR DESCRIPTION
This PR fixes a typo in the error message.