### PR TITLE
extended [allowRegex] parameter for `unused-parameter` and `unused-receiver` rules

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -735,13 +735,36 @@ _Configuration_: N/A
 
 _Description_: This rule warns on unused parameters. Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
 
-_Configuration_: N/A
+_Configuration_: Supports arguments with single of `map[string]any` with option `allowRegex` to provide additional to `_` mask to allowed unused parameter names, for example:
+
+```toml
+[rule.unused-parameter]
+    Arguments = [ { allowRegex = "^_" } ]
+```
+
+allows any names started with `_`, not just `_` itself:
+
+```go
+func SomeFunc(_someObj *MyStruct) {} // matches rule
+```
 
 ## unused-receiver
 
 _Description_: This rule warns on unused method receivers. Methods with unused receivers can be a symptom of an unfinished refactoring or a bug.
 
-_Configuration_: N/A
+_Configuration_: Supports arguments with single of `map[string]any` with option `allowRegex` to provide additional to `_` mask to allowed unused receiver names, for example:
+
+```toml
+[rule.unused-receiver]
+    Arguments = [ { allowRegex = "^_" } ]
+```
+
+allows any names started with `_`, not just `_` itself:
+
+```go
+func (_my *MyStruct) SomeMethod() {} // matches rule
+```
+
 
 ## use-any
 

