### PR TITLE
docs: fix typo in comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please contribute to this repository if any of the following is true:
 Prerequisites:
 
 * Familiarity with [GitHub PRs](https://help.github.com/articles/using-pull-requests) (pull requests) and issues.
-* Knowledge of Go and familarity with static code analysis, or tech writing.
+* Knowledge of Go and familiarity with static code analysis, or tech writing.
 
 ## Submitting a Pull Request
 

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -203,7 +203,7 @@ func (w *lintExported) lintTypeDoc(t *ast.TypeSpec, doc *ast.CommentGroup) {
 			break
 		}
 	}
-	// if comment starts wih name of type and has some text after - it's ok
+	// if comment starts with name of type and has some text after - it's ok
 	expectedPrefix := t.Name.Name+" "
 	if strings.HasPrefix(s, expectedPrefix){
 		return

--- a/rule/import-alias-naming.go
+++ b/rule/import-alias-naming.go
@@ -68,7 +68,7 @@ func (r *ImportAliasNamingRule) Apply(file *lint.File, arguments lint.Arguments)
 		}
 
 		alias := is.Name
-		if alias == nil || alias.Name == "_" || alias.Name == "." { // "_" and "." are special types of import aiases and should be processed by another linter rule
+		if alias == nil || alias.Name == "_" || alias.Name == "." { // "_" and "." are special types of import aliases and should be processed by another linter rule
 			continue
 		}
 

--- a/rule/unchecked-type-assertion.go
+++ b/rule/unchecked-type-assertion.go
@@ -13,7 +13,7 @@ const (
 	ruleUTAMessageIgnored = "type assertion result ignored"
 )
 
-// UncheckedTypeAssertionRule lints missing or ignored `ok`-value in danymic type casts.
+// UncheckedTypeAssertionRule lints missing or ignored `ok`-value in dynamic type casts.
 type UncheckedTypeAssertionRule struct {
 	sync.Mutex
 	acceptIgnoredAssertionResult bool

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -140,7 +140,7 @@ type instruction struct {
 	Confidence  float64 // confidence level
 }
 
-// JSONInstruction structure used when we parse json object insted of classic MATCH string
+// JSONInstruction structure used when we parse json object instead of classic MATCH string
 type JSONInstruction struct {
 	Match      string  `json:"MATCH"`
 	Category   string  `json:"Category"`

--- a/testdata/comment-spacings.go
+++ b/testdata/comment-spacings.go
@@ -27,7 +27,7 @@ var a string
 Should be valid
 */
 
-//	Tabs between comment delimeter and comment text should be fine
+//	Tabs between comment delimiter and comment text should be fine
 
 // MATCH:34 /no space between comment delimiter and comment text/
 

--- a/testdata/exported-issue-1002.go
+++ b/testdata/exported-issue-1002.go
@@ -1,7 +1,7 @@
 // Package golint comment
 package golint
 
-// by default code bellow is valid,
+// by default code below is valid,
 // but if checkPublicInterface is switched on - it should check documentation in interfaces
 
 // Some - some interface

--- a/testdata/unchecked-type-assertion-accept-ignored.go
+++ b/testdata/unchecked-type-assertion-accept-ignored.go
@@ -3,7 +3,7 @@ package fixtures
 var foo any = "foo"
 
 func handleIgnoredIsOKByConfig() {
-	// No lint here bacuse `acceptIgnoredAssertionResult` is set to `true`
+	// No lint here because `acceptIgnoredAssertionResult` is set to `true`
 	r, _ := foo.(int)
 }
 


### PR DESCRIPTION
The PR corrects spelling mistakes in comments and docs.