### PR TITLE
fix: add enforce-repeated-arg-type-style in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,7 @@ var allRules = append([]lint.Rule{
 	&rule.RedundantImportAlias{},
 	&rule.ImportAliasNamingRule{},
 	&rule.EnforceMapStyleRule{},
+	&rule.EnforceRepeatedArgTypeStyleRule{},
 	&rule.EnforceSliceStyleRule{},
 	&rule.MaxControlNestingRule{},
 }, defaultRules...)


### PR DESCRIPTION
Related to #953
Related to https://github.com/golangci/golangci-lint/issues/4353