### PR TITLE
modifies-value-receiver: warn on slice or map

### DIFF
--- a/rule/modifies-value-receiver.go
+++ b/rule/modifies-value-receiver.go
@@ -79,10 +79,6 @@ func (w lintModifiesValRecRule) Visit(node ast.Node) ast.Visitor {
 						continue
 					}
 
-					if w.skipType(ast.Expr(e.Sel)) {
-						continue
-					}
-
 				case *ast.Ident: // receiver := ...
 					if e.Name != receiverName {
 						continue

--- a/rule/modifies-value-receiver.go
+++ b/rule/modifies-value-receiver.go
@@ -78,7 +78,6 @@ func (w lintModifiesValRecRule) Visit(node ast.Node) ast.Visitor {
 					if name == "" || name != receiverName {
 						continue
 					}
-
 				case *ast.Ident: // receiver := ...
 					if e.Name != receiverName {
 						continue

--- a/testdata/modifies-value-receiver.go
+++ b/testdata/modifies-value-receiver.go
@@ -9,5 +9,6 @@ type data struct {
 func (this data) vmethod() {
 	this.num = 8 // MATCH /suspicious assignment to a by-value method receiver/
 	*this.key = "v.key"
+	this.items = make(map[string]bool) // MATCH /suspicious assignment to a by-value method receiver/
 	this.items["vmethod"] = true
 }


### PR DESCRIPTION
Assignments which index into the slice or map are already ignored on line 72, and those where the whole receiver is slice or map on line 50. We should not ignore assignments where the member variable is slice or map.

Closes #942 
