### PR TITLE
resolve #867: remove k[A-Z][A-Za-z\d]*$ sub-rule from `var-naming`

### DIFF
--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -141,15 +141,6 @@ func (w *lintNames) check(id *ast.Ident, thing string) {
 		})
 		return
 	}
-	if len(id.Name) > 2 && id.Name[0] == 'k' && id.Name[1] >= 'A' && id.Name[1] <= 'Z' {
-		should := string(id.Name[1]+'a'-'A') + id.Name[2:]
-		w.onFailure(lint.Failure{
-			Failure:    fmt.Sprintf("don't use leading k in Go names; %s %s should be %s", thing, id.Name, should),
-			Confidence: 0.8,
-			Node:       id,
-			Category:   "naming",
-		})
-	}
 
 	should := lint.Name(id.Name, w.whitelist, w.blacklist)
 	if id.Name == should {

--- a/testdata/golint/var-naming.go
+++ b/testdata/golint/var-naming.go
@@ -57,8 +57,7 @@ func f_it() { // MATCH /don't use underscores in Go names; func f_it should be f
 
 // Common styles in other languages that don't belong in Go.
 const (
-	CPP_CONST   = 1 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
-	kLeadingKay = 2 // MATCH /don't use leading k in Go names; const kLeadingKay should be leadingKay/
+	CPP_CONST = 1 // MATCH /don't use ALL_CAPS in Go names; use CamelCase/
 
 	HTML  = 3 // okay; no underscore
 	X509B = 4 // ditto


### PR DESCRIPTION
This PR proposes the removal of `k[A-Z][A-Za-z\d]*$` sub-rule from `var-naming`, as it doesn't clearly justify the reason for the check and fails to properly tackle any potential issues with [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation).

The emphasis is on ensuring clarity, reducing confusion, and enhancing the overall user experience for revive users.

The sub-rule originates from [golang/lint](https://github.com/golang/lint/blob/master/lint.go#L587) and has in the past led to false positives and confusion, see https://github.com/golang/lint/issues/258.

Closes #867 