### PR TITLE
fix: support method call from structures for string-format

### DIFF
--- a/rule/string-format.go
+++ b/rule/string-format.go
@@ -185,11 +185,13 @@ func (w lintStringFormatRule) Visit(node ast.Node) ast.Visitor {
 	if !ok {
 		return w
 	}
+
 	// Get the name of the call expression to check against rule scope
 	callName, ok := w.getCallName(call)
 	if !ok {
 		return w
 	}
+
 	for _, rule := range w.rules {
 		if rule.scope.funcName == callName {
 			rule.Apply(call)
@@ -217,7 +219,6 @@ func (lintStringFormatRule) getCallName(call *ast.CallExpr) (callName string, ok
 		if ok {
 			return recv.Sel.Name + "." + selector.Sel.Name, true
 		}
-		return "", false
 	}
 
 	return "", false

--- a/rule/string-format.go
+++ b/rule/string-format.go
@@ -185,13 +185,11 @@ func (w lintStringFormatRule) Visit(node ast.Node) ast.Visitor {
 	if !ok {
 		return w
 	}
-
 	// Get the name of the call expression to check against rule scope
 	callName, ok := w.getCallName(call)
 	if !ok {
 		return w
 	}
-
 	for _, rule := range w.rules {
 		if rule.scope.funcName == callName {
 			rule.Apply(call)
@@ -211,10 +209,15 @@ func (lintStringFormatRule) getCallName(call *ast.CallExpr) (callName string, ok
 	if selector, ok := call.Fun.(*ast.SelectorExpr); ok {
 		// Scoped function call
 		scope, ok := selector.X.(*ast.Ident)
-		if !ok {
-			return "", false
+		if ok {
+			return scope.Name + "." + selector.Sel.Name, true
 		}
-		return scope.Name + "." + selector.Sel.Name, true
+		// Scoped function call inside structure
+		recv, ok := selector.X.(*ast.SelectorExpr)
+		if ok {
+			return recv.Sel.Name + "." + selector.Sel.Name, true
+		}
+		return "", false
 	}
 
 	return "", false

--- a/test/string-format_test.go
+++ b/test/string-format_test.go
@@ -21,7 +21,11 @@ func TestStringFormat(t *testing.T) {
 			[]interface{}{
 				"s.Method3[2]",
 				"!/^[Tt][Hh]/",
-				"must not start with 'th'"}}})
+				"must not start with 'th'"},
+			[]interface{}{
+				"s.Method4", // same as before, but called from a struct
+				"!/^[Ot][Tt]/",
+				"must not start with 'ot'"}}})
 }
 
 func TestStringFormatArgumentParsing(t *testing.T) {

--- a/testdata/string-format.go
+++ b/testdata/string-format.go
@@ -18,6 +18,16 @@ func (s stringFormatMethods) Method3(a, b, c string) {
 
 }
 
+type stringFormatMethodsInjected struct{}
+
+func (s stringFormatMethodsInjected) Method4(a, b, c string) {
+
+}
+
+type container struct {
+	s stringFormatMethodsInjected
+}
+
 func stringFormat() {
 	stringFormatMethod1("This string is fine", "")
 	stringFormatMethod1("this string is not capitalized", "") // MATCH /must start with a capital letter/
@@ -27,4 +37,9 @@ func stringFormat() {
 		d: "This string is capitalized, but ends with a period."}) // MATCH /string literal doesn't match user defined regex /[^\.]$//
 	s := stringFormatMethods{}
 	s.Method3("", "", "This string starts with th") // MATCH /must not start with 'th'/
+
+	c := container{
+		s: stringFormatMethods{},
+	}
+	c.s.Method4("Other string starts with ot") // MATCH /must not start with 'ot'/
 }


### PR DESCRIPTION
This MR fix issue #839. Here the called object method is inside a structure (common pattern for dependency injection). Before the rule was not running for this rules.

The only thing is the function scope is tied to the structure name of the object, not to the object name.

This MR tries to fix this. A test was added to the string-format to evaluate this.

- [x] Did you add tests?
- [x] Does your code follows the coding style of the rest of the repository?
- [x] Does the Travis build passes?

Closes #839 
