### PR TITLE
basic - pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   #   rev: v4.4.0
   #   hooks:
   #     - id: end-of-file-fixer
-  - repo: https://github.com/mgechev/revive
+  - repo: https://github.com/mfederowicz/revive
     #for start use dev tag, after development we switch to proper tags with versions 
     rev: dev-pre-commit
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+  - repo: https://github.com/mgechev/revive
+    #for start use dev tag, after development we switch to proper tags with versions 
+    rev: dev-pre-commit
+    hooks:
+    -   id: revive

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,9 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/TekWizely/pre-commit-golang
+    rev: v1.0.0-rc.1
+    hooks:
+      -   id: go-revive
+      -   id: go-revive-mod
+      -   id: go-revive-repo-mod

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-      - id: end-of-file-fixer
+  # - repo: https://github.com/pre-commit/pre-commit-hooks
+  #   rev: v4.4.0
+  #   hooks:
+  #     - id: end-of-file-fixer
   - repo: https://github.com/mgechev/revive
     #for start use dev tag, after development we switch to proper tags with versions 
     rev: dev-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,6 @@
 repos:
-  # - repo: https://github.com/pre-commit/pre-commit-hooks
-  #   rev: v4.4.0
-  #   hooks:
-  #     - id: end-of-file-fixer
-  - repo: https://github.com/mfederowicz/revive
-    #for start use dev tag, after development we switch to proper tags with versions 
-    rev: dev-pre-commit
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
     hooks:
-    -   id: revive
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: revive
+    name: revive
+    description: Beautiful Go linter
+    entry: revive
+    language: golang

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 -   id: revive
     name: revive
     description: Beautiful Go linter
-    entry: revive
+    entry: revive -h
     language: golang

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,0 @@
--   id: revive
-    name: revive
-    description: Beautiful Go linter
-    entry: revive -h
-    language: golang


### PR DESCRIPTION
related with #913 


basic .pre-commit-config.yaml:
```
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.4.0
    hooks:
      - id: end-of-file-fixer
  - repo: https://github.com/mgechev/revive
    #for start use dev tag, after development we switch to proper tags with versions 
    rev: dev-pre-commit
    hooks:
    -   id: revive

```

in rev field for start we can set tag/branch but one condition is required file .pre-commit-hooks.yaml must exists i this tag/branch version otherwise command: `pre-commit run --all-files` (this command can be used to test configured hooks on our code without commit) will return error


.pre-commit-hooks.yaml
```
-   id: revive
    name: revive
    description: Beautiful Go linter
    entry: revive
    language: golang
```

hook presented above should be more configured, because it dumps some strage errors :

```
revive...................................................................Failed                                                                                              
- hook id: revive                                                                                                                                                            
- exit code: 2                                                                                                                                                               
                                                                                                                                                                             
Dockerfile:1:1: invalid file Dockerfile: Dockerfile:1:1: expected 'package', found FROM                                                                                      
panic: runtime error: invalid memory address or nil pointer dereference                                                                                                      
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x576179]                                                                                                       
                                                                                                                                                                             
goroutine 105 [running]:                                                                                                                                                     
go/ast.Walk({0x8eb140?, 0xc000317160?}, {0x8edcc0?, 0x0?})                                                                                                                   
        /usr/local/go1.21.1.linux-amd64/src/go/ast/walk.go:234 +0xf39                                                                                                        
github.com/mgechev/revive/rule.pick({0x8edcc0, 0x0}, 0xc000317150, 0x0)                                                                                                      
        /home/mfederowicz/.cache/pre-commit/repop2q1usxb/rule/utils.go:113 +0xe5                                                                                             
github.com/mgechev/revive/rule.lintUnusedReceiverRule.Visit({0xc000316e70, 0xc0001cfe00, {0x861334, 0x5e}}, {0x8eda90?, 0xc00031d020})                                       
        /home/mfederowicz/.cache/pre-commit/repop2q1usxb/rule/unused-receiver.go:116 +0x185                                                                                  
go/ast.Walk({0x8eb1a0?, 0xc0001d0a00?}, {0x8eda90?, 0xc00031d020?})                                                                                                          
        /usr/local/go1.21.1.linux-amd64/src/go/ast/walk.go:51 +0x5c                                                                                                          
go/ast.walkDeclList(...)

```

steps to install hooks in local repo:
```
pre-commit install

pre-commit installed at .git/hooks/pre-commit
```

steps to uninstall hooks in local repo:
```
pre-commit uninstall

pre-commit installed at .git/hooks/pre-commit
```

in development stage if we dont set rev field as `v1.2.3` we can see warning like below:

`[WARNING] The 'rev' field of repo 'https://github.com/mgechev/revive' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
`

steps to test code without commit:
```
pre-commit run --all-files
```