--- a/rule/unused-param.go
+++ b/rule/unused-param.go
@@ -14,39 +14,45 @@ type UnusedParamRule struct {
 	configured bool
 	// regex to check if some name is valid for unused parameter, "^_$" by default
 	allowRegex *regexp.Regexp
+	failureMsg string
 	sync.Mutex
 }
 
 func (r *UnusedParamRule) configure(args lint.Arguments) {
-	// optimistic pre-check
-	if r.configured {
-		return
-	}
 	r.Lock()
 	defer r.Unlock()
+
 	if r.configured {
 		return
 	}
 	r.configured = true
+
 	// while by default args is an array, i think it's good to provide structures inside it by default, not arrays or primitives
 	// it's more compatible to JSON nature of configurations
+	var allowedRegexStr string
 	if len(args) == 0 {
-		return
-	}
-	// Arguments = [{}]
-	options := args[0].(map[string]interface{})
-	// Arguments = [{allowedRegex="^_"}]
+		allowedRegexStr = "^_$"
+		r.failureMsg = "parameter '%s' seems to be unused, consider removing or renaming it as _"
+	} else {
+		// Arguments = [{}]
+		options := args[0].(map[string]interface{})
+		// Arguments = [{allowedRegex="^_"}]
 
-	if allowedRegexParam, ok := options["allowRegex"]; ok {
-		allowedRegexStr, ok := allowedRegexParam.(string)
-		if !ok {
-			panic(fmt.Errorf("error configuring [unused-parameter] rule: allowedRegex is not string but [%T]", allowedRegexParam))
+		if allowedRegexParam, ok := options["allowRegex"]; ok {
+			allowedRegexStr, ok = allowedRegexParam.(string)
+			if !ok {
+				panic(fmt.Errorf("error configuring %s rule: allowedRegex is not string but [%T]", r.Name(), allowedRegexParam))
+			}
 		}
-		var err error
-		r.allowRegex, err = regexp.Compile(allowedRegexStr)
-		if err != nil {
-			panic(fmt.Errorf("error configuring [unused-parameter] rule: allowedRegex is not valid regex [%s]: %v", allowedRegexStr, err))
-		}
+	}
+	var err error
+	r.allowRegex, err = regexp.Compile(allowedRegexStr)
+	if err != nil {
+		panic(fmt.Errorf("error configuring %s rule: allowedRegex is not valid regex [%s]: %v", r.Name(), allowedRegexStr, err))
+	}
+
+	if r.failureMsg == "" {
+		r.failureMsg = "parameter '%s' seems to be unused, consider removing or renaming it to match " + r.allowRegex.String()
 	}
 }
 
@@ -58,7 +64,11 @@ func (r *UnusedParamRule) Apply(file *lint.File, args lint.Arguments) []lint.Fai
 	onFailure := func(failure lint.Failure) {
 		failures = append(failures, failure)
 	}
-	w := lintUnusedParamRule{onFailure: onFailure, allowRegex: r.allowRegex}
+	w := lintUnusedParamRule{
+		onFailure:  onFailure,
+		allowRegex: r.allowRegex,
+		failureMsg: r.failureMsg,
+	}
 
 	ast.Walk(w, file.AST)
 
@@ -73,6 +83,7 @@ func (*UnusedParamRule) Name() string {
 type lintUnusedParamRule struct {
 	onFailure  func(lint.Failure)
 	allowRegex *regexp.Regexp
+	failureMsg string
 }
 
 func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
@@ -106,8 +117,7 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 
 		for _, p := range n.Type.Params.List {
 			for _, n := range p.Names {
-				// проверка на соответствие паттерну допустимых не используемых параметров
-				if w.allowRegex != nil && w.allowRegex.FindStringIndex(n.Name) != nil {
+				if w.allowRegex.FindStringIndex(n.Name) != nil {
 					continue
 				}
 				if params[n.Obj] {
@@ -115,7 +125,7 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 						Confidence: 1,
 						Node:       n,
 						Category:   "bad practice",
-						Failure:    fmt.Sprintf("parameter '%s' seems to be unused, consider removing or renaming it as _", n.Name),
+						Failure:    fmt.Sprintf(w.failureMsg, n.Name),
 					})
 				}
 			}

--- a/rule/unused-param.go
+++ b/rule/unused-param.go
@@ -3,22 +3,62 @@ package rule
 import (
 	"fmt"
 	"go/ast"
+	"regexp"
+	"sync"
 
 	"github.com/mgechev/revive/lint"
 )
 
 // UnusedParamRule lints unused params in functions.
-type UnusedParamRule struct{}
+type UnusedParamRule struct {
+	configured bool
+	// regex to check if some name is valid for unused parameter, "^_$" by default
+	allowRegex *regexp.Regexp
+	sync.Mutex
+}
+
+func (r *UnusedParamRule) configure(args lint.Arguments) {
+	// optimistic pre-check
+	if r.configured {
+		return
+	}
+	r.Lock()
+	defer r.Unlock()
+	if r.configured {
+		return
+	}
+	r.configured = true
+	// while by default args is an array, i think it's good to provide structures inside it by default, not arrays or primitives
+	// it's more compatible to JSON nature of configurations
+	if len(args) == 0 {
+		return
+	}
+	// Arguments = [{}]
+	options := args[0].(map[string]interface{})
+	// Arguments = [{allowedRegex="^_"}]
+
+	if allowedRegexParam, ok := options["allowRegex"]; ok {
+		allowedRegexStr, ok := allowedRegexParam.(string)
+		if !ok {
+			panic(fmt.Errorf("error configuring [unused-parameter] rule: allowedRegex is not string but [%T]", allowedRegexParam))
+		}
+		var err error
+		r.allowRegex, err = regexp.Compile(allowedRegexStr)
+		if err != nil {
+			panic(fmt.Errorf("error configuring [unused-parameter] rule: allowedRegex is not valid regex [%s]: %v", allowedRegexStr, err))
+		}
+	}
+}
 
 // Apply applies the rule to given file.
-func (*UnusedParamRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+func (r *UnusedParamRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
+	r.configure(args)
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {
 		failures = append(failures, failure)
 	}
-
-	w := lintUnusedParamRule{onFailure: onFailure}
+	w := lintUnusedParamRule{onFailure: onFailure, allowRegex: r.allowRegex}
 
 	ast.Walk(w, file.AST)
 
@@ -31,7 +71,8 @@ func (*UnusedParamRule) Name() string {
 }
 
 type lintUnusedParamRule struct {
-	onFailure func(lint.Failure)
+	onFailure  func(lint.Failure)
+	allowRegex *regexp.Regexp
 }
 
 func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
@@ -65,6 +106,10 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 
 		for _, p := range n.Type.Params.List {
 			for _, n := range p.Names {
+				// проверка на соответствие паттерну допустимых не используемых параметров
+				if w.allowRegex != nil && w.allowRegex.FindStringIndex(n.Name) != nil {
+					continue
+				}
 				if params[n.Obj] {
 					w.onFailure(lint.Failure{
 						Confidence: 1,

--- a/test/unused-param_test.go
+++ b/test/unused-param_test.go
@@ -3,11 +3,15 @@ package test
 import (
 	"testing"
 
+	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/rule"
 )
 
 func TestUnusedParam(t *testing.T) {
 	testRule(t, "unused-param", &rule.UnusedParamRule{})
+	testRule(t, "unused-param-custom-regex", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: []interface{}{
+		map[string]interface{}{"allowRegex": "^xxx"},
+	}})
 }
 
 func BenchmarkUnusedParam(b *testing.B) {

--- a/test/unused-receiver_test.go
+++ b/test/unused-receiver_test.go
@@ -3,9 +3,13 @@ package test
 import (
 	"testing"
 
+	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/rule"
 )
 
 func TestUnusedReceiver(t *testing.T) {
 	testRule(t, "unused-receiver", &rule.UnusedReceiverRule{})
+	testRule(t, "unused-receiver-custom-regex", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: []interface{}{
+		map[string]interface{}{"allowRegex": "^xxx"},
+	}})
 }

--- a/testdata/unused-param-custom-regex.go
+++ b/testdata/unused-param-custom-regex.go
@@ -1,0 +1,12 @@
+package fixtures
+
+// all will ok with xxxParam if Arguments = [{allowRegex="^xxx"}]
+
+func f0(xxxParam int) {}
+
+// still works with _
+
+func f1(_ int) {}
+
+func f2(yyyParam int) { // MATCH /parameter 'yyyParam' seems to be unused, consider removing or renaming it as _/
+}

--- a/testdata/unused-param-custom-regex.go
+++ b/testdata/unused-param-custom-regex.go
@@ -8,5 +8,5 @@ func f0(xxxParam int) {}
 
 func f1(_ int) {}
 
-func f2(yyyParam int) { // MATCH /parameter 'yyyParam' seems to be unused, consider removing or renaming it as _/
+func f2(yyyParam int) { // MATCH /parameter 'yyyParam' seems to be unused, consider removing or renaming it to match ^xxx/
 }

--- a/testdata/unused-receiver-custom-regex.go
+++ b/testdata/unused-receiver-custom-regex.go
@@ -1,0 +1,12 @@
+package fixtures
+
+// all will ok with xxxParam if Arguments = [{allowRegex="^xxx"}]
+
+func (xxxParam *SomeObj) f0() {}
+
+// still works with _
+
+func (_ *SomeObj) f1() {}
+
+func (yyyParam *SomeObj) f2() { // MATCH /method receiver 'yyyParam' is not referenced in method's body, consider removing or renaming it as _/
+}

--- a/testdata/unused-receiver-custom-regex.go
+++ b/testdata/unused-receiver-custom-regex.go
@@ -8,5 +8,5 @@ func (xxxParam *SomeObj) f0() {}
 
 func (_ *SomeObj) f1() {}
 
-func (yyyParam *SomeObj) f2() { // MATCH /method receiver 'yyyParam' is not referenced in method's body, consider removing or renaming it as _/
+func (yyyParam *SomeObj) f2() { // MATCH /method receiver 'yyyParam' is not referenced in method's body, consider removing or renaming it to match ^xxx/
 }


### PR DESCRIPTION
# Impl for #613 feature-request

Now can provide custom regexes for `unused-parameter` and `unused-receiver` to allow names matching some regex, no just `_` itself (does'nt break default behavior)

```toml
[rule.unused-parameter]
     Arguments = [ { allowRegex = "^_" } ]

[rule.unused-receiver]
     Arguments = [ { allowRegex = "^_" } ]
```