### PR TITLE
refactor: remove refs to io/ioutil

### DIFF
--- a/testdata/unhandled-error-w-ignorelist.go
+++ b/testdata/unhandled-error-w-ignorelist.go
@@ -3,7 +3,6 @@ package fixtures
 import (
 	b "bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 )
@@ -38,7 +37,7 @@ func testCase2() {
 	os.Chmod("test_file", os.ModeAppend)                          // ignore
 	os.WriteFile("test_file", []byte("some data"), os.ModeAppend) // ignore
 
-	ioutil.WriteFile("test_file", []byte("some data"), os.ModeAppend) // MATCH /Unhandled error in call to function ioutil.WriteFile/
+	os.WriteFile("test_file", []byte("some data"), os.ModeAppend) // ignore
 
 	_ = os.Chdir("..")
 	os.Chdir("..") // MATCH /Unhandled error in call to function os.Chdir/


### PR DESCRIPTION
io/ioutil has been deprecated since Go 1.16
https://pkg.go.dev/io/ioutil

Ignore unused error in `os.WriteFile` call - already set to be ignored in https://github.com/mgechev/revive/blob/8dbd58748ae8bc7d95a884fd8012c0c56c4efdff/test/unhandled-error_test.go#L18

<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
