### PR TITLE
fix(1007): return Sel.Name as FuncName when selector is an CallExpr

### DIFF
--- a/rule/add-constant.go
+++ b/rule/add-constant.go
@@ -53,7 +53,7 @@ func (r *AddConstantRule) Apply(file *lint.File, arguments lint.Arguments) []lin
 		onFailure:       onFailure,
 		strLits:         make(map[string]int),
 		strLitLimit:     r.strLitLimit,
-		allowList:        r.allowList,
+		allowList:       r.allowList,
 		ignoreFunctions: r.ignoreFunctions,
 		structTags:      make(map[*ast.BasicLit]struct{}),
 	}
@@ -72,7 +72,7 @@ type lintAddConstantRule struct {
 	onFailure       func(lint.Failure)
 	strLits         map[string]int
 	strLitLimit     int
-	allowList        allowList
+	allowList       allowList
 	ignoreFunctions []*regexp.Regexp
 	structTags      map[*ast.BasicLit]struct{}
 }
@@ -127,6 +127,11 @@ func (*lintAddConstantRule) getFuncName(expr *ast.CallExpr) string {
 		switch prefix := f.X.(type) {
 		case *ast.Ident:
 			return prefix.Name + "." + f.Sel.Name
+		case *ast.CallExpr:
+			// If the selector is an CallExpr, like `fn().Info`, we return `.Info` as function name
+			if f.Sel != nil {
+				return "." + f.Sel.Name
+			}
 		}
 	case *ast.Ident:
 		return f.Name

--- a/test/add-constant_test.go
+++ b/test/add-constant_test.go
@@ -13,7 +13,7 @@ func TestAddConstant(t *testing.T) {
 		"allowStrs":   "\"\"",
 		"allowInts":   "0,1,2",
 		"allowFloats": "0.0,1.0",
-		"ignoreFuncs": "os\\.(CreateFile|WriteFile|Chmod|FindProcess),\\.Println,ignoredFunc",
+		"ignoreFuncs": "os\\.(CreateFile|WriteFile|Chmod|FindProcess),\\.Println,ignoredFunc,\\.Info",
 	}}
 
 	testRule(t, "add-constant", &rule.AddConstantRule{}, &lint.RuleConfig{

--- a/testdata/add-constant.go
+++ b/testdata/add-constant.go
@@ -1,9 +1,24 @@
 package fixtures
 
 import (
+	"context"
 	"fmt"
 	"os"
 )
+
+type testLogger struct{}
+
+func (l *testLogger) Info(ctx context.Context, msg string) {}
+
+func getLogger() *testLogger {
+	return &testLogger{}
+}
+
+func test1007() {
+	getLogger().Info(context.Background(), "test1007")
+	getLogger().Info(context.Background(), "test1007")
+	getLogger().Info(context.Background(), "test1007")
+}
 
 func foo(a float32, b string, c any, d int) {
 	a = 1.0 // ignore


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

Fix: https://github.com/mgechev/revive/issues/1007

When the func selector is an callexpr, for example:

`getLogger().Info(context.Background(), "test1007")`

it will return empty string as function name, so ingoreFuncs will not take affect, this fixed change it to return `Sel.Name`

