### PR TITLE
fix: goreleaser uses unknown flag: `--rm-dist` 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Problem:

```
Run goreleaser/goreleaser-action@v2
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.1.0/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/c41b664f-359e-4cdb-b355-4bb23158e448 -f /home/runner/work/_temp/5e7de14d-460b-41c5-a406-e2cf60039cc8
GoReleaser latest installed successfully
v1.3.8 tag found for commit '7ef710a'
/opt/hostedtoolcache/goreleaser-action/2.1.0/x64/goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.1.0/x64/goreleaser' failed with exit code 1
```

See: https://goreleaser.com/deprecations/#-rm-dist

>--rm-dist[¶](https://goreleaser.com/deprecations/#-rm-dist)
>
>    since 2023-01-17 (v1.15.0), removed 2024-05-26 (v2.0)
>
>--rm-dist has been deprecated in favor of --clean.