### PR TITLE
refactor: remove unused parameter from pick function

### DIFF
--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -111,7 +111,7 @@ func (w lintFunctionForDataRaces) Visit(node ast.Node) ast.Visitor {
 			return ok
 		}
 
-		ids := pick(funcLit.Body, selectIDs, nil)
+		ids := pick(funcLit.Body, selectIDs)
 		for _, id := range ids {
 			id := id.(*ast.Ident)
 			_, isRangeID := w.rangeIDs[id.Obj]

--- a/rule/flag-param.go
+++ b/rule/flag-param.go
@@ -88,7 +88,7 @@ func (w conditionVisitor) Visit(node ast.Node) ast.Visitor {
 		return false
 	}
 
-	uses := pick(ifStmt.Cond, fselect, nil)
+	uses := pick(ifStmt.Cond, fselect)
 
 	if len(uses) < 1 {
 		return w

--- a/rule/modifies-value-receiver.go
+++ b/rule/modifies-value-receiver.go
@@ -97,7 +97,7 @@ func (w lintModifiesValRecRule) Visit(node ast.Node) ast.Visitor {
 			return false
 		}
 
-		assignmentsToReceiver := pick(n.Body, fselect, nil)
+		assignmentsToReceiver := pick(n.Body, fselect)
 
 		for _, assignment := range assignmentsToReceiver {
 			w.onFailure(lint.Failure{

--- a/rule/optimize-operands-order.go
+++ b/rule/optimize-operands-order.go
@@ -54,13 +54,13 @@ func (w lintOptimizeOperandsOrderlExpr) Visit(node ast.Node) ast.Visitor {
 	}
 
 	// check if the left sub-expression contains a function call
-	nodes := pick(binExpr.X, isCaller, nil)
+	nodes := pick(binExpr.X, isCaller)
 	if len(nodes) < 1 {
 		return w
 	}
 
 	// check if the right sub-expression does not contain a function call
-	nodes = pick(binExpr.Y, isCaller, nil)
+	nodes = pick(binExpr.Y, isCaller)
 	if len(nodes) > 0 {
 		return w
 	}

--- a/rule/unconditional-recursion.go
+++ b/rule/unconditional-recursion.go
@@ -195,5 +195,5 @@ func (lintUnconditionalRecursionRule) hasControlExit(node ast.Node) bool {
 		return false
 	}
 
-	return len(pick(node, isExit, nil)) != 0
+	return len(pick(node, isExit)) != 0
 }

--- a/rule/unused-param.go
+++ b/rule/unused-param.go
@@ -113,7 +113,7 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 
 			return false
 		}
-		_ = pick(n.Body, fselect, nil)
+		_ = pick(n.Body, fselect)
 
 		for _, p := range n.Type.Params.List {
 			for _, n := range p.Names {

--- a/rule/unused-receiver.go
+++ b/rule/unused-receiver.go
@@ -113,7 +113,7 @@ func (w lintUnusedReceiverRule) Visit(node ast.Node) ast.Visitor {
 
 			return isAnID && ident.Obj == recID.Obj
 		}
-		refs2recID := pick(n.Body, fselect, nil)
+		refs2recID := pick(n.Body, fselect)
 
 		if len(refs2recID) > 0 {
 			return nil // the receiver is referenced in the func body

--- a/rule/utils.go
+++ b/rule/utils.go
@@ -93,21 +93,15 @@ func srcLine(src []byte, p token.Position) string {
 
 // pick yields a list of nodes by picking them from a sub-ast with root node n.
 // Nodes are selected by applying the fselect function
-// f function is applied to each selected node before inserting it in the final result.
-// If f==nil then it defaults to the identity function (ie it returns the node itself)
-func pick(n ast.Node, fselect func(n ast.Node) bool, f func(n ast.Node) []ast.Node) []ast.Node {
+func pick(n ast.Node, fselect func(n ast.Node) bool) []ast.Node {
 	var result []ast.Node
 
 	if n == nil {
 		return result
 	}
 
-	if f == nil {
-		f = func(n ast.Node) []ast.Node { return []ast.Node{n} }
-	}
-
 	onSelect := func(n ast.Node) {
-		result = append(result, f(n)...)
+		result = append(result, n)
 	}
 	p := picker{fselect: fselect, onSelect: onSelect}
 	ast.Walk(p, n)


### PR DESCRIPTION
This PR refactors internal function: remove the parameter `f func(n ast.Node) []ast.Node` from `pick` because it is always `nil`.

This refactoring was found by the [`unparam`](https://github.com/mvdan/unparam) linter:
```sh
❯ go run mvdan.cc/unparam@latest ./...
lint/file.go:191:22: (*File).disabledIntervals$3 - filename is unused
lint/file.go:191:95: (*File).disabledIntervals$3 - result 0 ([]github.com/mgechev/revive/lint.DisabledInterval) is always nil
rule/utils.go:98:54: pick - f always receives nil
exit status 1
```