### PR TITLE
per-rule file exclude filters (#850)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 *.swp
 dist/
 *.log
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ vendor
 *.swp
 dist/
 *.log
-.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -439,17 +439,20 @@ errorCode = 0
 warningCode = 0
 
 [rule.blank-imports]
-   exclude=["**/*.pb.go"]
+   Exclude=["**/*.pb.go"]
 [rule.context-as-argument]
-   exclude=["src/somepkg/*.go", "TEST"]
+   Exclude=["src/somepkg/*.go", "TEST"]
 ```
 
 You can use following exclude patterns
 
 1. full paths to files `src/pkg/mypkg/some.go`
 2. globs `src/**/*.pb.go`
-3. regexes (should have prefix ~, will be ignored) `~\.(pb|auto|generated)\.go$`
+3. regexes (should have prefix ~) `~\.(pb|auto|generated)\.go$`
 4. well-known `TEST` (same as `**/*_test.go`)
+5. special cases:
+  a. `*` and `~` patterns exclude all files (same effect than disabling the rule)
+  b. `""` (empty) pattern excludes nothing
 
 > NOTE: do not mess with `exclude` that can  be used at top level of TOML file, that mean "exclude package patterns", not "exclude file patterns"
 

--- a/README.md
+++ b/README.md
@@ -425,6 +425,34 @@ warningCode = 0
 [rule.redefines-builtin-id]
 ```
 
+### Rule-level file excludes
+
+You also can setup custom excludes for each rule.
+
+It's alternative for global `-exclude` program arg.
+
+```toml
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+   exclude=["**/*.pb.go"]
+[rule.context-as-argument]
+   exclude=["src/somepkg/*.go", "TEST"]
+```
+
+You can use following exclude patterns
+
+1. full paths to files `src/pkg/mypkg/some.go`
+2. globs `src/**/*.pb.go`
+3. regexes (should have prefix ~, will be ignored) `~\.(pb|auto|generated)\.go$`
+4. well-known `TEST` (same as `**/*_test.go`)
+
+> NOTE: do not mess with `exclude` that can  be used at top level of TOML file, that mean "exclude package patterns", not "exclude file patterns"
+
 ## Available Rules
 
 List of all available rules. The rules ported from `golint` are left unchanged and indicated in the `golint` column.

--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,14 @@ func parseConfig(path string, config *lint.Config) error {
 	if err != nil {
 		return fmt.Errorf("cannot parse the config file: %v", err)
 	}
+	for k, r := range config.Rules {
+		err := r.Initialize()
+		if err != nil {
+			return fmt.Errorf("error in config of rule [%s] : [%v]", k, err)
+		}
+		config.Rules[k] = r
+	}
+
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,12 +73,12 @@ func TestGetConfig(t *testing.T) {
 		}
 		r2 := cfg.Rules["r2"]
 		if len(r2.Exclude) != 1 {
-			t.Fatal("r2 should have execlude set")
+			t.Fatal("r2 should have exclude set")
 		}
-		if r2.Match(&lint.File{Name: "some/file.go"}) {
+		if !r2.MustExclude("some/file.go") {
 			t.Fatal("r2 should be initialized and exclude some/file.go")
 		}
-		if !r2.Match(&lint.File{Name: "some/any-other.go"}) {
+		if r2.MustExclude("some/any-other.go") {
 			t.Fatal("r2 should not exclude some/any-other.go")
 		}
 	})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -61,6 +61,27 @@ func TestGetConfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("rule-level file filter excludes", func(t *testing.T) {
+		cfg, err := GetConfig("testdata/rule-level-exclude-850.toml")
+		if err != nil {
+			t.Fatal("should be valid config")
+		}
+		r1 := cfg.Rules["r1"]
+		if len(r1.Exclude) > 0 {
+			t.Fatal("r1 should have empty excludes")
+		}
+		r2 := cfg.Rules["r2"]
+		if len(r2.Exclude) != 1 {
+			t.Fatal("r2 should have execlude set")
+		}
+		if r2.Match(&lint.File{Name: "some/file.go"}) {
+			t.Fatal("r2 should be initialized and exclude some/file.go")
+		}
+		if !r2.Match(&lint.File{Name: "some/any-other.go"}) {
+			t.Fatal("r2 should not exclude some/any-other.go")
+		}
+	})
 }
 
 func TestGetLintingRules(t *testing.T) {

--- a/config/testdata/rule-level-exclude-850.toml
+++ b/config/testdata/rule-level-exclude-850.toml
@@ -1,0 +1,13 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+enableAllRules = false
+
+[rule.r1]
+    # no excludes
+
+[rule.r2]
+    exclude=["some/file.go"]

--- a/lint/config.go
+++ b/lint/config.go
@@ -31,14 +31,14 @@ func (rc *RuleConfig) Initialize() error {
 // RulesConfig defines the config for all rules.
 type RulesConfig = map[string]RuleConfig
 
-// Match - checks if given [File] `f` should be covered with configured rule (not excluded)
-func (rcfg *RuleConfig) Match(f *File) bool {
+// MustExclude - checks if given filename `name` must be excluded
+func (rcfg *RuleConfig) MustExclude(name string) bool {
 	for _, exclude := range rcfg.excludeFilters {
-		if exclude.Match(f) {
-			return false
+		if exclude.MatchFileName(name) {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // DirectiveConfig is type used for the linter directive configuration.

--- a/lint/config.go
+++ b/lint/config.go
@@ -3,15 +3,43 @@ package lint
 // Arguments is type used for the arguments of a rule.
 type Arguments = []interface{}
 
+type FileFilters = []*FileFilter
+
 // RuleConfig is type used for the rule configuration.
 type RuleConfig struct {
 	Arguments Arguments
 	Severity  Severity
 	Disabled  bool
+	// Exclude - rule-level file excludes, TOML related (strings)
+	Exclude []string
+	// excludeFilters - regex-based file filters, initialized from Exclude
+	excludeFilters []*FileFilter
+}
+
+// Initialize - should be called after reading from TOML file
+func (rc *RuleConfig) Initialize() error {
+	for _, f := range rc.Exclude {
+		ff, err := ParseFileFilter(f)
+		if err != nil {
+			return err
+		}
+		rc.excludeFilters = append(rc.excludeFilters, ff)
+	}
+	return nil
 }
 
 // RulesConfig defines the config for all rules.
 type RulesConfig = map[string]RuleConfig
+
+// Match - checks if given [File] `f` should be covered with configured rule (not excluded)
+func (rcfg *RuleConfig) Match(f *File) bool {
+	for _, exclude := range rcfg.excludeFilters {
+		if exclude.Match(f) {
+			return false
+		}
+	}
+	return true
+}
 
 // DirectiveConfig is type used for the linter directive configuration.
 type DirectiveConfig struct {

--- a/lint/file.go
+++ b/lint/file.go
@@ -102,6 +102,9 @@ func (f *File) lint(rules []Rule, config Config, failures chan Failure) {
 	disabledIntervals := f.disabledIntervals(rules, mustSpecifyDisableReason, failures)
 	for _, currentRule := range rules {
 		ruleConfig := rulesConfig[currentRule.Name()]
+		if !ruleConfig.Match(f) {
+			continue
+		}
 		currentFailures := currentRule.Apply(f, ruleConfig.Arguments)
 		for idx, failure := range currentFailures {
 			if failure.RuleName == "" {

--- a/lint/file.go
+++ b/lint/file.go
@@ -102,7 +102,7 @@ func (f *File) lint(rules []Rule, config Config, failures chan Failure) {
 	disabledIntervals := f.disabledIntervals(rules, mustSpecifyDisableReason, failures)
 	for _, currentRule := range rules {
 		ruleConfig := rulesConfig[currentRule.Name()]
-		if !ruleConfig.Match(f) {
+		if ruleConfig.MustExclude(f.Name) {
 			continue
 		}
 		currentFailures := currentRule.Apply(f, ruleConfig.Arguments)

--- a/lint/filefilter.go
+++ b/lint/filefilter.go
@@ -1,0 +1,126 @@
+package lint
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// FileFilter - file filter to exclude some files for rule
+// supports whole
+// 1. file/dir names : pkg/mypkg/my.go,
+// 2. globs: **/*.pb.go,
+// 3. regexes (~ prefix) ~-tmp\.\d+\.go
+// 4. special test marker `TEST` - treats as `~_test\.go`
+type FileFilter struct {
+	// raw definition of filter inside config
+	raw string
+	// don't care what was at start, will use regexes inside
+	rx *regexp.Regexp
+	// marks that it was empty rule that matches everything
+	matchesAll bool
+}
+
+// ParseFileFilter - creates [FileFilter] for given raw filter
+// if empty string, or `*`, or `~` is used it means "always true"
+// while regexp could be invalid, it could return it's compilation error
+func ParseFileFilter(cfgFilter string) (*FileFilter, error) {
+	cfgFilter = strings.TrimSpace(cfgFilter)
+	result := new(FileFilter)
+	result.raw = cfgFilter
+	result.matchesAll = len(result.raw) == 0 || result.raw == "*" || result.raw == "~"
+	if !result.matchesAll {
+		if err := result.prepareRegexp(); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func (ff *FileFilter) String() string { return ff.raw }
+
+// MatchFileName - checks if file name matches filter
+func (ff *FileFilter) MatchFileName(name string) bool {
+	if ff.matchesAll {
+		return true
+	}
+	name = strings.ReplaceAll(name, "\\", "/")
+	return ff.rx.MatchString(name)
+}
+
+// Match - checks if given [File] matches filter
+func (ff *FileFilter) Match(f *File) bool {
+	return ff.MatchFileName(f.Name)
+}
+
+var fileFilterInvalidGlobRegexp = regexp.MustCompile(`[^/]\*\*[^/]`)
+var escapeRegexSymbols = ".+{}()[]^$"
+
+func (ff *FileFilter) prepareRegexp() error {
+	var err error
+	var src = ff.raw
+	if src == "TEST" {
+		src = "~_test\\.go"
+	}
+	if strings.HasPrefix(src, "~") {
+		ff.rx, err = regexp.Compile(src[1:])
+		if err != nil {
+			return fmt.Errorf("invalid file filter [%s], regexp compile error: [%v]", ff.raw, err)
+		}
+		return nil
+	}
+	/* globs */
+	if strings.Contains(src, "*") {
+		if fileFilterInvalidGlobRegexp.MatchString(src) {
+			return fmt.Errorf("invalid file filter [%s], invalid glob pattern", ff.raw)
+		}
+		var rxBuild strings.Builder
+		rxBuild.WriteByte('^')
+		wasStar := false
+		justDirGlob := false
+		for _, c := range src {
+			if c == '*' {
+				if wasStar {
+					rxBuild.WriteString(`[\s\S]*`)
+					wasStar = false
+					justDirGlob = true
+					continue
+				}
+				wasStar = true
+				continue
+			}
+			if wasStar {
+				rxBuild.WriteString("[^/]*")
+				wasStar = false
+			}
+			if strings.ContainsRune(escapeRegexSymbols, c) {
+				rxBuild.WriteByte('\\')
+			}
+			rxBuild.WriteRune(c)
+			if c == '/' && justDirGlob {
+				rxBuild.WriteRune('?')
+			}
+			justDirGlob = false
+		}
+		if wasStar {
+			rxBuild.WriteString("[^/]*")
+		}
+		rxBuild.WriteByte('$')
+		ff.rx, err = regexp.Compile(rxBuild.String())
+		if err != nil {
+			return fmt.Errorf("invalid file filter [%s], regexp compile error after glob expand: [%v]", ff.raw, err)
+		}
+		return nil
+	}
+
+	// it's whole file mask, just escape dots and normilze separators
+	fillRx := src
+	fillRx = strings.ReplaceAll(fillRx, "\\", "/")
+	fillRx = strings.ReplaceAll(fillRx, ".", `\.`)
+	fillRx = "^" + fillRx + "$"
+	ff.rx, err = regexp.Compile(fillRx)
+	if err != nil {
+		return fmt.Errorf("invalid file filter [%s], regexp compile full path: [%v]", ff.raw, err)
+	}
+	return nil
+}

--- a/lint/filefilter_test.go
+++ b/lint/filefilter_test.go
@@ -1,0 +1,100 @@
+package lint_test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+)
+
+func TestFileFilter(t *testing.T) {
+	t.Run("whole file name", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("a/b/c.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ff.MatchFileName("a/b/c.go") {
+			t.Fatal("should match a/b/c.go")
+		}
+		if ff.MatchFileName("a/b/d.go") {
+			t.Fatal("should not match")
+		}
+	})
+
+	t.Run("regex", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("~b/[cd].go$")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ff.MatchFileName("a/b/c.go") {
+			t.Fatal("should match a/b/c.go")
+		}
+		if !ff.MatchFileName("b/d.go") {
+			t.Fatal("should match b/d.go")
+		}
+		if ff.MatchFileName("b/x.go") {
+			t.Fatal("should not match b/x.go")
+		}
+	})
+
+	t.Run("TEST well-known", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("TEST")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ff.MatchFileName("a/b/c_test.go") {
+			t.Fatal("should match a/b/c_test.go")
+		}
+		if ff.MatchFileName("a/b/c_test_no.go") {
+			t.Fatal("should not match a/b/c_test_no.go")
+		}
+	})
+
+	t.Run("glob *", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("a/b/*.pb.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ff.MatchFileName("a/b/xxx.pb.go") {
+			t.Fatal("should match a/b/xxx.pb.go")
+		}
+		if !ff.MatchFileName("a/b/yyy.pb.go") {
+			t.Fatal("should match a/b/yyy.pb.go")
+		}
+		if ff.MatchFileName("a/b/xxx.nopb.go") {
+			t.Fatal("should not match a/b/xxx.nopb.go")
+		}
+	})
+
+	t.Run("glob **", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("a/**/*.pb.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ff.MatchFileName("a/x/xxx.pb.go") {
+			t.Fatal("should match a/x/xxx.pb.go")
+		}
+		if !ff.MatchFileName("a/xxx.pb.go") {
+			t.Fatal("should match a/xxx.pb.go")
+		}
+		if !ff.MatchFileName("a/x/y/z/yyy.pb.go") {
+			t.Fatal("should match a/x/y/z/yyy.pb.go")
+		}
+		if ff.MatchFileName("a/b/xxx.nopb.go") {
+			t.Fatal("should not match a/b/xxx.nopb.go")
+		}
+	})
+
+	t.Run("just to cover Match", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("a/b/c.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ff.Match(&lint.File{Name: "a/b/c.go"}) {
+			t.Fatal("should match")
+		}
+		if ff.Match(&lint.File{Name: "a/b/d.go"}) {
+			t.Fatal("should not match")
+		}
+	})
+
+}

