### PR TITLE
fix redunant-import-alias rule - unused alias is also redundant

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -672,7 +672,8 @@ _Configuration_: N/A
 
 ## redundant-import-alias
 
-_Description_: This rule warns on redundant import aliases. This happens when the alias used on the import statement matches the imported package name. 
+_Description_: This rule warns on redundant import aliases. This happens when the alias 
+used on the import statement matches the imported package name.
 
 _Configuration_:
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -672,9 +672,18 @@ _Configuration_: N/A
 
 ## redundant-import-alias
 
-_Description_: This rule warns on redundant import aliases. This happens when the alias used on the import statement matches the imported package name.
+_Description_: This rule warns on redundant import aliases. This happens when the alias used on the import statement matches the imported package name. 
 
-_Configuration_: N/A
+_Configuration_:
+
+* `ignoreUsed` : (bool) ignore aliases used in code (useful when using popular sdk packages).
+
+Example:
+
+```toml
+[rule.redundant-import-alias]
+  arguments = [{ ignoreUsed = true}]
+```
 
 ## string-format
 

--- a/rule/redundant-import-alias.go
+++ b/rule/redundant-import-alias.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"fmt"
 	"go/ast"
+	"strings"
 	"sync"
 
 	"github.com/mgechev/revive/lint"
@@ -59,35 +60,39 @@ func (r *RedundantImportAlias) checkRedundantAliases(node ast.Node) map[string]s
 			return true
 		}
 
-		if imp.Name != nil && imp.Path != nil {
-			aliasedPackages[imp.Name.Name] = "redundant"
+		if imp.Name != nil && imp.Path != nil && imp.Name.Name != "_" && getImportPackageName(imp) == imp.Name.Name {
+			aliasedPackages[imp.Name.Name] = "redundant"	
 		}
+
 		return true
 	})
 
-	if r.ignoreUsed {
-		// Second pass: remove one time used aliases
-		ast.Inspect(node, func(n ast.Node) bool {
-			sel, ok := n.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-
-			x, ok := sel.X.(*ast.Ident)
-			if !ok {
-				return true
-			}
-
-			// This alias is being used; it's not redundant
-			if _, exists := aliasedPackages[x.Name]; exists {
-				delete(aliasedPackages, x.Name)
-			}
-
-			return true
-		})
+	if !r.ignoreUsed {
+		return aliasedPackages
 	}
 
+	// Second pass: remove one-time used aliases
+	ast.Inspect(node, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		x, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+
+		// This alias is being used; it's not redundant
+		if _, exists := aliasedPackages[x.Name]; exists {
+			delete(aliasedPackages, x.Name)
+		}
+
+		return true
+	})
+
 	return aliasedPackages
