### PR TITLE
code cleanup: replace interface{} with any

### DIFF
--- a/rule/add-constant.go
+++ b/rule/add-constant.go
@@ -179,7 +179,7 @@ func (r *AddConstantRule) configure(arguments lint.Arguments) {
 		r.strLitLimit = defaultStrLitLimit
 		r.whiteList = newWhiteList()
 		if len(arguments) > 0 {
-			args, ok := arguments[0].(map[string]interface{})
+			args, ok := arguments[0].(map[string]any)
 			if !ok {
 				panic(fmt.Sprintf("Invalid argument to the add-constant rule. Expecting a k,v map, got %T", arguments[0]))
 			}

--- a/rule/context-as-argument.go
+++ b/rule/context-as-argument.go
@@ -82,7 +82,7 @@ func (w lintContextArguments) Visit(n ast.Node) ast.Visitor {
 func getAllowTypesFromArguments(args lint.Arguments) map[string]struct{} {
 	allowTypesBefore := []string{}
 	if len(args) >= 1 {
-		argKV, ok := args[0].(map[string]interface{})
+		argKV, ok := args[0].(map[string]any)
 		if !ok {
 			panic(fmt.Sprintf("Invalid argument to the context-as-argument rule. Expecting a k,v map, got %T", args[0]))
 		}

--- a/rule/defer.go
+++ b/rule/defer.go
@@ -56,7 +56,7 @@ func (*DeferRule) allowFromArgs(args lint.Arguments) map[string]bool {
 		return allow
 	}
 
-	aa, ok := args[0].([]interface{})
+	aa, ok := args[0].([]any)
 	if !ok {
 		panic(fmt.Sprintf("Invalid argument '%v' for 'defer' rule. Expecting []string, got %T", args[0], args[0]))
 	}

--- a/rule/enforce-map-style.go
+++ b/rule/enforce-map-style.go
@@ -47,7 +47,7 @@ type EnforceMapStyleRule struct {
 func (r *EnforceMapStyleRule) configure(arguments lint.Arguments) {
 	r.Lock()
 	defer r.Unlock()
-	
+
 	if r.configured {
 		return
 	}
@@ -58,7 +58,7 @@ func (r *EnforceMapStyleRule) configure(arguments lint.Arguments) {
 		return
 	}
 
-	enforceMapStyle, ok := arguments[0].(string) 
+	enforceMapStyle, ok := arguments[0].(string)
 	if !ok {
 		panic(fmt.Sprintf("Invalid argument '%v' for 'enforce-map-style' rule. Expecting string, got %T", arguments[0], arguments[0]))
 	}

--- a/rule/function-length.go
+++ b/rule/function-length.go
@@ -171,7 +171,7 @@ func (w lintFuncLength) countFuncLitStmts(stmt ast.Expr) int {
 	return 0
 }
 
-func (w lintFuncLength) countBodyListStmts(t interface{}) int {
+func (w lintFuncLength) countBodyListStmts(t any) int {
 	i := reflect.ValueOf(t).Elem().FieldByName(`Body`).Elem().FieldByName(`List`).Interface()
 	return w.countStmts(i.([]ast.Stmt))
 }

--- a/rule/string-format.go
+++ b/rule/string-format.go
@@ -38,7 +38,7 @@ func (*StringFormatRule) Name() string {
 // ParseArgumentsTest is a public wrapper around w.parseArguments used for testing. Returns the error message provided to panic, or nil if no error was encountered
 func (StringFormatRule) ParseArgumentsTest(arguments lint.Arguments) *string {
 	w := lintStringFormatRule{}
-	c := make(chan interface{})
+	c := make(chan any)
 	// Parse the arguments in a goroutine, defer a recover() call, return the error encountered (or nil if there was no error)
 	go func() {
 		defer func() {
@@ -101,8 +101,8 @@ func (w *lintStringFormatRule) parseArguments(arguments lint.Arguments) {
 	}
 }
 
-func (w lintStringFormatRule) parseArgument(argument interface{}, ruleNum int) (scope stringFormatSubruleScope, regex *regexp.Regexp, negated bool, errorMessage string) {
-	g, ok := argument.([]interface{}) // Cast to generic slice first
+func (w lintStringFormatRule) parseArgument(argument any, ruleNum int) (scope stringFormatSubruleScope, regex *regexp.Regexp, negated bool, errorMessage string) {
+	g, ok := argument.([]any) // Cast to generic slice first
 	if !ok {
 		w.configError("argument is not a slice", ruleNum, 0)
 	}

--- a/rule/unused-param.go
+++ b/rule/unused-param.go
@@ -35,7 +35,7 @@ func (r *UnusedParamRule) configure(args lint.Arguments) {
 		r.failureMsg = "parameter '%s' seems to be unused, consider removing or renaming it as _"
 	} else {
 		// Arguments = [{}]
-		options := args[0].(map[string]interface{})
+		options := args[0].(map[string]any)
 		// Arguments = [{allowedRegex="^_"}]
 
 		if allowedRegexParam, ok := options["allowRegex"]; ok {

--- a/rule/unused-receiver.go
+++ b/rule/unused-receiver.go
@@ -35,7 +35,7 @@ func (r *UnusedReceiverRule) configure(args lint.Arguments) {
 		r.failureMsg = "method receiver '%s' is not referenced in method's body, consider removing or renaming it as _"
 	} else {
 		// Arguments = [{}]
-		options := args[0].(map[string]interface{})
+		options := args[0].(map[string]any)
 		// Arguments = [{allowedRegex="^_"}]
 
 		if allowedRegexParam, ok := options["allowRegex"]; ok {

--- a/rule/utils.go
+++ b/rule/utils.go
@@ -158,7 +158,7 @@ func isExprABooleanLit(n ast.Node) (lexeme string, ok bool) {
 }
 
 // gofmt returns a string representation of an AST subtree.
-func gofmt(x interface{}) string {
+func gofmt(x any) string {
 	buf := bytes.Buffer{}
 	fs := token.NewFileSet()
 	printer.Fprint(&buf, fs, x)

--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -44,14 +44,14 @@ func (r *VarNamingRule) configure(arguments lint.Arguments) {
 	if len(arguments) >= 3 {
 		// not pretty code because should keep compatibility with TOML (no mixed array types) and new map parameters
 		thirdArgument := arguments[2]
-		asSlice, ok := thirdArgument.([]interface{})
+		asSlice, ok := thirdArgument.([]any)
 		if !ok {
 			panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, got %T", "options", arguments[2]))
 		}
 		if len(asSlice) != 1 {
 			panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, of len==1, but %d", "options", len(asSlice)))
 		}
-		args, ok := asSlice[0].(map[string]interface{})
+		args, ok := asSlice[0].(map[string]any)
 		if !ok {
 			panic(fmt.Sprintf("Invalid third argument to the var-naming rule. Expecting a %s of type slice, of len==1, with map, but %T", "options", asSlice[0]))
 		}
@@ -255,8 +255,8 @@ func (w *lintNames) Visit(n ast.Node) ast.Visitor {
 	return w
 }
 
-func getList(arg interface{}, argName string) []string {
-	temp, ok := arg.([]interface{})
+func getList(arg any, argName string) []string {
+	temp, ok := arg.([]any)
 	if !ok {
 		panic(fmt.Sprintf("Invalid argument to the var-naming rule. Expecting a %s of type slice with initialisms, got %T", argName, arg))
 	}

--- a/test/add-constant_test.go
+++ b/test/add-constant_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAddConstant(t *testing.T) {
-	args := []interface{}{map[string]interface{}{
+	args := []any{map[string]any{
 		"maxLitCount": "2",
 		"allowStrs":   "\"\"",
 		"allowInts":   "0,1,2",

--- a/test/argument-limit_test.go
+++ b/test/argument-limit_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestArgumentLimit(t *testing.T) {
 	testRule(t, "argument-limit", &rule.ArgumentsLimitRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(3)},
+		Arguments: []any{int64(3)},
 	})
 }

--- a/test/banned-characters_test.go
+++ b/test/banned-characters_test.go
@@ -12,6 +12,6 @@ import (
 // One banned character from the list is not present in the fixture file.
 func TestBannedCharacters(t *testing.T) {
 	testRule(t, "banned-characters", &rule.BannedCharsRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"Ω", "Σ", "σ", "1"},
+		Arguments: []any{"Ω", "Σ", "σ", "1"},
 	})
 }

--- a/test/cognitive-complexity_test.go
+++ b/test/cognitive-complexity_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestCognitiveComplexity(t *testing.T) {
 	testRule(t, "cognitive-complexity", &rule.CognitiveComplexityRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(0)},
+		Arguments: []any{int64(0)},
 	})
 }

--- a/test/comment-spacings_test.go
+++ b/test/comment-spacings_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestCommentSpacings(t *testing.T) {
 	testRule(t, "comment-spacings", &rule.CommentSpacingsRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"myOwnDirective"}},
+		Arguments: []any{"myOwnDirective"}},
 	)
 }

--- a/test/context-as-argument_test.go
+++ b/test/context-as-argument_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestContextAsArgument(t *testing.T) {
 	testRule(t, "context-as-argument", &rule.ContextAsArgumentRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{
-			map[string]interface{}{
+		Arguments: []any{
+			map[string]any{
 				"allowTypesBefore": "AllowedBeforeType,AllowedBeforeStruct,*AllowedBeforePtrStruct,*testing.T",
 			},
 		},

--- a/test/cyclomatic_test.go
+++ b/test/cyclomatic_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestCyclomatic(t *testing.T) {
 	testRule(t, "cyclomatic", &rule.CyclomaticRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(1)},
+		Arguments: []any{int64(1)},
 	})
 	testRule(t, "cyclomatic-2", &rule.CyclomaticRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(3)},
+		Arguments: []any{int64(3)},
 	})
 }

--- a/test/defer_test.go
+++ b/test/defer_test.go
@@ -14,12 +14,12 @@ func TestDefer(t *testing.T) {
 
 func TestDeferLoopDisabled(t *testing.T) {
 	testRule(t, "defer-loop-disabled", &rule.DeferRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{[]interface{}{"return", "recover", "call-chain", "method-call"}},
+		Arguments: []any{[]any{"return", "recover", "call-chain", "method-call"}},
 	})
 }
 
 func TestDeferOthersDisabled(t *testing.T) {
 	testRule(t, "defer-only-loop-enabled", &rule.DeferRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{[]interface{}{"loop"}},
+		Arguments: []any{[]any{"loop"}},
 	})
 }

--- a/test/early-return_test.go
+++ b/test/early-return_test.go
@@ -11,5 +11,5 @@ import (
 // TestEarlyReturn tests early-return rule.
 func TestEarlyReturn(t *testing.T) {
 	testRule(t, "early-return", &rule.EarlyReturnRule{})
-	testRule(t, "early-return-scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []interface{}{ifelse.PreserveScope}})
+	testRule(t, "early-return-scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{ifelse.PreserveScope}})
 }

--- a/test/enforce-map-style_test.go
+++ b/test/enforce-map-style_test.go
@@ -13,12 +13,12 @@ func TestEnforceMapStyle_any(t *testing.T) {
 
 func TestEnforceMapStyle_make(t *testing.T) {
 	testRule(t, "enforce-map-style-make", &rule.EnforceMapStyleRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"make"},
+		Arguments: []any{"make"},
 	})
 }
 
 func TestEnforceMapStyle_literal(t *testing.T) {
 	testRule(t, "enforce-map-style-literal", &rule.EnforceMapStyleRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"literal"},
+		Arguments: []any{"literal"},
 	})
 }

--- a/test/enforce-slice-style_test.go
+++ b/test/enforce-slice-style_test.go
@@ -13,12 +13,12 @@ func TestEnforceSliceStyle_any(t *testing.T) {
 
 func TestEnforceSliceStyle_make(t *testing.T) {
 	testRule(t, "enforce-slice-style-make", &rule.EnforceSliceStyleRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"make"},
+		Arguments: []any{"make"},
 	})
 }
 
 func TestEnforceSliceStyle_literal(t *testing.T) {
 	testRule(t, "enforce-slice-style-literal", &rule.EnforceSliceStyleRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"literal"},
+		Arguments: []any{"literal"},
 	})
 }

--- a/test/error-strings-custom-functions_test.go
+++ b/test/error-strings-custom-functions_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestErrorStringsWithCustomFunctions(t *testing.T) {
-	args := []interface{}{"pkgErrors.Wrap"}
+	args := []any{"pkgErrors.Wrap"}
 	testRule(t, "error-strings-with-custom-functions", &rule.ErrorStringsRule{}, &lint.RuleConfig{
 		Arguments: args,
 	})

--- a/test/exported_test.go
+++ b/test/exported_test.go
@@ -8,19 +8,19 @@ import (
 )
 
 func TestExportedWithDisableStutteringCheck(t *testing.T) {
-	args := []interface{}{"disableStutteringCheck"}
+	args := []any{"disableStutteringCheck"}
 
 	testRule(t, "exported-issue-555", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: args})
 }
 
 func TestExportedWithChecksOnMethodsOfPrivateTypes(t *testing.T) {
-	args := []interface{}{"checkPrivateReceivers"}
+	args := []any{"checkPrivateReceivers"}
 
 	testRule(t, "exported-issue-552", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: args})
 }
 
 func TestExportedReplacingStuttersByRepetitive(t *testing.T) {
-	args := []interface{}{"sayRepetitiveInsteadOfStutters"}
+	args := []any{"sayRepetitiveInsteadOfStutters"}
 
 	testRule(t, "exported-issue-519", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: args})
 }

--- a/test/file-header_test.go
+++ b/test/file-header_test.go
@@ -9,27 +9,27 @@ import (
 
 func TestLintFileHeader(t *testing.T) {
 	testRule(t, "lint-file-header1", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"foobar"},
+		Arguments: []any{"foobar"},
 	})
 
 	testRule(t, "lint-file-header2", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"foobar"},
+		Arguments: []any{"foobar"},
 	})
 
 	testRule(t, "lint-file-header3", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"foobar"},
+		Arguments: []any{"foobar"},
 	})
 
 	testRule(t, "lint-file-header4", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"^\\sfoobar$"},
+		Arguments: []any{"^\\sfoobar$"},
 	})
 
 	testRule(t, "lint-file-header5", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"^\\sfoo.*bar$"},
+		Arguments: []any{"^\\sfoo.*bar$"},
 	})
 
 	testRule(t, "lint-file-header6", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"foobar"},
+		Arguments: []any{"foobar"},
 	})
 }
 
@@ -37,7 +37,7 @@ func BenchmarkLintFileHeader(b *testing.B) {
 	var t *testing.T
 	for i := 0; i <= b.N; i++ {
 		testRule(t, "lint-file-header1", &rule.FileHeaderRule{}, &lint.RuleConfig{
-			Arguments: []interface{}{"foobar"},
+			Arguments: []any{"foobar"},
 		})
 	}
 }

--- a/test/function-length_test.go
+++ b/test/function-length_test.go
@@ -9,18 +9,18 @@ import (
 
 func TestFuncLengthLimitsStatements(t *testing.T) {
 	testRule(t, "function-length1", &rule.FunctionLength{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(2), int64(100)},
+		Arguments: []any{int64(2), int64(100)},
 	})
 }
 
 func TestFuncLengthLimitsLines(t *testing.T) {
 	testRule(t, "function-length2", &rule.FunctionLength{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(100), int64(5)},
+		Arguments: []any{int64(100), int64(5)},
 	})
 }
 
 func TestFuncLengthLimitsDeactivated(t *testing.T) {
 	testRule(t, "function-length3", &rule.FunctionLength{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(0), int64(0)},
+		Arguments: []any{int64(0), int64(0)},
 	})
 }

--- a/test/function-result-limit_test.go
+++ b/test/function-result-limit_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestFunctionResultsLimit(t *testing.T) {
 	testRule(t, "function-result-limit", &rule.FunctionResultsLimitRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(3)},
+		Arguments: []any{int64(3)},
 	})
 }

