### PR TITLE
nested-structs: show issue with "struct{}" detection

### DIFF
--- a/testdata/nested-structs.go
+++ b/testdata/nested-structs.go
@@ -61,4 +61,7 @@ type mySetInterface interface {
 type test struct {
 	foo []chan struct{}     // Must not match
 	bar map[string]struct{} // Must not match
+	baz generic[struct{}]   // Must not match
 }
+
+type generic [T any] struct {}


### PR DESCRIPTION
Background
=========
This pull request is to demonstrate issue in https://github.com/mgechev/revive/issues/824

It seems like the intent is to not fail on "struct{}".