### PR TITLE
more precise regular expression for directive comments

### DIFF
--- a/rule/utils.go
+++ b/rule/utils.go
@@ -166,7 +166,7 @@ func checkNumberOfArguments(expected int, args lint.Arguments, ruleName string) 
 	}
 }
 
-var directiveCommentRE = regexp.MustCompile("//(line |extern |export |[a-z0-9]+:[a-z0-9])") // see https://go-review.googlesource.com/c/website/+/442516/1..2/_content/doc/comment.md#494
+var directiveCommentRE = regexp.MustCompile("^//(line |extern |export |[a-z0-9]+:[a-z0-9])") // see https://go-review.googlesource.com/c/website/+/442516/1..2/_content/doc/comment.md#494
 
 func isDirectiveComment(line string) bool {
 	return directiveCommentRE.MatchString(line)

--- a/testdata/comment-spacings.go
+++ b/testdata/comment-spacings.go
@@ -52,3 +52,6 @@ type c struct {
 //export MyFunction
 
 //nolint:gochecknoglobals
+
+//this is a regular command that's incorrectly formatted //nolint:foobar // because one two three
+// MATCH:56 /no space between comment delimiter and comment text/


### PR DESCRIPTION
Improves regular expression for handling cases like 

`//this is a regular command that's incorrectly formatted //nolint:foobar // because one two three` 


