### PR TITLE
removes redefinition of max built-in

### DIFF
--- a/rule/function-result-limit.go
+++ b/rule/function-result-limit.go
@@ -24,14 +24,14 @@ func (r *FunctionResultsLimitRule) configure(arguments lint.Arguments) {
 			r.max = defaultResultsLimit
 			return
 		}
-		max, ok := arguments[0].(int64) // Alt. non panicking version
+		maxResults, ok := arguments[0].(int64) // Alt. non panicking version
 		if !ok {
 			panic(fmt.Sprintf(`invalid value passed as return results number to the "function-result-limit" rule; need int64 but got %T`, arguments[0]))
 		}
-		if max < 0 {
+		if maxResults < 0 {
 			panic(`the value passed as return results number to the "function-result-limit" rule cannot be negative`)
 		}
-		r.max = int(max)
+		r.max = int(maxResults)
 	}
 }
 

--- a/rule/line-length-limit.go
+++ b/rule/line-length-limit.go
@@ -29,12 +29,12 @@ func (r *LineLengthLimitRule) configure(arguments lint.Arguments) {
 			return
 		}
 
-		max, ok := arguments[0].(int64) // Alt. non panicking version
-		if !ok || max < 0 {
+		maxLength, ok := arguments[0].(int64) // Alt. non panicking version
+		if !ok || maxLength < 0 {
 			panic(`invalid value passed as argument number to the "line-length-limit" rule`)
 		}
 
-		r.max = int(max)
+		r.max = int(maxLength)
 	}
 }
 

--- a/rule/max-control-nesting.go
+++ b/rule/max-control-nesting.go
@@ -120,9 +120,9 @@ func (r *MaxControlNestingRule) configure(arguments lint.Arguments) {
 
 	checkNumberOfArguments(1, arguments, r.Name())
 
-	max, ok := arguments[0].(int64) // Alt. non panicking version
+	maxNesting, ok := arguments[0].(int64) // Alt. non panicking version
 	if !ok {
 		panic(`invalid value passed as argument number to the "max-control-nesting" rule`)
 	}
-	r.max = max
+	r.max = maxNesting
 }

--- a/rule/max-public-structs.go
+++ b/rule/max-public-structs.go
@@ -27,11 +27,11 @@ func (r *MaxPublicStructsRule) configure(arguments lint.Arguments) {
 
 		checkNumberOfArguments(1, arguments, r.Name())
 
-		max, ok := arguments[0].(int64) // Alt. non panicking version
+		maxStructs, ok := arguments[0].(int64) // Alt. non panicking version
 		if !ok {
 			panic(`invalid value passed as argument number to the "max-public-structs" rule`)
 		}
-		r.max = max
+		r.max = maxStructs
 	}
 }
 


### PR DESCRIPTION
Removes redefinition of max built-in function to remove linting errors