--- a/lint/filefilter_test.go
+++ b/lint/filefilter_test.go
@@ -84,17 +84,45 @@ func TestFileFilter(t *testing.T) {
 		}
 	})
 
-	t.Run("just to cover Match", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("a/b/c.go")
+	t.Run("empty", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !ff.Match(&lint.File{Name: "a/b/c.go"}) {
-			t.Fatal("should match")
+		fileNames := []string{"pb.go", "a/pb.go", "a/x/xxx.pb.go", "a/x/xxx.pb_test.go"}
+		for _, fn := range fileNames {
+			if ff.MatchFileName(fn) {
+				t.Fatalf("should not match %s", fn)
+			}
 		}
-		if ff.Match(&lint.File{Name: "a/b/d.go"}) {
-			t.Fatal("should not match")
-		}
+
 	})
 
+	t.Run("just *", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileNames := []string{"pb.go", "a/pb.go", "a/x/xxx.pb.go", "a/x/xxx.pb_test.go"}
+		for _, fn := range fileNames {
+			if !ff.MatchFileName(fn) {
+				t.Fatalf("should match %s", fn)
+			}
+		}
+
+	})
+
+	t.Run("just ~", func(t *testing.T) {
+		ff, err := lint.ParseFileFilter("~")
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileNames := []string{"pb.go", "a/pb.go", "a/x/xxx.pb.go", "a/x/xxx.pb_test.go"}
+		for _, fn := range fileNames {
+			if !ff.MatchFileName(fn) {
+				t.Fatalf("should match %s", fn)
+			}
+		}
+
+	})
 }

