### PR TITLE
imporve `var-naming`  - add upperCaseConst  option to allow UPPER_CASED constants #851

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -669,13 +669,17 @@ _Configuration_: N/A
 
 _Description_: This rule warns when [initialism](https://github.com/golang/go/wiki/CodeReviewComments#initialisms), [variable](https://github.com/golang/go/wiki/CodeReviewComments#variable-names) or [package](https://github.com/golang/go/wiki/CodeReviewComments#package-names) naming conventions are not followed.
 
-_Configuration_: This rule accepts two slices of strings, a whitelist and a blacklist of initialisms. By default, the rule behaves exactly as the alternative in `golint` but optionally, you can relax it (see [golint/lint/issues/89](https://github.com/golang/lint/issues/89))
+_Configuration_: This rule accepts two slices of strings and one optional slice with single map with named parameters.
+(it's due to TOML hasn't "slice of any" and we keep backward compatibility with previous config version)
+First slice is a whitelist and second one is a blacklist of initialisms. 
+In map, you can add "upperCaseConst=true" parameter to allow `UPPER_CASE` for `const` 
+By default, the rule behaves exactly as the alternative in `golint` but optionally, you can relax it (see [golint/lint/issues/89](https://github.com/golang/lint/issues/89))
 
 Example:
 
 ```toml
 [rule.var-naming]
-  arguments = [["ID"], ["VM"]]
+  arguments = [["ID"], ["VM"], [{upperCaseConst=true}]]
 ```
 
 ## var-declaration

--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -38,7 +38,8 @@ func (r *VarNamingRule) configure(arguments lint.Arguments) {
 
 		if len(arguments) >= 3 {
 			// not pretty code because should keep compatibility with TOML (no mixed array types) and new map parameters
-			asSlice, ok := arguments[2].([]interface{})
+			thirdArgument := arguments[2]
+			asSlice, ok := thirdArgument.([]interface{})
 			if !ok {
 				panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, got %T", "options", arguments[2]))
 			}
@@ -124,7 +125,7 @@ func (w *lintNames) check(id *ast.Ident, thing string) {
 
 	// #851 upperCaseConst support
 	// if it's const
-	if thing == "const" && w.upperCaseConst && upperCaseConstRE.Match([]byte(id.Name)) {
+	if thing == token.CONST.String() && w.upperCaseConst && upperCaseConstRE.Match([]byte(id.Name)) {
 		return
 	}
 
@@ -218,15 +219,8 @@ func (w *lintNames) Visit(n ast.Node) ast.Visitor {
 		if v.Tok == token.IMPORT {
 			return w
 		}
-		var thing string
-		switch v.Tok {
-		case token.CONST:
-			thing = "const"
-		case token.TYPE:
-			thing = "type"
-		case token.VAR:
-			thing = "var"
-		}
+
+		thing := v.Tok.String()
 		for _, spec := range v.Specs {
 			switch s := spec.(type) {
 			case *ast.TypeSpec:

--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -36,15 +36,21 @@ func (r *VarNamingRule) configure(arguments lint.Arguments) {
 			r.blacklist = getList(arguments[1], "blacklist")
 		}
 
-		// try to find first  argument of type map - treat it as "other options" map
-		for _, a := range arguments {
-			args, ok := a.(map[string]interface{})
-			if ok {
-				r.upperCaseConst = fmt.Sprint(args["upperCaseConst"]) == "true"
-				break
+		if len(arguments) >= 3 {
+			// not pretty code because should keep compatibility with TOML (no mixed array types) and new map parameters
+			asSlice, ok := arguments[2].([]interface{})
+			if !ok {
+				panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, got %T", "options", arguments[2]))
 			}
+			if len(asSlice) != 1 {
+				panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, of len==1, but %d", "options", len(asSlice)))
+			}
+			args, ok := asSlice[0].(map[string]interface{})
+			if !ok {
+				panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, of len==1, with map, but %T", "options", asSlice[0]))
+			}
+			r.upperCaseConst = fmt.Sprint(args["upperCaseConst"]) == "true"
 		}
-
 		r.configured = true
 	}
 	r.Unlock()

--- a/test/var-naming_test.go
+++ b/test/var-naming_test.go
@@ -13,4 +13,9 @@ func TestVarNaming(t *testing.T) {
 	})
 
 	testRule(t, "var-naming_test", &rule.VarNamingRule{}, &lint.RuleConfig{})
+
+	testRule(t, "var-naming_upperCaseConst-false", &rule.VarNamingRule{}, &lint.RuleConfig{})
+	testRule(t, "var-naming_upperCaseConst-true", &rule.VarNamingRule{}, &lint.RuleConfig{
+		Arguments: []interface{}{[]interface{}{}, []interface{}{}, map[string]interface{}{"upperCaseConst": true}},
+	})
 }

--- a/test/var-naming_test.go
+++ b/test/var-naming_test.go
@@ -16,6 +16,6 @@ func TestVarNaming(t *testing.T) {
 
 	testRule(t, "var-naming_upperCaseConst-false", &rule.VarNamingRule{}, &lint.RuleConfig{})
 	testRule(t, "var-naming_upperCaseConst-true", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{[]interface{}{}, []interface{}{}, map[string]interface{}{"upperCaseConst": true}},
+		Arguments: []interface{}{[]interface{}{}, []interface{}{}, []interface{}{map[string]interface{}{"upperCaseConst": true}}},
 	})
 }

--- a/testdata/var-naming_upperCaseConst-false.go
+++ b/testdata/var-naming_upperCaseConst-false.go
@@ -1,0 +1,9 @@
+// should fail if upperCaseConst = false (by default) #851
+
+package fixtures
+
+const SOME_CONST_2 = 1 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
+
+const (
+	SOME_CONST_3 = 3 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
+)

--- a/testdata/var-naming_upperCaseConst-false.go
+++ b/testdata/var-naming_upperCaseConst-false.go
@@ -6,7 +6,4 @@ const SOME_CONST_2 = 1 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
 
 const (
 	SOME_CONST_3 = 3 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
-	// DUE TO LEGACY - names less 5 symbols without undescores are not treated as UPPER_CASE
-	// It's strange, but VERYLARGENAME is not linted too
-	VER = 0
 )

--- a/testdata/var-naming_upperCaseConst-false.go
+++ b/testdata/var-naming_upperCaseConst-false.go
@@ -6,5 +6,7 @@ const SOME_CONST_2 = 1 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
 
 const (
 	SOME_CONST_3 = 3 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
-	VER          = 0 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
+	// DUE TO LEGACY - names less 5 symbols without undescores are not treated as UPPER_CASE
+	// It's strange, but VERYLARGENAME is not linted too
+	VER = 0
 )

--- a/testdata/var-naming_upperCaseConst-false.go
+++ b/testdata/var-naming_upperCaseConst-false.go
@@ -6,4 +6,5 @@ const SOME_CONST_2 = 1 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
 
 const (
 	SOME_CONST_3 = 3 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
+	VER          = 0 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
 )

--- a/testdata/var-naming_upperCaseConst-true.go
+++ b/testdata/var-naming_upperCaseConst-true.go
@@ -1,0 +1,9 @@
+// should pass if upperCaseConst = true
+
+package fixtures
+
+const SOME_CONST_2 = 2
+
+const (
+	SOME_CONST_3 = 3
+)

--- a/testdata/var-naming_upperCaseConst-true.go
+++ b/testdata/var-naming_upperCaseConst-true.go
@@ -6,4 +6,5 @@ const SOME_CONST_2 = 2
 
 const (
 	SOME_CONST_3 = 3
+	VER          = 0
 )


### PR DESCRIPTION

it's improvement for  #851 task
