### PR TITLE
fix: redundant-import-alias with confidence 0.95

### DIFF
--- a/rule/redundant-import-alias.go
+++ b/rule/redundant-import-alias.go
@@ -22,7 +22,7 @@ func (*RedundantImportAlias) Apply(file *lint.File, _ lint.Arguments) []lint.Fai
 
 		if getImportPackageName(imp) == imp.Name.Name {
 			failures = append(failures, lint.Failure{
-				Confidence: 1,
+				Confidence: 0.95,
 				Failure:    fmt.Sprintf("Import alias \"%s\" is redundant", imp.Name.Name),
 				Node:       imp,
 				Category:   "imports",


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
Followup PR for https://github.com/mgechev/revive/issues/853

<!-- ### CHECKLIST ### -->
Interacting with the new rule `redundant-import-alias` on my company projects, it has turned out really useful. But in some rare occasions, the warning is not accurate. Indeed, when the package name does not match the folder name (I guess this is too rare in any go project).

The proper solution is to actually check that the alias matches the package name, but meeting that requirement would trade-off performance and memory usage.
So, I guess a more humble fix is to reduce de `Confidence` parameter inside the failure.