--- a/test/file-filter_test.go
+++ b/test/file-filter_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+)
+
+type TestFileFilterRule struct {
+	WasApplyed bool
+}
+
+var _ lint.Rule = (*TestFileFilterRule)(nil)
+
+func (*TestFileFilterRule) Name() string { return "test-file-filter" }
+func (tfr *TestFileFilterRule) Apply(*lint.File, lint.Arguments) []lint.Failure {
+	tfr.WasApplyed = true
+	return nil
+}
+
+func TestFileExcludeFilterAtRuleLevel(t *testing.T) {
+	t.Run("is called if no excludes", func(t *testing.T) {
+		rule := &TestFileFilterRule{}
+		testRule(t, "file-to-exclude", rule, &lint.RuleConfig{})
+		if !rule.WasApplyed {
+			t.Fatal("should call rule if no excludes")
+		}
+	})
+	t.Run("is called if exclude not match", func(t *testing.T) {
+		rule := &TestFileFilterRule{}
+		cfg := &lint.RuleConfig{Exclude: []string{"no-matched.go"}}
+		cfg.Initialize()
+		testRule(t, "file-to-exclude", rule, cfg)
+		if !rule.WasApplyed {
+			t.Fatal("should call rule if no excludes")
+		}
+	})
+
+	t.Run("not called if exclude not match", func(t *testing.T) {
+		rule := &TestFileFilterRule{}
+		cfg := &lint.RuleConfig{Exclude: []string{"file-to-exclude.go"}}
+		cfg.Initialize()
+		testRule(t, "file-to-exclude", rule, cfg)
+		if rule.WasApplyed {
+			t.Fatal("should not call rule if excluded")
+		}
+	})
+}

--- a/testdata/file-to-exclude.go
+++ b/testdata/file-to-exclude.go
@@ -1,0 +1,2 @@
+// just to check FileFilter
+package fixtures


### PR DESCRIPTION
Rule-level file exclude filter feature implementation #850

Tryed to keep project at max compatibility level.

But where are some changes in core structures.

Filters are prechecked and initialized after reading from TOML, so it could cause error.
So `Initialize() error` method added to RuleConfig

Logically it should be applyed in `normalize...`  part of GetConfig, but just parse can return error, not normalize, so
added call of initialization to `parse` part of GetConfig

All tested.

Closes #850
