### PR TITLE
check param, result, type param of function in redefines-builtin-id rule

### DIFF
--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -158,11 +158,15 @@ func (w *lintRedefinesBuiltinID) Visit(node ast.Node) ast.Visitor {
 		}
 		for _, field := range fields {
 			for _, name := range field.Names {
-				if obj := name.Obj; obj != nil && (obj.Kind == ast.Var || obj.Kind == ast.Typ) {
-					id := obj.Name
-					if ok, bt := w.isBuiltIn(id); ok {
-						w.addFailure(name, fmt.Sprintf("redefinition of the built-in %s %s", bt, id))
-					}
+				obj := name.Obj
+				isTypeOrName := obj != nil && (obj.Kind == ast.Var || obj.Kind == ast.Typ)
+				if !isTypeOrName {
+					continue
+				}
+				
+				id := obj.Name
+				if ok, bt := w.isBuiltIn(id); ok {
+					w.addFailure(name, fmt.Sprintf("redefinition of the built-in %s %s", bt, id))
 				}
 			}
 		}

--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -138,12 +138,10 @@ func (w *lintRedefinesBuiltinID) Visit(node ast.Node) ast.Visitor {
 		}
 		for _, field := range fields {
 			for _, name := range field.Names {
-				if obj := name.Obj; obj != nil {
-					if obj.Kind == ast.Var || obj.Kind == ast.Typ {
-						id := obj.Name
-						if ok, bt := w.isBuiltIn(id); ok {
-							w.addFailure(name, fmt.Sprintf("redefinition of the built-in %s %s", bt, id))
-						}
+				if obj := name.Obj; obj != nil && (obj.Kind == ast.Var || obj.Kind == ast.Typ) {
+					id := obj.Name
+					if ok, bt := w.isBuiltIn(id); ok {
+						w.addFailure(name, fmt.Sprintf("redefinition of the built-in %s %s", bt, id))
 					}
 				}
 			}

--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -125,6 +125,29 @@ func (w *lintRedefinesBuiltinID) Visit(node ast.Node) ast.Visitor {
 		if ok, bt := w.isBuiltIn(id); ok {
 			w.addFailure(n, fmt.Sprintf("redefinition of the built-in %s %s", bt, id))
 		}
+	case *ast.FuncType:
+		var fields []*ast.Field
+		if n.TypeParams != nil {
+			fields = append(fields, n.TypeParams.List...)
+		}
+		if n.Params != nil {
+			fields = append(fields, n.Params.List...)
+		}
+		if n.Results != nil {
+			fields = append(fields, n.Results.List...)
+		}
+		for _, field := range fields {
+			for _, name := range field.Names {
+				if obj := name.Obj; obj != nil {
+					if obj.Kind == ast.Var || obj.Kind == ast.Typ {
+						id := obj.Name
+						if ok, bt := w.isBuiltIn(id); ok {
+							w.addFailure(name, fmt.Sprintf("redefinition of the built-in %s %s", bt, id))
+						}
+					}
+				}
+			}
+		}
 	case *ast.AssignStmt:
 		for _, e := range n.Lhs {
 			id, ok := e.(*ast.Ident)

--- a/testdata/redefines-builtin-id.go
+++ b/testdata/redefines-builtin-id.go
@@ -32,3 +32,14 @@ var i, copy int // MATCH /redefinition of the built-in function copy/
 
 // issue #792
 type ()
+
+func foo1(new int) { // MATCH /redefinition of the built-in function new/
+	_ = new
+}
+
+func foo2() (new int) { // MATCH /redefinition of the built-in function new/
+	return
+}
+
+func foo3[new any]() { // MATCH /redefinition of the built-in function new/
+}


### PR DESCRIPTION
Close #1022 

Currently, function related variables (param, result, and type param) are not checked by `redefines-builtin-id rule`.
It would be nice if revive reports `redefinition of the built-in ...` errors for function related variables.

<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
