### PR TITLE
enforce-slice-style: Support nil declaration enforcement

### DIFF
--- a/test/enforce-slice-style_test.go
+++ b/test/enforce-slice-style_test.go
@@ -22,3 +22,9 @@ func TestEnforceSliceStyle_literal(t *testing.T) {
 		Arguments: []any{"literal"},
 	})
 }
+
+func TestEnforceSliceStyle_nil(t *testing.T) {
+	testRule(t, "enforce-slice-style-nil", &rule.EnforceSliceStyleRule{}, &lint.RuleConfig{
+		Arguments: []any{"nil"},
+	})
+}

--- a/testdata/enforce-slice-style-any.go
+++ b/testdata/enforce-slice-style-any.go
@@ -9,6 +9,7 @@ func somefn() {
 	m5 := []string{"v1", "v2"}
 	m6 := [8]string{}
 	m7 := [...]string{}
+	var m8 []string
 
 	_ = m0
 	_ = m1
@@ -18,6 +19,7 @@ func somefn() {
 	_ = m5
 	_ = m6
 	_ = m7
+	_ = m8
 }
 
 type Slice []string
@@ -29,6 +31,7 @@ func somefn2() {
 	m3 := make(Slice, 0, 0)
 	m4 := Slice{}
 	m5 := Slice{"v1", "v2"}
+	var m6 Slice
 
 	_ = m0
 	_ = m1
@@ -36,6 +39,7 @@ func somefn2() {
 	_ = m3
 	_ = m4
 	_ = m5
+	_ = m6
 }
 
 type SliceSlice Slice
@@ -47,6 +51,7 @@ func somefn3() {
 	m3 := make(SliceSlice, 0, 0)
 	m4 := SliceSlice{}
 	m5 := SliceSlice{"v1", "v2"}
+	var m6 SliceSlice
 
 	_ = m0
 	_ = m1
@@ -54,6 +59,7 @@ func somefn3() {
 	_ = m3
 	_ = m4
 	_ = m5
+	_ = m6
 }
 
 func somefn4() {
@@ -64,6 +70,7 @@ func somefn4() {
 	m1["el3"] = make([]string, 0, 0)
 	m1["el4"] = []string{}
 	m1["el5"] = []string{"v1", "v2"}
+	m1["el6"] = nil
 
 	_ = m1
 }

--- a/testdata/enforce-slice-style-literal.go
+++ b/testdata/enforce-slice-style-literal.go
@@ -9,6 +9,7 @@ func somefn() {
 	m5 := []string{"v1", "v2"}
 	m6 := [8]string{}
 	m7 := [...]string{}
+	var m8 []string
 
 	_ = m0
 	_ = m1
@@ -18,6 +19,7 @@ func somefn() {
 	_ = m5
 	_ = m6
 	_ = m7
+	_ = m8
 }
 
 type Slice []string
@@ -29,6 +31,7 @@ func somefn2() {
 	m3 := make(Slice, 0, 0) // MATCH /use []type{} instead of make([]type, 0) (or declare nil slice)/
 	m4 := Slice{}
 	m5 := Slice{"v1", "v2"}
+	var m6 Slice
 
 	_ = m0
 	_ = m1
@@ -36,6 +39,7 @@ func somefn2() {
 	_ = m3
 	_ = m4
 	_ = m5
+	_ = m6
 }
 
 type SliceSlice Slice
@@ -47,6 +51,7 @@ func somefn3() {
 	m3 := make(SliceSlice, 0, 0) // MATCH /use []type{} instead of make([]type, 0) (or declare nil slice)/
 	m4 := SliceSlice{}
 	m5 := SliceSlice{"v1", "v2"}
+	var m6 SliceSlice
 
 	_ = m0
 	_ = m1
@@ -54,6 +59,7 @@ func somefn3() {
 	_ = m3
 	_ = m4
 	_ = m5
+	_ = m6
 }
 
 func somefn4() {
@@ -64,6 +70,7 @@ func somefn4() {
 	m1["el3"] = make([]string, 0, 0) // MATCH /use []type{} instead of make([]type, 0) (or declare nil slice)/
 	m1["el4"] = []string{}
 	m1["el5"] = []string{"v1", "v2"}
+	m1["el6"] = nil
 
 	_ = m1
 }

--- a/testdata/enforce-slice-style-make.go
+++ b/testdata/enforce-slice-style-make.go
@@ -9,6 +9,7 @@ func somefn() {
 	m5 := []string{"v1", "v2"}
 	m6 := [8]string{}
 	m7 := [...]string{}
+	var m8 []string
 
 	_ = m0
 	_ = m1
@@ -18,6 +19,7 @@ func somefn() {
 	_ = m5
 	_ = m6
 	_ = m7
+	_ = m8
 }
 
 type Slice []string
@@ -29,6 +31,7 @@ func somefn2() {
 	m3 := make(Slice, 0, 0)
 	m4 := Slice{} // MATCH /use make([]type) instead of []type{} (or declare nil slice)/
 	m5 := Slice{"v1", "v2"}
+	var m6 Slice
 
 	_ = m0
 	_ = m1
@@ -36,6 +39,7 @@ func somefn2() {
 	_ = m3
 	_ = m4
 	_ = m5
+	_ = m6
 }
 
 type SliceSlice Slice
@@ -47,6 +51,7 @@ func somefn3() {
 	m3 := make(SliceSlice, 0, 0)
 	m4 := SliceSlice{} // MATCH /use make([]type) instead of []type{} (or declare nil slice)/
 	m5 := SliceSlice{"v1", "v2"}
+	var m6 SliceSlice
 
 	_ = m0
 	_ = m1
@@ -54,6 +59,7 @@ func somefn3() {
 	_ = m3
 	_ = m4
 	_ = m5
+	_ = m6
 }
 
 func somefn4() {
@@ -64,6 +70,7 @@ func somefn4() {
 	m1["el3"] = make([]string, 0, 0)
 	m1["el4"] = []string{} // MATCH /use make([]type) instead of []type{} (or declare nil slice)/
 	m1["el5"] = []string{"v1", "v2"}
+	m1["el6"] = nil
 
 	_ = m1
 }

--- a/testdata/enforce-slice-style-nil.go
+++ b/testdata/enforce-slice-style-nil.go
@@ -1,0 +1,92 @@
+package fixtures
+
+func somefn() {
+	m0 := make([]string, 10)
+	m1 := make([]string, 0, 10)
+	m2 := make([]string, 0)    // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	m3 := make([]string, 0, 0) // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	m4 := []string{}           // MATCH /use nil slice declaration (e.g. var args []type) instead of []type{}/
+	m5 := []string{"v1", "v2"}
+	m6 := [8]string{}
+	m7 := [...]string{}
+	var m8 []string
+
+	_ = m0
+	_ = m1
+	_ = m2
+	_ = m3
+	_ = m4
+	_ = m5
+	_ = m6
+	_ = m7
+	_ = m8
+}
+
+type Slice []string
+
+func somefn2() {
+	m0 := make(Slice, 10)
+	m1 := make(Slice, 0, 10)
+	m2 := make(Slice, 0)    // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	m3 := make(Slice, 0, 0) // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	m4 := Slice{}           // MATCH /use nil slice declaration (e.g. var args []type) instead of []type{}/
+	m5 := Slice{"v1", "v2"}
+	var m6 Slice
+
+	_ = m0
+	_ = m1
+	_ = m2
+	_ = m3
+	_ = m4
+	_ = m5
+	_ = m6
+}
+
+type SliceSlice Slice
+
+func somefn3() {
+	m0 := make(SliceSlice, 10)
+	m1 := make(SliceSlice, 0, 10)
+	m2 := make(SliceSlice, 0)    // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	m3 := make(SliceSlice, 0, 0) // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	m4 := SliceSlice{}           // MATCH /use nil slice declaration (e.g. var args []type) instead of []type{}/
+	m5 := SliceSlice{"v1", "v2"}
+	var m6 SliceSlice
+
+	_ = m0
+	_ = m1
+	_ = m2
+	_ = m3
+	_ = m4
+	_ = m5
+	_ = m6
+}
+
+func somefn4() {
+	m1 := [][]string{} // MATCH /use nil slice declaration (e.g. var args []type) instead of []type{}/
+	m1["el0"] = make([]string, 10)
+	m1["el1"] = make([]string, 0, 10)
+	m1["el2"] = make([]string, 0)    // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	m1["el3"] = make([]string, 0, 0) // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	m1["el4"] = []string{}           // MATCH /use nil slice declaration (e.g. var args []type) instead of []type{}/
+	m1["el5"] = []string{"v1", "v2"}
+	m1["el6"] = nil
+
+	_ = m1
+}
+
+func somefn5() {
+	afunc([]string{})        // MATCH /use nil slice declaration (e.g. var args []type) instead of []type{}/
+	afunc(make([]string, 0)) // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	afunc([]string(nil))
+}
+
+func somefn6() {
+	type s struct {
+		a []string
+	}
+	s1 = s{a: []string{}}        // MATCH /use nil slice declaration (e.g. var args []type) instead of []type{}/
+	s2 = s{a: make([]string, 0)} // MATCH /use nil slice declaration (e.g. var args []type) instead of make([]type, 0)/
+	s3 = s{}
+	s4 = s{a: nil}
+}


### PR DESCRIPTION
Add support for enforcing nil slice declarations as recommended by both the Go Code Review and Uber style guides.

This initial version is quite strict in that it also prevents using empty literal and make-style slices in struct assignments and as function arguments.

<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
Closes #971 