### PR TITLE
Makes exported rule behave as golint

### DIFF
--- a/rule/exported.go
+++ b/rule/exported.go
@@ -204,8 +204,8 @@ func (w *lintExported) lintTypeDoc(t *ast.TypeSpec, doc *ast.CommentGroup) {
 		}
 	}
 	// if comment starts with name of type and has some text after - it's ok
-	expectedPrefix := t.Name.Name+" "
-	if strings.HasPrefix(s, expectedPrefix){
+	expectedPrefix := t.Name.Name + " "
+	if strings.HasPrefix(s, expectedPrefix) {
 		return
 	}
 	w.onFailure(lint.Failure{
@@ -244,7 +244,7 @@ func (w *lintExported) lintValueSpecDoc(vs *ast.ValueSpec, gd *ast.GenDecl, genD
 		return
 	}
 
-	if vs.Doc == nil && vs.Comment == nil && gd.Doc == nil {
+	if vs.Doc == nil && gd.Doc == nil {
 		if genDeclMissingComments[gd] {
 			return
 		}
@@ -348,7 +348,7 @@ func (w *lintExported) doCheckPublicInterface(typeName string, iface *ast.Interf
 
 func (w *lintExported) lintInterfaceMethod(typeName string, m *ast.Field) {
 	if len(m.Names) == 0 {
-		return 
+		return
 	}
 	if !ast.IsExported(m.Names[0].Name) {
 		return

--- a/testdata/golint/const-block.go
+++ b/testdata/golint/const-block.go
@@ -4,16 +4,16 @@
 package foo
 
 const (
-	InlineComment = "ShouldBeOK" // InlineComment is a valid comment
+	InlineComment = "ShouldBeOK" // InlineComment is not a valid documentation
+	// MATCH:7 /exported const InlineComment should have comment (or a comment on this block) or be unexported/
 
-	// Prefix for something.
 	// MATCH /comment on exported const InlineWhatever should be of the form "InlineWhatever ..."/
 	InlineWhatever = "blah"
 
 	Whatsit = "missing_comment"
-	// MATCH:13 /exported const Whatsit should have comment (or a comment on this block) or be unexported/
 
 	// We should only warn once per block for missing comments,
+	// thus do not warn on:13 /exported const Whatsit should have comment (or a comment on this block) or be unexported/
 	// but always complain about malformed comments.
 
 	WhosYourDaddy = "another_missing_one"


### PR DESCRIPTION
Closes #1045 by making the exported rule behave as `golint` did.

The rule accepted documentation comments in the same line of variable/constant declarations while `golint` doesn't. 