### PR TITLE
var-naming: avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -127,7 +127,7 @@ func (w *lintNames) check(id *ast.Ident, thing string) {
 
 	// #851 upperCaseConst support
 	// if it's const
-	if thing == token.CONST.String() && w.upperCaseConst && upperCaseConstRE.Match([]byte(id.Name)) {
+	if thing == token.CONST.String() && w.upperCaseConst && upperCaseConstRE.MatchString(id.Name) {
 		return
 	}
 


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance improvement.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := upperCaseConstRE.Match([]byte("FOO_BAR")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := upperCaseConstRE.MatchString("FOO_BAR"); !match {
			b.Fail()
		}
	}
}
```

```
goos: linux
goarch: amd64
pkg: github.com/mgechev/revive/rule
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 5248138	       285.8 ns/op	       8 B/op	       1 allocs/op
BenchmarkMatchString-16    	 6899334	       170.9 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/mgechev/revive/rule	4.102s
```