### PR TITLE
Move away from deprecated github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.11.0
 	golang.org/x/mod v0.20.0
 	golang.org/x/tools v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/mgechev/revive/lint"
-	"github.com/pkg/errors"
 )
 
 func testRule(t *testing.T, filename string, rule lint.Rule, config ...*lint.RuleConfig) {
@@ -69,7 +68,7 @@ func assertFailures(t *testing.T, baseDir string, fi os.FileInfo, src []byte, ru
 
 	ins := parseInstructions(t, fi.Name(), src)
 	if ins == nil {
-		return errors.Errorf("Test file %v does not have instructions", fi.Name())
+		return fmt.Errorf("Test file %v does not have instructions", fi.Name())
 	}
 
 	ps, err := l.Lint([][]string{{fi.Name()}}, rules, lint.Config{


### PR DESCRIPTION
The PR replaces the package `github.com/pkg/errors` with native error wrapping.

The package [github.com/pkg/errors](https://github.com/pkg/errors) is archived from Dec 1, 2021 due to the existence of Go native error wrapping.
