### PR TITLE
adds check for receiver names length

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ List of all available rules. The rules ported from `golint` are left unchanged a
 | [`var-naming`](./RULES_DESCRIPTIONS.md#var-naming)          |  allowlist & blocklist of initialisms   | Naming rules.                                                    |   yes    |  no   |
 | [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |  n/a   | Package commenting conventions.                                  |   yes    |  no   |
 | [`range`](./RULES_DESCRIPTIONS.md#range)               |  n/a   | Prevents redundant variables when iterating over a collection.   |   yes    |  no   |
-| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  string (optional)   | Conventions around the naming of receivers.                      |   yes    |  no   |
+| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  map (optional)   | Conventions around the naming of receivers.                      |   yes    |  no   |
 | [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |  []string   | Prevents redundant else statements.                              |   yes    |  no   |
 | [`argument-limit`](./RULES_DESCRIPTIONS.md#argument-limit)      |  int (defaults to 8)  | Specifies the maximum number of arguments a function can receive |    no    |  no   |
 | [`cyclomatic`](./RULES_DESCRIPTIONS.md#cyclomatic)          |  int (defaults to 10)   | Sets restriction for maximum Cyclomatic complexity.              |    no    |  no   |

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ List of all available rules. The rules ported from `golint` are left unchanged a
 | [`var-naming`](./RULES_DESCRIPTIONS.md#var-naming)          |  allowlist & blocklist of initialisms   | Naming rules.                                                    |   yes    |  no   |
 | [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |  n/a   | Package commenting conventions.                                  |   yes    |  no   |
 | [`range`](./RULES_DESCRIPTIONS.md#range)               |  n/a   | Prevents redundant variables when iterating over a collection.   |   yes    |  no   |
-| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  n/a   | Conventions around the naming of receivers.                      |   yes    |  no   |
+| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  string (optional)   | Conventions around the naming of receivers.                      |   yes    |  no   |
 | [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |  []string   | Prevents redundant else statements.                              |   yes    |  no   |
 | [`argument-limit`](./RULES_DESCRIPTIONS.md#argument-limit)      |  int (defaults to 8)  | Specifies the maximum number of arguments a function can receive |    no    |  no   |
 | [`cyclomatic`](./RULES_DESCRIPTIONS.md#cyclomatic)          |  int (defaults to 10)   | Sets restriction for maximum Cyclomatic complexity.              |    no    |  no   |

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -737,7 +737,12 @@ _Configuration_: N/A
 
 _Description_: By convention, receiver names in a method should reflect their identity. For example, if the receiver is of type `Parts`, `p` is an adequate name for it. Contrary to other languages, it is not idiomatic to name receivers as `this` or `self`.
 
-_Configuration_: N/A
+_Configuration_: (optional) a string indicating the maximum length of the receiver name. If not set, name length is not checked.
+
+```toml
+[rule.receiver-naming]
+    arguments=["max-length=2"]
+```
 
 ## redefines-builtin-id
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -737,11 +737,13 @@ _Configuration_: N/A
 
 _Description_: By convention, receiver names in a method should reflect their identity. For example, if the receiver is of type `Parts`, `p` is an adequate name for it. Contrary to other languages, it is not idiomatic to name receivers as `this` or `self`.
 
-_Configuration_: (optional) a string indicating the maximum length of the receiver name. If not set, name length is not checked.
+_Configuration_: (optional) list of key-value-pair-map (`[]map[string]any`).
+
+- `maxLength` : (int) max length of receiver name
 
 ```toml
 [rule.receiver-naming]
-    arguments=["max-length=2"]
+    arguments = [{maxLength=2}]
 ```
 
 ## redefines-builtin-id

--- a/rule/receiver-naming.go
+++ b/rule/receiver-naming.go
@@ -108,7 +108,7 @@ func (w lintReceiverName) Visit(n ast.Node) ast.Visitor {
 		return w
 	}
 
-	if w.receiverNameMaxLength > 0 && len(name) > w.receiverNameMaxLength {
+	if w.receiverNameMaxLength > 0 && len([]rune(name)) > w.receiverNameMaxLength {
 		w.onFailure(lint.Failure{
 			Node:       n,
 			Confidence: 1,

--- a/test/receiver-naming_test.go
+++ b/test/receiver-naming_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mgechev/revive/internal/typeparams"
+	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/rule"
 )
 
@@ -12,4 +13,9 @@ func TestReceiverNamingTypeParams(t *testing.T) {
 		t.Skip("type parameters are not enabled in the current build environment")
 	}
 	testRule(t, "receiver-naming-issue-669", &rule.ReceiverNamingRule{})
+}
+
+func TestReceiverNamingMaxLength(t *testing.T) {
+	testRule(t, "receiver-naming-issue-1040", &rule.ReceiverNamingRule{},
+		&lint.RuleConfig{Arguments: []any{"max-length=2"}})
 }

--- a/test/receiver-naming_test.go
+++ b/test/receiver-naming_test.go
@@ -16,6 +16,9 @@ func TestReceiverNamingTypeParams(t *testing.T) {
 }
 
 func TestReceiverNamingMaxLength(t *testing.T) {
+	args := []any{map[string]any{
+		"maxLength": int64(2),
+	}}
 	testRule(t, "receiver-naming-issue-1040", &rule.ReceiverNamingRule{},
-		&lint.RuleConfig{Arguments: []any{"max-length=2"}})
+		&lint.RuleConfig{Arguments: args})
 }

--- a/testdata/receiver-naming-issue-1040.go
+++ b/testdata/receiver-naming-issue-1040.go
@@ -1,0 +1,5 @@
+package fixtures
+
+func (o *o) f1()     {}
+func (tw *tw) f2()   {}
+func (thr *thr) f3() {} // MATCH /receiver name thr is longer than 2 characters/


### PR DESCRIPTION
Closes #1040 
The rule receiver-naming now accepts an optional argument indicating the maximum length of receiver names. If no argument is provided the rule does not check for names length. 