### PR TITLE
add nolint to default list of acceptable comments for comment-spacings

### DIFF
--- a/rule/comment-spacings.go
+++ b/rule/comment-spacings.go
@@ -23,6 +23,7 @@ func (r *CommentSpacingsRule) configure(arguments lint.Arguments) {
 		r.allowList = []string{
 			"//go:",
 			"//revive:",
+			"//nolint:",
 		}
 
 		for _, arg := range arguments {

--- a/testdata/comment-spacings.go
+++ b/testdata/comment-spacings.go
@@ -39,3 +39,6 @@ Should be valid
 
 /* valid
  */
+
+//nolint:staticcheck // nolint should be in the default list of acceptable comments.
+var b string


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

Adds `//nolint:` to the default list of acceptable comments without a space before them.
 
<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
