### PR TITLE
fix:ignore color marks when compare stings in test

### DIFF
--- a/revivelib/core_test.go
+++ b/revivelib/core_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/mgechev/revive/config"
 	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/revivelib"
@@ -45,6 +46,7 @@ func TestReviveFormat(t *testing.T) {
 	}
 
 	// ACT
+	color.NoColor = true
 	failures, exitCode, err := revive.Format("stylish", failuresChan)
 	// ASSERT
 	if err != nil {


### PR DESCRIPTION
related with #925 

when we ignore color markers/command before formatter starts, then output text should be identical with compared text :P