### PR TITLE
fix #864: confusing-naming FP on methods of generic types

### DIFF
--- a/testdata/confusing-naming1.go
+++ b/testdata/confusing-naming1.go
@@ -1,5 +1,4 @@
 // Test of confusing-naming rule.
-
 // Package pkg ...
 package pkg
 
@@ -59,4 +58,15 @@ type tBar struct {
 	asd string
 	qwe bool
 	zxc float32
+}
+
+// issue #864
+type x[T any] struct{}
+
+func (x[T]) method() {
+}
+
+type y[T any] struct{}
+
+func (y[T]) method() {
 }


### PR DESCRIPTION
Closes #864
