### PR TITLE
fix: enforce-repeated-arg-type-style rule finds false positives in case of invalid types

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -389,6 +389,9 @@ declaration. The 'short' style encourages omitting repeated types for concisenes
 whereas the 'full' style mandates explicitly stating the type for each argument
 and return value, even if they are repeated, promoting clarity.
 
+_IMPORTANT_: When `short` style is used, the rule will not flag the arguments that use
+imported types. This is because the rule cannot efficiently determine the imported type.
+
 _Configuration (1)_: (string) as a single string, it configures both argument
 and return value styles. Accepts 'any', 'short', or 'full' (default: 'any').
 

--- a/rule/enforce-repeated-arg-type-style.go
+++ b/rule/enforce-repeated-arg-type-style.go
@@ -135,12 +135,8 @@ func (r *EnforceRepeatedArgTypeStyleRule) Apply(file *lint.File, arguments lint.
 				var prevType ast.Expr
 				if fn.Type.Params != nil {
 					for _, field := range fn.Type.Params.List {
-						if r.isInvalidType(typesInfo.Types[field.Type].Type) {
-							// TODO: In theory, we could have compared raw import names (import package alias + selector), but will it work properly in all the cases?
-							continue
-						}
-
-						if types.Identical(typesInfo.Types[field.Type].Type, typesInfo.Types[prevType].Type) {
+						// TODO: For invalid types we could have compared raw import names (import package alias + selector), but will it work properly in all the cases?
+						if !r.isInvalidType(typesInfo.Types[field.Type].Type) && types.Identical(typesInfo.Types[field.Type].Type, typesInfo.Types[prevType].Type) {
 							failures = append(failures, lint.Failure{
 								Confidence: 1,
 								Node:       field,
@@ -172,12 +168,8 @@ func (r *EnforceRepeatedArgTypeStyleRule) Apply(file *lint.File, arguments lint.
 				var prevType ast.Expr
 				if fn.Type.Results != nil {
 					for _, field := range fn.Type.Results.List {
-						if r.isInvalidType(typesInfo.Types[field.Type].Type) {
-							// TODO: In theory, we could have compared raw import names (import package alias + selector), but will it work properly in all the cases?
-							continue
-						}
-
-						if field.Names != nil && types.Identical(typesInfo.Types[field.Type].Type, typesInfo.Types[prevType].Type) {
+						// TODO: For invalid types we could have compared raw import names (import package alias + selector), but will it work properly in all the cases?
+						if !r.isInvalidType(typesInfo.Types[field.Type].Type) && field.Names != nil && types.Identical(typesInfo.Types[field.Type].Type, typesInfo.Types[prevType].Type) {
 							failures = append(failures, lint.Failure{
 								Confidence: 1,
 								Node:       field,

--- a/rule/enforce-repeated-arg-type-style.go
+++ b/rule/enforce-repeated-arg-type-style.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
+	"strings"
 	"sync"
 
 	"github.com/mgechev/revive/lint"
@@ -134,6 +135,11 @@ func (r *EnforceRepeatedArgTypeStyleRule) Apply(file *lint.File, arguments lint.
 				var prevType ast.Expr
 				if fn.Type.Params != nil {
 					for _, field := range fn.Type.Params.List {
+						if r.isInvalidType(typesInfo.Types[field.Type].Type) {
+							// TODO: In theory, we could have compared raw import names (import package alias + selector), but will it work properly in all the cases?
+							continue
+						}
+
 						if types.Identical(typesInfo.Types[field.Type].Type, typesInfo.Types[prevType].Type) {
 							failures = append(failures, lint.Failure{
 								Confidence: 1,
@@ -166,6 +172,11 @@ func (r *EnforceRepeatedArgTypeStyleRule) Apply(file *lint.File, arguments lint.
 				var prevType ast.Expr
 				if fn.Type.Results != nil {
 					for _, field := range fn.Type.Results.List {
+						if r.isInvalidType(typesInfo.Types[field.Type].Type) {
+							// TODO: In theory, we could have compared raw import names (import package alias + selector), but will it work properly in all the cases?
+							continue
+						}
+
 						if field.Names != nil && types.Identical(typesInfo.Types[field.Type].Type, typesInfo.Types[prevType].Type) {
 							failures = append(failures, lint.Failure{
 								Confidence: 1,
@@ -188,4 +199,11 @@ func (r *EnforceRepeatedArgTypeStyleRule) Apply(file *lint.File, arguments lint.
 // Name returns the name of the linter rule.
 func (*EnforceRepeatedArgTypeStyleRule) Name() string {
 	return "enforce-repeated-arg-type-style"
+}
+
+// Invalid types are imported from other packages, and we can't compare them.
+// Note, we check the string suffix to cover all the cases: non-pointer, pointer, double pointer, etc.
+// See: https://github.com/mgechev/revive/issues/1032
+func (*EnforceRepeatedArgTypeStyleRule) isInvalidType(t types.Type) bool {
+	return strings.HasSuffix(t.String(), "invalid type")
 }


### PR DESCRIPTION
closes #1032