### PR TITLE
adds tests for specific go versions

### DIFF
--- a/test/datarace_test.go
+++ b/test/datarace_test.go
@@ -9,3 +9,7 @@ import (
 func TestDatarace(t *testing.T) {
 	testRule(t, "datarace", &rule.DataRaceRule{})
 }
+
+func TestDataraceAfterGo1_22(t *testing.T) {
+	testRule(t, "go1.22/datarace", &rule.DataRaceRule{})
+}

--- a/test/file-filter_test.go
+++ b/test/file-filter_test.go
@@ -38,7 +38,7 @@ func TestFileExcludeFilterAtRuleLevel(t *testing.T) {
 
 	t.Run("not called if exclude not match", func(t *testing.T) {
 		rule := &TestFileFilterRule{}
-		cfg := &lint.RuleConfig{Exclude: []string{"file-to-exclude.go"}}
+		cfg := &lint.RuleConfig{Exclude: []string{"../testdata/file-to-exclude.go"}}
 		cfg.Initialize()
 		testRule(t, "file-to-exclude", rule, cfg)
 		if rule.WasApplyed {

--- a/test/golint_test.go
+++ b/test/golint_test.go
@@ -64,7 +64,7 @@ func TestAll(t *testing.T) {
 				t.Fatalf("Failed reading %s: %v", fi.Name(), err)
 			}
 
-			if err := assertFailures(t, baseDir, fileInfo, src, rules, map[string]lint.RuleConfig{}); err != nil {
+			if err := assertFailures(t, path.Dir(baseDir), fileInfo, src, rules, map[string]lint.RuleConfig{}); err != nil {
 				t.Errorf("Linting %s: %v", fi.Name(), err)
 			}
 		})

--- a/test/range-val-address_test.go
+++ b/test/range-val-address_test.go
@@ -10,3 +10,7 @@ import (
 func TestRangeValAddress(t *testing.T) {
 	testRule(t, "range-val-address", &rule.RangeValAddress{}, &lint.RuleConfig{})
 }
+
+func TestRangeValAddressAfterGo1_22(t *testing.T) {
+	testRule(t, "go1.22/range-val-address", &rule.RangeValAddress{}, &lint.RuleConfig{})
+}

--- a/test/range-val-in-closure_test.go
+++ b/test/range-val-in-closure_test.go
@@ -10,3 +10,7 @@ import (
 func TestRangeValInClosure(t *testing.T) {
 	testRule(t, "range-val-in-closure", &rule.RangeValInClosureRule{}, &lint.RuleConfig{})
 }
+
+func TestRangeValInClosureAfterGo1_22(t *testing.T) {
+	testRule(t, "go1.22/range-val-in-closure", &rule.RangeValInClosureRule{}, &lint.RuleConfig{})
+}

--- a/test/redefines-builtin-id_test.go
+++ b/test/redefines-builtin-id_test.go
@@ -10,3 +10,7 @@ import (
 func TestRedefinesBuiltinID(t *testing.T) {
 	testRule(t, "redefines-builtin-id", &rule.RedefinesBuiltinIDRule{})
 }
+
+func TestRedefinesBuiltinIDAfterGo1_21(t *testing.T) {
+	testRule(t, "go1.21/redefines-builtin-id", &rule.RedefinesBuiltinIDRule{})
+}

--- a/testdata/go.mod
+++ b/testdata/go.mod
@@ -1,0 +1,5 @@
+module github.com/mgechev/revive/testdata
+
+// set the lowest go version 
+// to trigger testing of all rules
+go 1.0

--- a/testdata/go1.21/go.mod
+++ b/testdata/go1.21/go.mod
@@ -1,0 +1,3 @@
+module github.com/mgechev/revive/testdata
+
+go 1.21

--- a/testdata/go1.21/redefines-builtin-id.go
+++ b/testdata/go1.21/redefines-builtin-id.go
@@ -34,9 +34,9 @@ var i, copy int // MATCH /redefinition of the built-in function copy/
 type ()
 
 func foo() {
-	clear := 0 // Shall not match /redefinition of the built-in function clear/
-	max := 0   // Shall not match /redefinition of the built-in function max/
-	min := 0   // Shall not match /redefinition of the built-in function min/
+	clear := 0 // MATCH /redefinition of the built-in function clear/
+	max := 0   // MATCH /redefinition of the built-in function max/
+	min := 0   // MATCH /redefinition of the built-in function min/
 	_ = clear
 	_ = max
 	_ = min

--- a/testdata/go1.22/datarace.go
+++ b/testdata/go1.22/datarace.go
@@ -1,0 +1,30 @@
+package fixtures
+
+func datarace() (r int, c char) {
+	for _, p := range []int{1, 2} {
+		go func() {
+			print(r) // MATCH /potential datarace: return value r is captured (by-reference) in goroutine/
+			print(p) // Shall not match /datarace: range value p is captured (by-reference) in goroutine/
+		}()
+		for i, p1 := range []int{1, 2} {
+			a := p1
+			go func() {
+				print(r)  // MATCH /potential datarace: return value r is captured (by-reference) in goroutine/
+				print(p)  // Shall not match /datarace: range value p is captured (by-reference) in goroutine/
+				print(p1) // Shall not match /datarace: range value p1 is captured (by-reference) in goroutine/
+				print(a)
+				print(i) // Shall not match /datarace: range value i is captured (by-reference) in goroutine/
+			}()
+			print(i)
+			print(p)
+			go func() {
+				_ = c // MATCH /potential datarace: return value c is captured (by-reference) in goroutine/
+			}()
+		}
+		print(p1)
+	}
+	go func() {
+		print(r) // MATCH /potential datarace: return value r is captured (by-reference) in goroutine/
+	}()
+	print(r)
+}

--- a/testdata/go1.22/go.mod
+++ b/testdata/go1.22/go.mod
@@ -1,0 +1,3 @@
+module github.com/mgechev/revive/testdata
+
+go 1.22

--- a/testdata/go1.22/range-val-address.go
+++ b/testdata/go1.22/range-val-address.go
@@ -1,0 +1,163 @@
+package fixtures
+
+func rangeValAddress() {
+	m := map[string]*string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for _, value := range mySlice {
+		m["address"] = &value // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+	}
+}
+
+func rangeValAddress2() {
+	m := map[string]*string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for i := range mySlice {
+		m["address"] = &mySlice[i]
+	}
+}
+
+func rangeValAddress3() {
+	m := map[string]*string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for _, value := range mySlice {
+		a := &value // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+		m["address"] = a
+	}
+}
+
+func rangeValAddress4() {
+	m := []*string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for _, value := range mySlice {
+		m = append(m, &value) // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+	}
+}
+
+func rangeValAddress5() {
+	m := map[*string]string{}
+
+	mySlice := []string{"A", "B", "C"}
+	for _, value := range mySlice {
+		m[&value] = value // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+	}
+}
+
+func rangeValAddress6() {
+	type v struct {
+		id string
+	}
+	m := []*string{}
+
+	mySlice := []v{{id: "A"}, {id: "B"}, {id: "C"}}
+	for _, value := range mySlice {
+		m = append(m, &value.id) // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+	}
+}
+
+func rangeValAddress7() {
+	type v struct {
+		id string
+	}
+	m := []*string{}
+
+	for _, value := range []v{{id: "A"}, {id: "B"}, {id: "C"}} {
+		m = append(m, &value.id) // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+	}
+}
+
+func rangeValAddress8() {
+	type v struct {
+		id string
+	}
+	m := []*string{}
+
+	mySlice := []*v{{id: "A"}, {id: "B"}, {id: "C"}}
+	for _, value := range mySlice {
+		m = append(m, &value.id)
+	}
+}
+
+func rangeValAddress9() {
+	type v struct {
+		id string
+	}
+	m := []*string{}
+
+	mySlice := map[string]*v{"a": {id: "A"}, "b": {id: "B"}, "c": {id: "C"}}
+	for _, value := range mySlice {
+		m = append(m, &value.id)
+	}
+}
+
+func rangeValAddress10() {
+	type v struct {
+		id string
+	}
+	m := []*string{}
+
+	for _, value := range map[string]*v{"a": {id: "A"}, "b": {id: "B"}, "c": {id: "C"}} {
+		m = append(m, &value.id)
+	}
+}
+
+func rangeValAddress11() {
+	type v struct {
+		id string
+	}
+	m := map[string]*string{}
+
+	for key, value := range map[string]*v{"a": {id: "A"}, "b": {id: "B"}, "c": {id: "C"}} {
+		m[key] = &value.id
+	}
+}
+
+func rangeValAddress12() {
+	type v struct {
+		id string
+	}
+	m := map[string]*string{}
+
+	for key, value := range map[string]v{"a": {id: "A"}, "b": {id: "B"}, "c": {id: "C"}} {
+		m[key] = &value.id // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+	}
+}
+
+func rangeValAddress13() {
+	type v struct {
+		id string
+	}
+	m := []*string{}
+
+	otherSlice := map[string]*v{"a": {id: "A"}, "b": {id: "B"}, "c": {id: "C"}}
+	mySlice := otherSlice
+	for _, value := range mySlice {
+		m = append(m, &value.id)
+	}
+}
+
+func rangeValAddress14() {
+	type v struct {
+		id *string
+	}
+
+	m := []v{}
+	for _, value := range []string{"A", "B", "C"} {
+		a := v{id: &value} // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+		m = append(m, a)
+	}
+}
+
+func rangeValAddress15() {
+	type v struct {
+		id *string
+	}
+
+	m := []v{}
+	for _, value := range []string{"A", "B", "C"} {
+		m = append(m, v{id: &value}) // Shall not match /suspicious assignment of 'value'. range-loop variables always have the same address/
+	}
+}

--- a/testdata/go1.22/range-val-in-closure.go
+++ b/testdata/go1.22/range-val-in-closure.go
@@ -1,0 +1,49 @@
+package fixtures
+
+import "fmt"
+
+func foo() {
+	mySlice := []string{"A", "B", "C"}
+	for index, value := range mySlice {
+		go func() {
+			fmt.Printf("Index: %d\n", index) // Shall not match
+			fmt.Printf("Value: %s\n", value) // Shall not match
+		}()
+	}
+
+	myDict := make(map[string]int)
+	myDict["A"] = 1
+	myDict["B"] = 2
+	myDict["C"] = 3
+	for key, value := range myDict {
+		defer func() {
+			fmt.Printf("Index: %d\n", key)   // Shall not match
+			fmt.Printf("Value: %s\n", value) // Shall not match
+		}()
+	}
+
+	for i, newg := range groups {
+		go func(newg int) {
+			newg.run(m.opts.Context, i) // Shall not match
+		}(newg)
+	}
+
+	for i, newg := range groups {
+		newg := newg
+		go func() {
+			newg.run(m.opts.Context, i) // Shall not match
+		}()
+	}
+}
+
+func issue637() {
+	for key := range m {
+		myKey := key
+		go func() {
+			println(t{
+				key:        myKey,
+				otherField: (10 + key), // Shall not match
+			})
+		}()
+	}
+}


### PR DESCRIPTION
Reorganizes testing infrastructure to enable testing rules under different go versions.
Now, `testdata` folder is organized by go version:
* At its root we find test files applicable for go versions >= 1.0 
* Under go1.21, files for go version >= 1.21
* Under go1.22, files for go version >= 1.22

This PR will make possible updating `revive` go version to 1.23 and keep test passing.