### PR TITLE
Check function literals in `unused-param`

### DIFF
--- a/rule/unused-param.go
+++ b/rule/unused-param.go
@@ -87,54 +87,64 @@ type lintUnusedParamRule struct {
 }
 
 func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
+	var (
+		funcType *ast.FuncType
+		funcBody *ast.BlockStmt
+	)
 	switch n := node.(type) {
+	case *ast.FuncLit:
+		funcType = n.Type
+		funcBody = n.Body
 	case *ast.FuncDecl:
-		params := retrieveNamedParams(n.Type.Params)
-		if len(params) < 1 {
-			return nil // skip, func without parameters
-		}
-
 		if n.Body == nil {
-			return nil // skip, is a function prototype
+			return w // skip, is a function prototype
 		}
 
-		// inspect the func body looking for references to parameters
-		fselect := func(n ast.Node) bool {
-			ident, isAnID := n.(*ast.Ident)
-
-			if !isAnID {
-				return false
-			}
-
-			_, isAParam := params[ident.Obj]
-			if isAParam {
-				params[ident.Obj] = false // mark as used
-			}
-
-			return false
-		}
-		_ = pick(n.Body, fselect)
-
-		for _, p := range n.Type.Params.List {
-			for _, n := range p.Names {
-				if w.allowRegex.FindStringIndex(n.Name) != nil {
-					continue
-				}
-				if params[n.Obj] {
-					w.onFailure(lint.Failure{
-						Confidence: 1,
-						Node:       n,
-						Category:   "bad practice",
-						Failure:    fmt.Sprintf(w.failureMsg, n.Name),
-					})
-				}
-			}
-		}
-
-		return nil // full method body already inspected
+		funcType = n.Type
+		funcBody = n.Body
+	default:
+		return w // skip, not a function
 	}
 
-	return w
+	params := retrieveNamedParams(funcType.Params)
+	if len(params) < 1 {
+		return w // skip, func without parameters
+	}
+
+	// inspect the func body looking for references to parameters
+	fselect := func(n ast.Node) bool {
+		ident, isAnID := n.(*ast.Ident)
+
+		if !isAnID {
+			return false
+		}
+
+		_, isAParam := params[ident.Obj]
+		if isAParam {
+			params[ident.Obj] = false // mark as used
+		}
+
+		return false
+	}
+	_ = pick(funcBody, fselect)
+
+	for _, p := range funcType.Params.List {
+		for _, n := range p.Names {
+			if w.allowRegex.FindStringIndex(n.Name) != nil {
+				continue
+			}
+			if params[n.Obj] {
+				w.onFailure(lint.Failure{
+					Confidence: 1,
+					Node:       n,
+					Category:   "bad practice",
+					Failure:    fmt.Sprintf(w.failureMsg, n.Name),
+				})
+			}
+		}
+	}
+
+	return w // full method body was inspected
 }
 
 func retrieveNamedParams(params *ast.FieldList) map[*ast.Object]bool {

--- a/rule/unused-param.go
+++ b/rule/unused-param.go
@@ -97,7 +97,7 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 		funcBody = n.Body
 	case *ast.FuncDecl:
 		if n.Body == nil {
-			return w // skip, is a function prototype
+			return nil // skip, is a function prototype
 		}
 
 		funcType = n.Type

--- a/testdata/unused-param.go
+++ b/testdata/unused-param.go
@@ -166,3 +166,15 @@ func encodeFixed64Rpc(dAtA []byte, offset int, v uint64, i int) int {
 
 	return 8
 }
+
+func innerAnonymousFunctionWithoutUsage() {
+	innerFunc := func(a int) {} // MATCH /parameter 'a' seems to be unused, consider removing or renaming it as _/
+	innerFunc(1)
+}
+
+func innerAnonymousFunctionWithUsage() {
+	innerFunc := func(a int) {
+		a += 1
+	}
+	innerFunc(1)
+}

--- a/testdata/unused-param.go
+++ b/testdata/unused-param.go
@@ -177,4 +177,8 @@ func innerAnonymousFunctionWithUsage() {
 		a += 1
 	}
 	innerFunc(1)
+
+	return someFunc(func(values []int) float64 { // MATCH /parameter 'values' seems to be unused, consider removing or renaming it as _/
+		return 1.1
+	})
 }


### PR DESCRIPTION
Closes #965

See #965 for the motivation behind this PR.

- [X] Added tests
- [X] I believe this code follows the existing style, but if this could be improved I'm very open to any feedback
- [x] Passes CI

This does potentially significantly change the performance of this rule because we will now walk into the function bodies. If we are concerned about a performance regression here I think an alternative could be to either add a new rule or add a configuration to the rule to gate checking anonymous functions.
