### PR TITLE
cleanup: rename unused parameters and receivers to _

### DIFF
--- a/revivelib/core_internal_test.go
+++ b/revivelib/core_internal_test.go
@@ -43,7 +43,7 @@ func (*mockRule) Name() string {
 	return "mock-rule"
 }
 
-func (*mockRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (*mockRule) Apply(_ *lint.File, _ lint.Arguments) []lint.Failure {
 	return nil
 }
 

--- a/rule/add-constant.go
+++ b/rule/add-constant.go
@@ -105,7 +105,7 @@ func (w lintAddConstantRule) checkFunc(expr *ast.CallExpr) {
 	}
 }
 
-func (_ lintAddConstantRule) getFuncName(expr *ast.CallExpr) string {
+func (lintAddConstantRule) getFuncName(expr *ast.CallExpr) string {
 	switch f := expr.Fun.(type) {
 	case *ast.SelectorExpr:
 		switch prefix := f.X.(type) {

--- a/rule/add-constant.go
+++ b/rule/add-constant.go
@@ -105,7 +105,7 @@ func (w lintAddConstantRule) checkFunc(expr *ast.CallExpr) {
 	}
 }
 
-func (w lintAddConstantRule) getFuncName(expr *ast.CallExpr) string {
+func (_ lintAddConstantRule) getFuncName(expr *ast.CallExpr) string {
 	switch f := expr.Fun.(type) {
 	case *ast.SelectorExpr:
 		switch prefix := f.X.(type) {

--- a/rule/constant-logical-expr.go
+++ b/rule/constant-logical-expr.go
@@ -11,7 +11,7 @@ import (
 type ConstantLogicalExprRule struct{}
 
 // Apply applies the rule to given file.
-func (_ *ConstantLogicalExprRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+func (*ConstantLogicalExprRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {
@@ -63,7 +63,7 @@ func (w *lintConstantLogicalExpr) Visit(node ast.Node) ast.Visitor {
 	return w
 }
 
-func (_ *lintConstantLogicalExpr) isOperatorWithLogicalResult(t token.Token) bool {
+func (*lintConstantLogicalExpr) isOperatorWithLogicalResult(t token.Token) bool {
 	switch t {
 	case token.LAND, token.LOR, token.EQL, token.LSS, token.GTR, token.NEQ, token.LEQ, token.GEQ:
 		return true
@@ -72,7 +72,7 @@ func (_ *lintConstantLogicalExpr) isOperatorWithLogicalResult(t token.Token) boo
 	return false
 }
 
-func (_ *lintConstantLogicalExpr) isEqualityOperator(t token.Token) bool {
+func (*lintConstantLogicalExpr) isEqualityOperator(t token.Token) bool {
 	switch t {
 	case token.EQL, token.LEQ, token.GEQ:
 		return true
@@ -81,7 +81,7 @@ func (_ *lintConstantLogicalExpr) isEqualityOperator(t token.Token) bool {
 	return false
 }
 
-func (_ *lintConstantLogicalExpr) isInequalityOperator(t token.Token) bool {
+func (*lintConstantLogicalExpr) isInequalityOperator(t token.Token) bool {
 	switch t {
 	case token.LSS, token.GTR, token.NEQ:
 		return true

--- a/rule/constant-logical-expr.go
+++ b/rule/constant-logical-expr.go
@@ -11,7 +11,7 @@ import (
 type ConstantLogicalExprRule struct{}
 
 // Apply applies the rule to given file.
-func (r *ConstantLogicalExprRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+func (_ *ConstantLogicalExprRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {
@@ -63,7 +63,7 @@ func (w *lintConstantLogicalExpr) Visit(node ast.Node) ast.Visitor {
 	return w
 }
 
-func (w *lintConstantLogicalExpr) isOperatorWithLogicalResult(t token.Token) bool {
+func (_ *lintConstantLogicalExpr) isOperatorWithLogicalResult(t token.Token) bool {
 	switch t {
 	case token.LAND, token.LOR, token.EQL, token.LSS, token.GTR, token.NEQ, token.LEQ, token.GEQ:
 		return true
@@ -72,7 +72,7 @@ func (w *lintConstantLogicalExpr) isOperatorWithLogicalResult(t token.Token) boo
 	return false
 }
 
-func (w *lintConstantLogicalExpr) isEqualityOperator(t token.Token) bool {
+func (_ *lintConstantLogicalExpr) isEqualityOperator(t token.Token) bool {
 	switch t {
 	case token.EQL, token.LEQ, token.GEQ:
 		return true
@@ -81,7 +81,7 @@ func (w *lintConstantLogicalExpr) isEqualityOperator(t token.Token) bool {
 	return false
 }
 
-func (w *lintConstantLogicalExpr) isInequalityOperator(t token.Token) bool {
+func (_ *lintConstantLogicalExpr) isInequalityOperator(t token.Token) bool {
 	switch t {
 	case token.LSS, token.GTR, token.NEQ:
 		return true

--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -53,7 +53,7 @@ func (w lintDataRaces) Visit(n ast.Node) ast.Visitor {
 	return nil
 }
 
-func (_ lintDataRaces) ExtractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
+func (lintDataRaces) ExtractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
 	r := map[*ast.Object]struct{}{}
 	for _, f := range fields {
 		for _, id := range f.Names {

--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -53,7 +53,7 @@ func (w lintDataRaces) Visit(n ast.Node) ast.Visitor {
 	return nil
 }
 
-func (w lintDataRaces) ExtractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
+func (_ lintDataRaces) ExtractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
 	r := map[*ast.Object]struct{}{}
 	for _, f := range fields {
 		for _, id := range f.Names {

--- a/rule/early-return.go
+++ b/rule/early-return.go
@@ -22,7 +22,7 @@ func (*EarlyReturnRule) Name() string {
 }
 
 // CheckIfElse evaluates the rule against an ifelse.Chain.
-func (e *EarlyReturnRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
+func (_ *EarlyReturnRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
 	if !chain.Else.Deviates() {
 		// this rule only applies if the else-block deviates control flow
 		return

--- a/rule/early-return.go
+++ b/rule/early-return.go
@@ -22,7 +22,7 @@ func (*EarlyReturnRule) Name() string {
 }
 
 // CheckIfElse evaluates the rule against an ifelse.Chain.
-func (_ *EarlyReturnRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
+func (*EarlyReturnRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
 	if !chain.Else.Deviates() {
 		// this rule only applies if the else-block deviates control flow
 		return

--- a/rule/enforce-map-style.go
+++ b/rule/enforce-map-style.go
@@ -141,7 +141,7 @@ func (r *EnforceMapStyleRule) Apply(file *lint.File, arguments lint.Arguments) [
 }
 
 // Name returns the rule name.
-func (_ *EnforceMapStyleRule) Name() string {
+func (*EnforceMapStyleRule) Name() string {
 	return "enforce-map-style"
 }
 

--- a/rule/enforce-map-style.go
+++ b/rule/enforce-map-style.go
@@ -141,7 +141,7 @@ func (r *EnforceMapStyleRule) Apply(file *lint.File, arguments lint.Arguments) [
 }
 
 // Name returns the rule name.
-func (r *EnforceMapStyleRule) Name() string {
+func (_ *EnforceMapStyleRule) Name() string {
 	return "enforce-map-style"
 }
 

--- a/rule/enforce-slice-style.go
+++ b/rule/enforce-slice-style.go
@@ -165,7 +165,7 @@ func (r *EnforceSliceStyleRule) Apply(file *lint.File, arguments lint.Arguments)
 }
 
 // Name returns the rule name.
-func (_ *EnforceSliceStyleRule) Name() string {
+func (*EnforceSliceStyleRule) Name() string {
 	return "enforce-slice-style"
 }
 

--- a/rule/enforce-slice-style.go
+++ b/rule/enforce-slice-style.go
@@ -165,7 +165,7 @@ func (r *EnforceSliceStyleRule) Apply(file *lint.File, arguments lint.Arguments)
 }
 
 // Name returns the rule name.
-func (r *EnforceSliceStyleRule) Name() string {
+func (_ *EnforceSliceStyleRule) Name() string {
 	return "enforce-slice-style"
 }
 

--- a/rule/indent-error-flow.go
+++ b/rule/indent-error-flow.go
@@ -19,7 +19,7 @@ func (*IndentErrorFlowRule) Name() string {
 }
 
 // CheckIfElse evaluates the rule against an ifelse.Chain.
-func (_ *IndentErrorFlowRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
+func (*IndentErrorFlowRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
 	if !chain.If.Deviates() {
 		// this rule only applies if the if-block deviates control flow
 		return

--- a/rule/indent-error-flow.go
+++ b/rule/indent-error-flow.go
@@ -19,7 +19,7 @@ func (*IndentErrorFlowRule) Name() string {
 }
 
 // CheckIfElse evaluates the rule against an ifelse.Chain.
-func (e *IndentErrorFlowRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
+func (_ *IndentErrorFlowRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
 	if !chain.If.Deviates() {
 		// this rule only applies if the if-block deviates control flow
 		return

--- a/rule/superfluous-else.go
+++ b/rule/superfluous-else.go
@@ -20,7 +20,7 @@ func (*SuperfluousElseRule) Name() string {
 }
 
 // CheckIfElse evaluates the rule against an ifelse.Chain.
-func (_ *SuperfluousElseRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
+func (*SuperfluousElseRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
 	if !chain.If.Deviates() {
 		// this rule only applies if the if-block deviates control flow
 		return

--- a/rule/superfluous-else.go
+++ b/rule/superfluous-else.go
@@ -20,7 +20,7 @@ func (*SuperfluousElseRule) Name() string {
 }
 
 // CheckIfElse evaluates the rule against an ifelse.Chain.
-func (e *SuperfluousElseRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
+func (_ *SuperfluousElseRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) (failMsg string) {
 	if !chain.If.Deviates() {
 		// this rule only applies if the if-block deviates control flow
 		return


### PR DESCRIPTION
PR related with #904 

all unused functions parameters and receivers have been replaced with undersorce (_) sign to supress warnings. Maybe there is more elegant way to do this, but I dont want to remove parameters declaration 

test command: `revive -config ~/revive.toml -formatter stylish {test,rule,revivelib}`

config: 
```
ignoreGeneratedHeader = false
severity = "warning"
confidence = 0.8
errorCode = 0
warningCode = 0

[rule.unused-parameter]
[rule.unused-receiver]
```