### PR TITLE
Fix a performance regression #995

### DIFF
--- a/lint/config.go
+++ b/lint/config.go
@@ -1,5 +1,9 @@
 package lint
 
+import (
+	goversion "github.com/hashicorp/go-version"
+)
+
 // Arguments is type used for the arguments of a rule.
 type Arguments = []interface{}
 
@@ -61,4 +65,7 @@ type Config struct {
 	WarningCode           int              `toml:"warningCode"`
 	Directives            DirectivesConfig `toml:"directive"`
 	Exclude               []string         `toml:"exclude"`
+	// If set, overrides the go language version specified in go.mod of
+	// packages being linted, and assumes this specific language version.
+	GoVersion *goversion.Version
 }

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -69,6 +69,10 @@ func (l *Linter) Lint(packages [][]string, ruleSet []Rule, config Config) (<-cha
 		if len(files) == 0 {
 			continue
 		}
+		if config.GoVersion != nil {
+			perPkgVersions[n] = config.GoVersion
+			continue
+		}
 
 		dir, err := filepath.Abs(filepath.Dir(files[0]))
 		if err != nil {


### PR DESCRIPTION
* Support go workspaces when detecting the go version.
* Do not invoke go list for every package.

Closes  #995