### PR TITLE
extend parsing instructions to use json object instead of plain txt

### DIFF
--- a/test/json-data-format_test.go
+++ b/test/json-data-format_test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
+)
+
+func TestJsonDataFormat(t *testing.T) {
+	testRule(t, "json-data-format-atomic", &rule.AtomicRule{})
+
+}
+func TestJsonDataFormatVarNaming(t *testing.T) {
+	testRule(t, "json-data-format-var-naming", &rule.VarNamingRule{}, &lint.RuleConfig{})
+
+}

--- a/testdata/json-data-format-atomic.go
+++ b/testdata/json-data-format-atomic.go
@@ -1,0 +1,13 @@
+package fixtures
+
+import (
+	"sync/atomic"
+)
+
+type Counter uint64
+
+func AtomicTests() {
+	x = atomic.AddUint64(&x, 1) // json:{"MATCH": "direct assignment to atomic value","Confidence": 1}
+	x := uint64(1)
+
+}

--- a/testdata/json-data-format-var-naming.go
+++ b/testdata/json-data-format-var-naming.go
@@ -1,0 +1,8 @@
+package fixtures
+
+func foo() string {
+	customID := "result"    // ignore
+	customVm := "result"    // json:{"MATCH": "var customVm should be customVM"}
+	CUSTOMER_UP := "result" // json:{"MATCH": "don't use ALL_CAPS in Go names; use CamelCase", "Confidence": 0.8}
+	return customId
+}


### PR DESCRIPTION
related with #424 

now we can use instead of txt format:

`x = atomic.AddUint64(&x, 1)        // MATCH /direct assignment to atomic value/`

json format:

`x = atomic.AddUint64(&x, 1) // json:{"MATCH": "direct assignment to atomic value","Confidence": 1}`

of course this is only draft because I dont know how it should looks like logic to use all Failure properties, so I asume that for example we want to check if Confidence property have value equal to that setted up in json object, and if value is not equal then throw/log error otherwise everything is ok

this draft dont remove old MATH txt format, but add json feature, so we can use old format for some time :)

@chavacava what do you think about? 