### PR TITLE
check clear/max/min in redefines-builtin-id rule on go1.21+

### DIFF
--- a/lint/package.go
+++ b/lint/package.go
@@ -33,6 +33,7 @@ var (
 	falseValue = 2
 	notSet     = 3
 
+	go121 = goversion.Must(goversion.NewVersion("1.21"))
 	go122 = goversion.Must(goversion.NewVersion("1.22"))
 )
 
@@ -192,6 +193,11 @@ func (p *Package) lint(rules []Rule, config Config, failures chan Failure) {
 		})(file)
 	}
 	wg.Wait()
+}
+
+// IsAtLeastGo121 returns true if the Go version for this package is 1.21 or higher, false otherwise
+func (p *Package) IsAtLeastGo121() bool {
+	return p.goVersion.GreaterThanOrEqual(go121)
 }
 
 // IsAtLeastGo122 returns true if the Go version for this package is 1.22 or higher, false otherwise

--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"maps"
 
 	"github.com/mgechev/revive/lint"
 )
@@ -31,6 +32,12 @@ var builtFunctions = map[string]bool{
 	"println": true,
 	"real":    true,
 	"recover": true,
+}
+
+var builtFunctionsAfterGo121 = map[string]bool{
+	"clear": true,
+	"max":   true,
+	"min":   true,
 }
 
 var builtInTypes = map[string]bool{
@@ -69,7 +76,17 @@ func (*RedefinesBuiltinIDRule) Apply(file *lint.File, _ lint.Arguments) []lint.F
 	}
 
 	astFile := file.AST
-	w := &lintRedefinesBuiltinID{onFailure}
+
+	builtFuncs := maps.Clone(builtFunctions)
+	if file.Pkg.IsAtLeastGo121() {
+		maps.Copy(builtFuncs, builtFunctionsAfterGo121)
+	}
+	w := &lintRedefinesBuiltinID{
+		onFailure:           onFailure,
+		builtInConstAndVars: builtInConstAndVars,
+		builtFunctions:      builtFuncs,
+		builtInTypes:        builtInTypes,
+	}
 	ast.Walk(w, astFile)
 
 	return failures
@@ -81,7 +98,10 @@ func (*RedefinesBuiltinIDRule) Name() string {
 }
 
 type lintRedefinesBuiltinID struct {
-	onFailure func(lint.Failure)
+	onFailure           func(lint.Failure)
+	builtInConstAndVars map[string]bool
+	builtFunctions      map[string]bool
+	builtInTypes        map[string]bool
 }
 
 func (w *lintRedefinesBuiltinID) Visit(node ast.Node) ast.Visitor {
@@ -162,16 +182,16 @@ func (w lintRedefinesBuiltinID) addFailure(node ast.Node, msg string) {
 	})
 }
 
-func (lintRedefinesBuiltinID) isBuiltIn(id string) (r bool, builtInKind string) {
-	if builtFunctions[id] {
+func (w lintRedefinesBuiltinID) isBuiltIn(id string) (r bool, builtInKind string) {
+	if w.builtFunctions[id] {
 		return true, "function"
 	}
 
-	if builtInConstAndVars[id] {
+	if w.builtInConstAndVars[id] {
 		return true, "constant or variable"
 	}
 
-	if builtInTypes[id] {
+	if w.builtInTypes[id] {
 		return true, "type"
 	}
 

--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -182,7 +182,7 @@ func (w lintRedefinesBuiltinID) addFailure(node ast.Node, msg string) {
 	})
 }
 
-func (w lintRedefinesBuiltinID) isBuiltIn(id string) (r bool, builtInKind string) {
+func (w *lintRedefinesBuiltinID) isBuiltIn(id string) (r bool, builtInKind string) {
 	if w.builtFunctions[id] {
 		return true, "function"
 	}

--- a/testdata/redefines-builtin-id.go
+++ b/testdata/redefines-builtin-id.go
@@ -32,3 +32,12 @@ var i, copy int // MATCH /redefinition of the built-in function copy/
 
 // issue #792
 type ()
+
+func foo() {
+	clear := 0 // MATCH /redefinition of the built-in function clear/
+	max := 0   // MATCH /redefinition of the built-in function max/
+	min := 0   // MATCH /redefinition of the built-in function min/
+	_ = clear
+	_ = max
+	_ = min
+}


### PR DESCRIPTION
Close #1021 

go1.21 has introduced new functions `clear`, `max` and `min`.
It would be nice revive checks these functions in redefines-builtin-id rule on go1.21+.

<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the Travis build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
