### PR TITLE
Docs: Fix invalid toml in rule.add-constant example

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -92,7 +92,7 @@ Example:
 
 ```toml
 [rule.add-constant]
-  arguments = [{maxLitCount = "3",allowStrs ="\"\"",allowInts="0,1,2",allowFloats="0.0,0.,1.0,1.,2.0,2.","ignoreFuncs": "os\\.*,fmt\\.Println,make"}]
+  arguments = [{ maxLitCount = "3", allowStrs = "\"\"", allowInts = "0,1,2", allowFloats = "0.0,0.,1.0,1.,2.0,2.", ignoreFuncs = "os\\.*,fmt\\.Println,make" }]
 ```
 
 ## argument-limit


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
_< !-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->_

The example for `[rule.add-constant]` was invalid TOML.
Instead of `"ignoreFuncs": "foo"` it should be `ignoreFuncs = "foo"`.

(Also added some spacing for improved readability.)