### PR TITLE
Prevent empty-block on range over channel

### DIFF
--- a/rule/empty-block.go
+++ b/rule/empty-block.go
@@ -52,12 +52,14 @@ func (w lintEmptyBlock) Visit(node ast.Node) ast.Visitor {
 		}
 	case *ast.RangeStmt:
 		if len(n.Body.List) == 0 {
-			w.onFailure(lint.Failure{
-				Confidence: 0.9,
-				Node:       n,
-				Category:   "logic",
-				Failure:    "this block is empty, you can remove it",
-			})
+			if n.Key != nil || n.Value != nil || !isRangeOverChannel(n.X) {
+				w.onFailure(lint.Failure{
+					Confidence: 0.9,
+					Node:       n,
+					Category:   "logic",
+					Failure:    "this block is empty, you can remove it",
+				})
+			}
 			return nil // skip visiting the range subtree (it will produce a duplicated failure)
 		}
 	case *ast.BlockStmt:
@@ -72,4 +74,117 @@ func (w lintEmptyBlock) Visit(node ast.Node) ast.Visitor {
 	}
 
 	return w
+}
+
+// isRangeOverChannel implements a best-effort detection for expressions in the context of 'for range'
+// whose result is a channel.
+// To do this it assumes that channels can only come from call return values, assignments or variables.
+func isRangeOverChannel(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.CallExpr:
+		return isChanCallExpr(e, 0)
+	case *ast.Ident:
+		return isChanIdent(e)
+	}
+	return false
+}
+
+func isChanIdent(ident *ast.Ident) bool {
+	var typ ast.Expr
+	switch decl := ident.Obj.Decl.(type) {
+	case *ast.Field:
+		// function parameter
+		typ = decl.Type.(*ast.ChanType)
+	case *ast.AssignStmt:
+		return isChanAssignStmt(decl, ident.Name)
+	case *ast.ValueSpec:
+		// defined variable (var x type)
+		if decl.Type != nil {
+			typ = decl.Type
+			break
+		}
+		// assigned variable (var x = ...)
+		idx := -1
+		for i, n := range decl.Names {
+			if n.Name == ident.Name {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 || idx+1 > len(decl.Values) {
+			return false
+		}
+		var isChan bool
+		switch expr := decl.Values[idx].(type) {
+		case *ast.Ident:
+			isChan = isChanIdent(expr)
+		case *ast.CallExpr:
+			isChan = isChanCallExpr(expr, idx)
+		}
+		if isChan {
+			return true
+		}
+	}
+	_, isChan := typ.(*ast.ChanType)
+	return isChan
+}
+
+func isChanAssignStmt(assign *ast.AssignStmt, name string) bool {
+	idx := -1
+	for i, lhs := range assign.Lhs {
+		ident, ok := lhs.(*ast.Ident)
+		if !ok || ident.Name != name {
+			continue
+		}
+		idx = i
+		break
+	}
+	if idx < 0 {
+		return false
+	}
+
+	var rhs ast.Expr
+	if len(assign.Lhs) == len(assign.Rhs) {
+		// assignment with equal sides: a, b := c, d()
+		rhs = assign.Rhs[idx]
+	} else {
+		// assignment with uneven sides: a, b := c()
+		rhs = assign.Rhs[0]
+	}
+
+	switch expr := rhs.(type) {
+	case *ast.CallExpr:
+		return isChanCallExpr(expr, idx)
+	case *ast.Ident:
+		return isChanIdent(expr)
+	}
+	return false
+}
+
+func isChanCallExpr(call *ast.CallExpr, returnValueIndex int) bool {
+	var fieldList *ast.FieldList
+	var typ ast.Expr
+
+	switch f := call.Fun.(type) {
+	case *ast.FuncLit:
+		// inline function definition and call
+		fieldList = f.Type.Results
+	case *ast.Ident:
+		if f.Name == "make" {
+			// special handling for make builtin
+			typ = call.Args[0]
+			break
+		}
+		// normal function call
+		decl, ok := f.Obj.Decl.(*ast.FuncDecl)
+		if !ok {
+			break
+		}
+		fieldList = decl.Type.Results
+	}
+	if fieldList != nil && len(fieldList.List) > returnValueIndex {
+		typ = fieldList.List[returnValueIndex].Type
+	}
+	_, isChan := typ.(*ast.ChanType)
+	return isChan
 }


### PR DESCRIPTION
An empty loop over channels is a common pattern:
https://sourcegraph.com/search?q=context%3Aglobal+lang%3AGo+for%5C+range%5C+.*%5C+%5C%7B%5Cs*%5C%7D&patternType=regexp&sm=1&groupBy=repo
https://sourcegraph.com/search?q=context%3Aglobal+lang%3AGo+for%5C+range%5C+.*%5C+%5C%7B%5Cs*%5C%7D+repo%3Agithub.com%2Fgolang%2Fgo&patternType=regexp&sm=1&groupBy=repo

Since the given AST doesn't really provide much type info I had to resort to finding the declaration/definition of the object to figure out whether `for range` was actually looping over a channel.
This doesn't feel very reliable, but it works for the test data. I'll be happy to extend the checks if an issue gets reported.

I tried re-adding `file.Pkg.TypeCheck()` from https://github.com/mgechev/revive/pull/415, but didn't notice any difference in the AST.

Closes #386
