### PR TITLE
fix #1029

### DIFF
--- a/rule/defer.go
+++ b/rule/defer.go
@@ -111,7 +111,7 @@ func (w lintDeferRule) Visit(node ast.Node) ast.Visitor {
 			// but it is very likely to be a misunderstanding of defer's behavior around arguments.
 			w.newFailure("recover must be called inside a deferred function, this is executing recover immediately", n, 1, "logic", "immediate-recover")
 		}
-
+		return nil // no need to analyze the arguments of the function call
 	case *ast.DeferStmt:
 		if isIdent(n.Call.Fun, "recover") {
 			// defer recover()

--- a/testdata/defer.go
+++ b/testdata/defer.go
@@ -47,3 +47,20 @@ func f() {
 		return nil
 	})
 }
+
+// Issue #1029
+func verify2(a any) func() {
+	return func() {
+		fn := a.(func() error)
+		if err := fn(); err != nil {
+			panic(err)
+		}
+	}
+
+}
+
+func mainf() {
+	defer verify2(func() error { // MATCH /prefer not to defer chains of function calls/
+		return nil
+	})()
+}


### PR DESCRIPTION
Closes #1029 by skipping the analysis of function call arguments
