### PR TITLE
Remove added colon in `comment-spacings` rule

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -182,15 +182,16 @@ _Description_: Spots comments of the form:
 
 _Configuration_: ([]string) list of exceptions. For example, to accept comments of the form
 ```go
+//mypragma: activate something
 //+optional
 ```
-You need to add `"+optional"` in the configuration
+You need to add both `"mypragma:"` and `"+optional"` in the configuration
 
 Example:
 
 ```toml
 [rule.comment-spacings]
-  arguments =["+optional", "foo:"]
+  arguments =["mypragma:", "+optional"]
 ```
 ## confusing-naming
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -182,15 +182,15 @@ _Description_: Spots comments of the form:
 
 _Configuration_: ([]string) list of exceptions. For example, to accept comments of the form
 ```go
-//mypragma: activate something
+//+optional
 ```
-You need to add `"mypragma"` in the configuration
+You need to add `"+optional"` in the configuration
 
 Example:
 
 ```toml
 [rule.comment-spacings]
-  arguments =["mypragma","otherpragma"]
+  arguments =["+optional", "foo:"]
 ```
 ## confusing-naming
 

--- a/rule/comment-spacings.go
+++ b/rule/comment-spacings.go
@@ -31,7 +31,7 @@ func (r *CommentSpacingsRule) configure(arguments lint.Arguments) {
 			if !ok {
 				panic(fmt.Sprintf("invalid argument %v for %s; expected string but got %T", arg, r.Name(), arg))
 			}
-			r.allowList = append(r.allowList, `//`+allow+`:`)
+			r.allowList = append(r.allowList, `//`+allow)
 		}
 	}
 }

--- a/test/comment-spacings_test.go
+++ b/test/comment-spacings_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestCommentSpacings(t *testing.T) {
 	testRule(t, "comment-spacings", &rule.CommentSpacingsRule{}, &lint.RuleConfig{
-		Arguments: []any{"myOwnDirective"}},
+		Arguments: []any{"myOwnDirective:", "+optional"}},
 	)
 }

--- a/testdata/comment-spacings.go
+++ b/testdata/comment-spacings.go
@@ -42,3 +42,8 @@ Should be valid
 
 //nolint:staticcheck // nolint should be in the default list of acceptable comments.
 var b string
+
+type c struct {
+	//+optional
+	d *int `json:"d,omitempty"`
+}


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
**Please, describe in details what's your motivation for this PR:**

 Some projects like Kubebuilder have markers that do not follow the pattern //name:, e.g.: //+optional. Due to a colon added at the end of the values when parsing the arguments, revive complains about comments starting with the marker even if one adds it as an exception.

**Did you add tests?**

The current tests are still valid with the changes.

**Does your code follow the coding style of the rest of the repository?**

Yes.

<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
Closes #980 