--- a/test/import-blacklist_test.go
+++ b/test/import-blacklist_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestImportsBlacklistOriginal(t *testing.T) {
-	args := []interface{}{"crypto/md5", "crypto/sha1"}
+	args := []any{"crypto/md5", "crypto/sha1"}
 
 	testRule(t, "imports-blacklist-original", &rule.ImportsBlacklistRule{}, &lint.RuleConfig{
 		Arguments: args,
@@ -16,7 +16,7 @@ func TestImportsBlacklistOriginal(t *testing.T) {
 }
 
 func TestImportsBlacklist(t *testing.T) {
-	args := []interface{}{"github.com/full/match", "wildcard/**/between", "wildcard/backward/**", "**/wildcard/forward", "full"}
+	args := []any{"github.com/full/match", "wildcard/**/between", "wildcard/backward/**", "**/wildcard/forward", "full"}
 
 	testRule(t, "imports-blacklist", &rule.ImportsBlacklistRule{}, &lint.RuleConfig{
 		Arguments: args,
@@ -24,7 +24,7 @@ func TestImportsBlacklist(t *testing.T) {
 }
 
 func BenchmarkImportsBlacklist(b *testing.B) {
-	args := []interface{}{"github.com/full/match", "wildcard/**/between", "wildcard/backward/**", "**/wildcard/forward", "full"}
+	args := []any{"github.com/full/match", "wildcard/**/between", "wildcard/backward/**", "**/wildcard/forward", "full"}
 	var t *testing.T
 	for i := 0; i <= b.N; i++ {
 		testRule(t, "imports-blacklist", &rule.ImportsBlacklistRule{}, &lint.RuleConfig{

--- a/test/line-length-limit_test.go
+++ b/test/line-length-limit_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestLineLengthLimit(t *testing.T) {
 	testRule(t, "line-length-limit", &rule.LineLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(100)},
+		Arguments: []any{int64(100)},
 	})
 }

--- a/test/max-public-structs_test.go
+++ b/test/max-public-structs_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestMaxPublicStructs(t *testing.T) {
 	testRule(t, "max-public-structs", &rule.MaxPublicStructsRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{int64(1)},
+		Arguments: []any{int64(1)},
 	})
 }

--- a/test/string-format_test.go
+++ b/test/string-format_test.go
@@ -10,19 +10,19 @@ import (
 func TestStringFormat(t *testing.T) {
 	testRule(t, "string-format", &rule.StringFormatRule{}, &lint.RuleConfig{
 		Arguments: lint.Arguments{
-			[]interface{}{
+			[]any{
 				"stringFormatMethod1", // The first argument is checked by default
 				"/^[A-Z]/",
 				"must start with a capital letter"},
 
-			[]interface{}{
+			[]any{
 				"stringFormatMethod2[2].d",
 				"/[^\\.]$/"}, // Must not end with a period
-			[]interface{}{
+			[]any{
 				"s.Method3[2]",
 				"!/^[Tt][Hh]/",
 				"must not start with 'th'"},
-			[]interface{}{
+			[]any{
 				"s.Method4", // same as before, but called from a struct
 				"!/^[Ot][Tt]/",
 				"must not start with 'ot'"}}})
@@ -47,56 +47,56 @@ func TestStringFormatArgumentParsing(t *testing.T) {
 		{
 			name: "Missing Regex",
 			config: lint.Arguments{
-				[]interface{}{
+				[]any{
 					"method[0]"}},
 			expectedError: stringPtr("invalid configuration for string-format: less than two slices found in argument, scope and regex are required [argument 0, option 0]")},
 		{
 			name: "Bad Argument Type",
 			config: lint.Arguments{
-				[]interface{}{
+				[]any{
 					1}},
 			expectedError: stringPtr("invalid configuration for string-format: less than two slices found in argument, scope and regex are required [argument 0, option 0]")},
 		{
 			name: "Empty Scope",
 			config: lint.Arguments{
-				[]interface{}{
+				[]any{
 					"",
 					"//"}},
 			expectedError: stringPtr("invalid configuration for string-format: empty scope provided [argument 0, option 0]")},
 		{
 			name: "Small or Empty Regex",
 			config: lint.Arguments{
-				[]interface{}{
+				[]any{
 					"method[1].a",
 					"-"}},
 			expectedError: stringPtr("invalid configuration for string-format: regex is too small (regexes should begin and end with '/') [argument 0, option 1]")},
 		{
 			name: "Bad Scope",
 			config: lint.Arguments{
-				[]interface{}{
+				[]any{
 					"1.a",
 					"//"}},
 			expectedError: stringPtr("failed to parse configuration for string-format: unable to parse rule scope [argument 0, option 0]")},
 		{
 			name: "Bad Regex",
 			config: lint.Arguments{
-				[]interface{}{
+				[]any{
 					"method[1].a",
 					"/(/"}},
 			expectedError: stringPtr("failed to parse configuration for string-format: unable to compile /(/ as regexp [argument 0, option 1]")},
 		{
 			name: "Sample Config",
 			config: lint.Arguments{
-				[]interface{}{
+				[]any{
 					"core.WriteError[1].Message", "/^([^A-Z]$)/", "must not start with a capital letter"},
-				[]interface{}{
+				[]any{
 					"fmt.Errorf[0]", "/^|[^\\.!?]$/", "must not end in punctuation"},
-				[]interface{}{
+				[]any{
 					"panic", "/^[^\\n]*$/", "must not contain line breaks"}}},
 		{
 			name: "Underscores in Scope",
 			config: lint.Arguments{
-				[]interface{}{
+				[]any{
 					"some_pkg._some_function_name[5].some_member",
 					"//"}}}}
 

--- a/test/struct-tag_test.go
+++ b/test/struct-tag_test.go
@@ -14,6 +14,6 @@ func TestStructTag(t *testing.T) {
 
 func TestStructTagWithUserOptions(t *testing.T) {
 	testRule(t, "struct-tag-useroptions", &rule.StructTagRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{"json,inline,outline", "bson,gnu"},
+		Arguments: []any{"json,inline,outline", "bson,gnu"},
 	})
 }

--- a/test/superfluous-else_test.go
+++ b/test/superfluous-else_test.go
@@ -11,5 +11,5 @@ import (
 // TestSuperfluousElse rule.
 func TestSuperfluousElse(t *testing.T) {
 	testRule(t, "superfluous-else", &rule.SuperfluousElseRule{})
-	testRule(t, "superfluous-else-scope", &rule.SuperfluousElseRule{}, &lint.RuleConfig{Arguments: []interface{}{ifelse.PreserveScope}})
+	testRule(t, "superfluous-else-scope", &rule.SuperfluousElseRule{}, &lint.RuleConfig{Arguments: []any{ifelse.PreserveScope}})
 }

--- a/test/unhandled-error_test.go
+++ b/test/unhandled-error_test.go
@@ -12,7 +12,7 @@ func TestUnhandledError(t *testing.T) {
 }
 
 func TestUnhandledErrorWithIgnoreList(t *testing.T) {
-	args := []interface{}{
+	args := []any{
 		`unhandledError1`,
 		`fmt\.Print`,
 		`os\.(Create|WriteFile|Chmod)`,

--- a/test/unused-param_test.go
+++ b/test/unused-param_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestUnusedParam(t *testing.T) {
 	testRule(t, "unused-param", &rule.UnusedParamRule{})
-	testRule(t, "unused-param-custom-regex", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: []interface{}{
-		map[string]interface{}{"allowRegex": "^xxx"},
+	testRule(t, "unused-param-custom-regex", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: []any{
+		map[string]any{"allowRegex": "^xxx"},
 	}})
 }
 

--- a/test/unused-receiver_test.go
+++ b/test/unused-receiver_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUnusedReceiver(t *testing.T) {
 	testRule(t, "unused-receiver", &rule.UnusedReceiverRule{})
-	testRule(t, "unused-receiver-custom-regex", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: []interface{}{
-		map[string]interface{}{"allowRegex": "^xxx"},
+	testRule(t, "unused-receiver-custom-regex", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: []any{
+		map[string]any{"allowRegex": "^xxx"},
 	}})
 }

--- a/test/var-naming_test.go
+++ b/test/var-naming_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestVarNaming(t *testing.T) {
 	testRule(t, "var-naming", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{[]interface{}{"ID"}, []interface{}{"VM"}},
+		Arguments: []any{[]any{"ID"}, []any{"VM"}},
 	})
 
 	testRule(t, "var-naming_test", &rule.VarNamingRule{}, &lint.RuleConfig{})
 
 	testRule(t, "var-naming_upperCaseConst-false", &rule.VarNamingRule{}, &lint.RuleConfig{})
 	testRule(t, "var-naming_upperCaseConst-true", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []interface{}{[]interface{}{}, []interface{}{}, []interface{}{map[string]interface{}{"upperCaseConst": true}}},
+		Arguments: []any{[]any{}, []any{}, []any{map[string]any{"upperCaseConst": true}}},
 	})
 }


### PR DESCRIPTION
cleanup related with #903 

for start I saved mantioned configuration in revive.toml and run:  `revive -config ~/revive.toml -formatter stylish {test,rule}` 

cleanup made by command: `gofmt -r 'interface{} -> any' -w *.go` executed under test and rule directory

after cleanup, run test again and of course any warnings :)

cleanup command founded in: [article](https://medium.com/@csaba.ujvari/go-1-18-any-instead-of-interface-ce15dd7bea5d)