+
 }
 
 func (r *RedundantImportAlias) configure(arguments lint.Arguments) {
@@ -95,22 +100,32 @@ func (r *RedundantImportAlias) configure(arguments lint.Arguments) {
 	defer r.Unlock()
 
 	r.ignoreUsed = defaultIgnoreUsed
-	if len(arguments) > 0 {
 
-		args, ok := arguments[0].(map[string]any)
-		if !ok {
-			panic(fmt.Sprintf("Invalid argument to the redundant-import-alias rule. Expecting a k,v map, got %T", arguments[0]))
-		}
+	if len(arguments) == 0 {
+		return
+	}
 
-		for k, v := range args {
-			switch k {
-			case "ignoreUsed":
-				value, ok := v.(bool)
-				if !ok {
-					panic(fmt.Sprintf("Invalid argument to the redundant-import-alias rule, expecting string representation of an bool. Got '%v' (%T)", v, v))
-				}
-				r.ignoreUsed = value
+	args, ok := arguments[0].(map[string]any)
+	if !ok {
+		panic(fmt.Sprintf("Invalid argument to the redundant-import-alias rule. Expecting a k,v map, got %T", arguments[0]))
+	}
+
+	for k, v := range args {
+		switch k {
+		case "ignoreUsed":
+			value, ok := v.(bool)
+			if !ok {
+				panic(fmt.Sprintf("Invalid argument to the redundant-import-alias rule, expecting string representation of an bool. Got '%v' (%T)", v, v))
 			}
+			r.ignoreUsed = value
 		}
 	}
+
+}
+
+func getImportPackageName(imp *ast.ImportSpec) string {
+	path := strings.Trim(imp.Path.Value, `"`)
+	parts := strings.Split(path, "/")
+	packageName := parts[len(parts)-1]
+	return packageName
 }

--- a/rule/redundant-import-alias.go
+++ b/rule/redundant-import-alias.go
@@ -60,7 +60,7 @@ func (r *RedundantImportAlias) checkRedundantAliases(node ast.Node) map[string]s
 			return true
 		}
 
-		if imp.Name != nil && imp.Path != nil && imp.Name.Name != "_" && getImportPackageName(imp) == imp.Name.Name {
+		if imp.Name != nil && imp.Path != nil && imp.Name.Name != "_" && r.getImportPackageName(imp) == imp.Name.Name {
 			aliasedPackages[imp.Name.Name] = "redundant"	
 		}
 
@@ -123,7 +123,7 @@ func (r *RedundantImportAlias) configure(arguments lint.Arguments) {
 
 }
 
-func getImportPackageName(imp *ast.ImportSpec) string {
+func (r *RedundantImportAlias) getImportPackageName(imp *ast.ImportSpec) string {
 	path := strings.Trim(imp.Path.Value, `"`)
 	parts := strings.Split(path, "/")
 	packageName := parts[len(parts)-1]

--- a/test/redundant-import-alias_test.go
+++ b/test/redundant-import-alias_test.go
@@ -1,11 +1,33 @@
 package test
 
 import (
-	"github.com/mgechev/revive/rule"
 	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
 )
 
 // TestRedundantImportAlias rule.
+func TestRedundantImportIgnoredAliases(t *testing.T) {
+
+	args := []any{map[string]any{
+		"ignoreUsed": true,
+	}}
+
+	testRule(t, "redundant-import-alias-ignored", &rule.RedundantImportAlias{}, &lint.RuleConfig{
+		Arguments: args,
+	})
+
+}
+
 func TestRedundantImportAlias(t *testing.T) {
-	testRule(t, "redundant-import-alias", &rule.RedundantImportAlias{})
+
+	args := []any{map[string]any{
+		"ignoreUsed": false,
+	}}
+
+	testRule(t, "redundant-import-alias", &rule.RedundantImportAlias{}, &lint.RuleConfig{
+		Arguments: args,
+	})
+
 }

--- a/testdata/redundant-import-alias-ignored.go
+++ b/testdata/redundant-import-alias-ignored.go
@@ -1,10 +1,8 @@
 package fixtures
 
 import (
-	runpb "cloud.google.com/go/run/apiv2/runpb" // MATCH /Import alias "runpb" is redundant/
-
-	md5 "crypto/md5" // MATCH /Import alias "md5" is redundant/
-
+	runpb "cloud.google.com/go/run/apiv2/runpb"
+	md5 "crypto/md5"
 	strings "strings" // MATCH /Import alias "strings" is redundant/
 
 	"crypto/md5"

--- a/testdata/redundant-import-alias-ignored.go
+++ b/testdata/redundant-import-alias-ignored.go
@@ -2,15 +2,11 @@ package fixtures
 
 import (
 	runpb "cloud.google.com/go/run/apiv2/runpb"
-	md5 "crypto/md5"
-	strings "strings" // MATCH /Import alias "strings" is redundant/
-
 	"crypto/md5"
-	_ "crypto/md5" // MATCH /Import alias "_" is redundant/
-
+	md5 "crypto/md5"
 	"strings"
-	str "strings" // MATCH /Import alias "str" is redundant/
-
+	str "strings"     // MATCH /Import alias "str" is redundant/
+	strings "strings" // MATCH /Import alias "strings" is redundant/
 )
 
 func UseRunpb() {

--- a/testdata/redundant-import-alias-ignored.go
+++ b/testdata/redundant-import-alias-ignored.go
@@ -5,7 +5,7 @@ import (
 	"crypto/md5"
 	md5 "crypto/md5"
 	"strings"
-	str "strings"     // MATCH /Import alias "str" is redundant/
+	str "strings" 
 	strings "strings" // MATCH /Import alias "strings" is redundant/
 )
 

--- a/testdata/redundant-import-alias.go
+++ b/testdata/redundant-import-alias.go
@@ -1,16 +1,13 @@
 package fixtures
 
-import (
+import(
 	"crypto/md5"
-	md5 "crypto/md5" // MATCH /Import alias "md5" is redundant/
-
-	runpb "cloud.google.com/go/run/apiv2/runpb" // MATCH /Import alias "runpb" is redundant/
+		"strings"
+		_ "crypto/md5"
+		str "strings"
+		strings "strings"  // MATCH /Import alias "strings" is redundant/
+		crypto "crypto/md5"
+        redundant "abc/redundant" // MATCH /Import alias "redundant" is redundant/
+		md5 "crypto/md5"  // MATCH /Import alias "md5" is redundant/
 )
 
-func UseRunpb() {
-	runpb.RegisterTasksServer()
-}
-
-func UseMd5() {
-	fmt.PrintLn(md5.Size)
-}

--- a/testdata/redundant-import-alias.go
+++ b/testdata/redundant-import-alias.go
@@ -1,18 +1,10 @@
 package fixtures
 
 import (
-	runpb "cloud.google.com/go/run/apiv2/runpb" // MATCH /Import alias "runpb" is redundant/
-
+	"crypto/md5"
 	md5 "crypto/md5" // MATCH /Import alias "md5" is redundant/
 
-	strings "strings" // MATCH /Import alias "strings" is redundant/
-
-	"crypto/md5"
-	_ "crypto/md5" // MATCH /Import alias "_" is redundant/
-
-	"strings"
-	str "strings" // MATCH /Import alias "str" is redundant/
-
+	runpb "cloud.google.com/go/run/apiv2/runpb" // MATCH /Import alias "runpb" is redundant/
 )
 
 func UseRunpb() {


### PR DESCRIPTION
related with: #936 

I think we should change definition of redundant alias, because import like this:

import apiv2 "cloud.google.com/go/run/apiv2" is ok i one condition: when alias apiv2 is used min one time in code below import, otherwise is redundant because is not used

of course this rule checks only imports with aliases, imports without aliases are ignored in this rule :)