### PR TITLE
(var-naming) support private uppercase constants #865

### DIFF
--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -27,34 +27,36 @@ type VarNamingRule struct {
 
 func (r *VarNamingRule) configure(arguments lint.Arguments) {
 	r.Lock()
-	if !r.configured {
-		if len(arguments) >= 1 {
-			r.whitelist = getList(arguments[0], "whitelist")
-		}
-
-		if len(arguments) >= 2 {
-			r.blacklist = getList(arguments[1], "blacklist")
-		}
-
-		if len(arguments) >= 3 {
-			// not pretty code because should keep compatibility with TOML (no mixed array types) and new map parameters
-			thirdArgument := arguments[2]
-			asSlice, ok := thirdArgument.([]interface{})
-			if !ok {
-				panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, got %T", "options", arguments[2]))
-			}
-			if len(asSlice) != 1 {
-				panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, of len==1, but %d", "options", len(asSlice)))
-			}
-			args, ok := asSlice[0].(map[string]interface{})
-			if !ok {
-				panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, of len==1, with map, but %T", "options", asSlice[0]))
-			}
-			r.upperCaseConst = fmt.Sprint(args["upperCaseConst"]) == "true"
-		}
-		r.configured = true
+	defer r.Unlock()
+	if r.configured {
+		return
 	}
-	r.Unlock()
+
+	r.configured = true
+	if len(arguments) >= 1 {
+		r.whitelist = getList(arguments[0], "whitelist")
+	}
+
+	if len(arguments) >= 2 {
+		r.blacklist = getList(arguments[1], "blacklist")
+	}
+
+	if len(arguments) >= 3 {
+		// not pretty code because should keep compatibility with TOML (no mixed array types) and new map parameters
+		thirdArgument := arguments[2]
+		asSlice, ok := thirdArgument.([]interface{})
+		if !ok {
+			panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, got %T", "options", arguments[2]))
+		}
+		if len(asSlice) != 1 {
+			panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, of len==1, but %d", "options", len(asSlice)))
+		}
+		args, ok := asSlice[0].(map[string]interface{})
+		if !ok {
+			panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, of len==1, with map, but %T", "options", asSlice[0]))
+		}
+		r.upperCaseConst = fmt.Sprint(args["upperCaseConst"]) == "true"
+	}
 }
 
 // Apply applies the rule to given file.

--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -13,8 +13,8 @@ import (
 
 var anyCapsRE = regexp.MustCompile(`[A-Z]`)
 
-// regexp for constant names like `SOME_CONST`, `SOME_CONST_2`, `X123_3` (#851)
-var upperCaseConstRE = regexp.MustCompile(`^[A-Z][A-Z\d]*(_[A-Z\d]+)*$`)
+// regexp for constant names like `SOME_CONST`, `SOME_CONST_2`, `X123_3`, `_SOME_PRIVATE_CONST` (#851, #865)
+var upperCaseConstRE = regexp.MustCompile(`^_?[A-Z][A-Z\d]*(_[A-Z\d]+)*$`)
 
 // VarNamingRule lints given else constructs.
 type VarNamingRule struct {

--- a/testdata/var-naming_upperCaseConst-false.go
+++ b/testdata/var-naming_upperCaseConst-false.go
@@ -1,9 +1,11 @@
-// should fail if upperCaseConst = false (by default) #851
+// should fail if upperCaseConst = false (by default) #851, #865
 
 package fixtures
 
-const SOME_CONST_2 = 1 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
+const SOME_CONST_2 = 1          // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
+const _SOME_PRIVATE_CONST_2 = 2 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
 
 const (
-	SOME_CONST_3 = 3 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
+	SOME_CONST_3          = 3 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
+	_SOME_PRIVATE_CONST_3 = 3 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
 )

--- a/testdata/var-naming_upperCaseConst-true.go
+++ b/testdata/var-naming_upperCaseConst-true.go
@@ -3,8 +3,10 @@
 package fixtures
 
 const SOME_CONST_2 = 2
+const _SOME_PRIVATE_CONST_2 = 2
 
 const (
-	SOME_CONST_3 = 3
-	VER          = 0
+	SOME_CONST_3          = 3
+	_SOME_PRIVATE_CONST_3 = 3
+	VER                   = 0
 )


### PR DESCRIPTION
`var-naming` rule with `upperCaseConst=true` now allows to use private uppercase constants

Closes #865