### PR TITLE
Rule optimize-operands-order: do not consider built-in len as a caller

### DIFF
--- a/rule/optimize-operands-order.go
+++ b/rule/optimize-operands-order.go
@@ -49,8 +49,17 @@ func (w lintOptimizeOperandsOrderlExpr) Visit(node ast.Node) ast.Visitor {
 	}
 
 	isCaller := func(n ast.Node) bool {
-		_, ok := n.(*ast.CallExpr)
-		return ok
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+
+		ident, isIdent := ce.Fun.(*ast.Ident)
+		if !isIdent {
+			return true
+		}
+
+		return ident.Name != "len" || ident.Obj != nil
 	}
 
 	// check if the left sub-expression contains a function call

--- a/testdata/optimize-operands-order.go
+++ b/testdata/optimize-operands-order.go
@@ -27,6 +27,20 @@ func conditionalExpr(x, y bool) bool {
 	return caller(x, y) && y                         // MATCH /for better performance 'caller(x, y) && y' might be rewritten as 'y && caller(x, y)'/
 }
 
+func conditionalExprSlice(s []string) bool {
+	if len(s) > 0 || s[0] == "" { // should not match, not safe
+		return false
+	}
+
+	f := func() bool {
+		len(s) > 1
+	}
+
+	if f() || s[0] == "test" { // MATCH /for better performance 'f() || s[0] == "test"' might be rewritten as 's[0] == "test" || f()'/
+		return true
+	}
+}
+
 func caller(x, y bool) bool {
 	return true
 }


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->
Fixes: https://github.com/mgechev/revive/issues/1004

Update rule `optimize-operands-order`, `isCaller` logic to not consider built-in function `len` as a caller. 

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
Closes #1004 