### PR TITLE
fix: literal calls case

### DIFF
--- a/rule/unconditional-recursion.go
+++ b/rule/unconditional-recursion.go
@@ -62,13 +62,11 @@ func (w lintUnconditionalRecursionRule) Visit(node ast.Node) ast.Visitor {
 		var rec *ast.Ident
 		switch {
 		case n.Recv == nil:
-			rec = nil
 		case n.Recv.NumFields() < 1 || len(n.Recv.List[0].Names) < 1:
-			rec = &ast.Ident{Name: "_"}
+			rec = nil
 		default:
 			rec = n.Recv.List[0].Names[0]
 		}
-
 		w.currentFunc = &funcStatus{&funcDesc{rec, n.Name}, false}
 	case *ast.CallExpr:
 		var funcID *ast.Ident
@@ -125,6 +123,8 @@ func (w lintUnconditionalRecursionRule) Visit(node ast.Node) ast.Visitor {
 		}
 		// unconditional loop
 		return w
+	case *ast.FuncLit:
+		return nil // literal call (closure) is not an issue
 	}
 
 	return w

--- a/rule/unconditional-recursion.go
+++ b/rule/unconditional-recursion.go
@@ -45,8 +45,9 @@ type funcStatus struct {
 }
 
 type lintUnconditionalRecursionRule struct {
-	onFailure   func(lint.Failure)
-	currentFunc *funcStatus
+	onFailure     func(lint.Failure)
+	currentFunc   *funcStatus
+	inGoStatement bool
 }
 
 // Visit will traverse the file AST.
@@ -62,13 +63,19 @@ func (w lintUnconditionalRecursionRule) Visit(node ast.Node) ast.Visitor {
 		var rec *ast.Ident
 		switch {
 		case n.Recv == nil:
-		case n.Recv.NumFields() < 1 || len(n.Recv.List[0].Names) < 1:
 			rec = nil
+		case n.Recv.NumFields() < 1 || len(n.Recv.List[0].Names) < 1:
+			rec = &ast.Ident{Name: "_"}
 		default:
 			rec = n.Recv.List[0].Names[0]
 		}
 		w.currentFunc = &funcStatus{&funcDesc{rec, n.Name}, false}
 	case *ast.CallExpr:
+		// check if call arguments has a recursive call
+		for _, arg := range n.Args {
+			ast.Walk(w, arg)
+		}
+
 		var funcID *ast.Ident
 		var selector *ast.Ident
 		switch c := n.Fun.(type) {
@@ -82,6 +89,9 @@ func (w lintUnconditionalRecursionRule) Visit(node ast.Node) ast.Visitor {
 				return nil
 			}
 			funcID = c.Sel
+		case *ast.FuncLit:
+			ast.Walk(w, c.Body) // analyze the body of the function literal
+			return nil
 		default:
 			return w
 		}
@@ -91,11 +101,12 @@ func (w lintUnconditionalRecursionRule) Visit(node ast.Node) ast.Visitor {
 			w.currentFunc.funcDesc.equal(&funcDesc{selector, funcID}) {
 			w.onFailure(lint.Failure{
 				Category:   "logic",
-				Confidence: 1,
+				Confidence: 0.8,
 				Node:       n,
 				Failure:    "unconditional recursive call",
 			})
 		}
+		return nil
 	case *ast.IfStmt:
 		w.updateFuncStatus(n.Body)
 		w.updateFuncStatus(n.Else)
@@ -113,10 +124,10 @@ func (w lintUnconditionalRecursionRule) Visit(node ast.Node) ast.Visitor {
 		w.updateFuncStatus(n.Body)
 		return nil
 	case *ast.GoStmt:
-		for _, a := range n.Call.Args {
-			ast.Walk(w, a) // check if arguments have a recursive call
-		}
-		return nil // recursive async call is not an issue
+		w.inGoStatement = true
+		ast.Walk(w, n.Call)
+		w.inGoStatement = false
+		return nil
 	case *ast.ForStmt:
 		if n.Cond != nil {
 			return nil
@@ -124,7 +135,10 @@ func (w lintUnconditionalRecursionRule) Visit(node ast.Node) ast.Visitor {
 		// unconditional loop
 		return w
 	case *ast.FuncLit:
-		return nil // literal call (closure) is not an issue
+		if w.inGoStatement {
+			return w
+		}
+		return nil // literal call (closure) is not necessarily an issue
 	}
 
 	return w

--- a/test/utils.go
+++ b/test/utils.go
@@ -86,6 +86,10 @@ func assertFailures(t *testing.T, baseDir string, fi os.FileInfo, src []byte, ru
 	for _, in := range ins {
 		ok := false
 		for i, p := range failures {
+			if p.Position.Start.Line != in.Line {
+				continue
+			}
+
 			if in.Match == p.Failure {
 				// check replacement if we are expecting one
 				if in.Replacement != "" {

--- a/test/utils.go
+++ b/test/utils.go
@@ -89,7 +89,6 @@ func assertFailures(t *testing.T, baseDir string, fi os.FileInfo, src []byte, ru
 			if p.Position.Start.Line != in.Line {
 				continue
 			}
-
 			if in.Match == p.Failure {
 				// check replacement if we are expecting one
 				if in.Replacement != "" {

--- a/test/utils.go
+++ b/test/utils.go
@@ -86,9 +86,6 @@ func assertFailures(t *testing.T, baseDir string, fi os.FileInfo, src []byte, ru
 	for _, in := range ins {
 		ok := false
 		for i, p := range failures {
-			if p.Position.Start.Line != in.Line {
-				continue
-			}
 			if in.Match == p.Failure {
 				// check replacement if we are expecting one
 				if in.Replacement != "" {

--- a/testdata/unconditional-recursion.go
+++ b/testdata/unconditional-recursion.go
@@ -187,3 +187,15 @@ func (*fooType) BarFunc() {
 func (_ *fooType) BazFunc() {
 	BazFunc()
 }
+
+// Tests for #902
+func falsePositiveFuncLiteral() {
+	_ = foo(func() {
+		falsePositiveFuncLiteral()
+	})
+}
+func nr902() {
+	go func() {
+		nr902() // MATCH /unconditional recursive call/
+	}()
+}

--- a/testdata/unconditional-recursion.go
+++ b/testdata/unconditional-recursion.go
@@ -134,8 +134,8 @@ func ur10() {
 	ur10()
 }
 
-func ur11() {
-	go ur11()
+func ur11() { // this pattern produces "infinite" number of goroutines
+	go ur11() // MATCH /unconditional recursive call/
 }
 
 func ur12() {


### PR DESCRIPTION
related with issue #902

fix is simple, we should add `case *ast.FuncLit` in rule: rule/unconditional-recursion.go , and return nil, then test pass. 

but at the end I dont know if I should add some additional code as in previous cases for ex: `w.updateFuncStatus(n.Body)` but if test pass it should be ok :P 