### PR TITLE
unhandled-error: use full function name in error message

### DIFF
--- a/rule/unhandled-error.go
+++ b/rule/unhandled-error.go
@@ -119,7 +119,7 @@ func (w *lintUnhandledErrors) addFailure(n *ast.CallExpr) {
 		Category:   "bad practice",
 		Confidence: 1,
 		Node:       n,
-		Failure:    fmt.Sprintf("Unhandled error in call to function %v", gofmt(n.Fun)),
+		Failure:    fmt.Sprintf("Unhandled error in call to function %v", name),
 	})
 }
 

--- a/testdata/unhandled-error-w-ignorelist.go
+++ b/testdata/unhandled-error-w-ignorelist.go
@@ -87,10 +87,3 @@ func testCase5() {
 	s2.reterr()  // ignore
 	s2.reterr1() // MATCH /Unhandled error in call to function fixtures.unhandledErrorStruct2.reterr1/
 }
-
-func testCase6() {
-	f := func() error {
-		return nil
-	}
-	f() // MATCH /Unhandled error in call to function f/
-}

--- a/testdata/unhandled-error-w-ignorelist.go
+++ b/testdata/unhandled-error-w-ignorelist.go
@@ -87,3 +87,10 @@ func testCase5() {
 	s2.reterr()  // ignore
 	s2.reterr1() // MATCH /Unhandled error in call to function fixtures.unhandledErrorStruct2.reterr1/
 }
+
+func testCase6() {
+	f := func() error {
+		return nil
+	}
+	f() // MATCH /Unhandled error in call to function f/
+}

--- a/testdata/unhandled-error-w-ignorelist.go
+++ b/testdata/unhandled-error-w-ignorelist.go
@@ -56,7 +56,7 @@ func testCase4() {
 	b1.Write(nil) // ignore
 	b2.Write(nil) // ignore
 
-	b2.Read([]byte("bytes")) // MATCH /Unhandled error in call to function b2.Read/
+	b2.Read([]byte("bytes")) // MATCH /Unhandled error in call to function bytes.Buffer.Read/
 }
 
 type unhandledErrorStruct1 struct {
@@ -81,9 +81,9 @@ func testCase5() {
 	// fixtures\.unhandledErrorStruct2\.reterr
 	s1 := unhandledErrorStruct1{}
 	_ = s1.reterr()
-	s1.reterr() // MATCH /Unhandled error in call to function s1.reterr/
+	s1.reterr() // MATCH /Unhandled error in call to function fixtures.unhandledErrorStruct1.reterr/
 
 	s2 := unhandledErrorStruct2{}
 	s2.reterr()  // ignore
-	s2.reterr1() // MATCH /Unhandled error in call to function s2.reterr1/
+	s2.reterr1() // MATCH /Unhandled error in call to function fixtures.unhandledErrorStruct2.reterr1/
 }


### PR DESCRIPTION
<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

This PR updates the error message used by the `unhandled-error` rule to use
the full function name. The full function name matches the name used to
evaluate ignored functions in the configuration, therefore it's friendlier to
users to wish to configure an exlusion based on an error message.

The error message is sufficiently covered by existing tests, which are updated
in this PR.

Closes: #961
