### PR TITLE
feat: capitalise var naming to IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ vendor
 *.swp
 dist/
 *.log
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 *.swp
 dist/
 *.log
+.vscode

--- a/lint/utils.go
+++ b/lint/utils.go
@@ -71,6 +71,10 @@ func Name(name string, whitelist, blacklist []string) (should string) {
 			if w == 0 && unicode.IsLower(runes[w]) {
 				u = strings.ToLower(u)
 			}
+			// Keep lowercase s for IDs
+			if u == "IDS" {
+				u = "IDs"
+			}
 			// All the common initialisms are ASCII,
 			// so we can replace the bytes exactly.
 			copy(runes[w:], []rune(u))
@@ -99,6 +103,7 @@ var commonInitialisms = map[string]bool{
 	"HTTP":  true,
 	"HTTPS": true,
 	"ID":    true,
+	"IDS":   true,
 	"IP":    true,
 	"JSON":  true,
 	"LHS":   true,

--- a/testdata/var-naming.go
+++ b/testdata/var-naming.go
@@ -2,6 +2,7 @@ package fixtures
 
 func foo() string {
 	customId := "result"
-	customVm := "result" // MATCH /var customVm should be customVM/
+	customVm := "result"  // MATCH /var customVm should be customVM/
+	customIds := "result" // MATCH /var customIds should be customIDs/
 	return customId
 }


### PR DESCRIPTION
`var-naming` does not check that ID is capitalised when it is plural such as IDs. For example if I have `uIds := []string{}` it will allow this var name where really it should return var `uIds should be uIDs`.

Closes #947