### PR TITLE
Enhance container build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           go-version: 1.22
       -
-        name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -30,3 +27,68 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  buildx:
+    runs-on: ubuntu-latest
+
+    env:
+      PLATFORMS: linux/amd64,linux/arm64
+      IMAGE_NAME: ${{ github.repository }}
+      REGISTRY: ghcr.io
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,prefix=v,pattern={{version}}
+            type=semver,prefix=v,pattern={{major}}.{{minor}}
+            type=semver,prefix=v,pattern={{major}}
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ env.PLATFORMS }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            BUILDER=buildx
+          push: true
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,23 +18,6 @@ builds:
       - darwin
       - windows
 
-dockers:
-  - image_templates:
-      - "ghcr.io/mgechev/revive:{{ .Version }}"
-      - "ghcr.io/mgechev/revive:{{ .Tag }}"
-      - "ghcr.io/mgechev/revive:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/mgechev/revive:v{{ .Major }}"
-      - "ghcr.io/mgechev/revive:latest"
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - --label=org.opencontainers.image.created={{.Date}}
-      - --label=org.opencontainers.image.title={{ .ProjectName }}
-      - "--label=org.opencontainers.image.description=🔥 ~6x faster, stricter, configurable, extensible, and beautiful drop-in replacement for golint"
-      - --label=org.opencontainers.image.url=https://github.com/mgechev/revive
-      - --label=org.opencontainers.image.source=https://github.com/mgechev/revive
-      - --label=org.opencontainers.image.version={{ .Version }}
-      - --label=org.opencontainers.image.revision={{ .FullCommit }}
-      - --label=org.opencontainers.image.licenses=MIT
 changelog:
   filters:
     exclude:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,23 @@
+FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+
+ARG VERSION
+ARG REVISION
+ARG BUILDTIME
+ARG BUILDER
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV CGO_ENABLED=0
+
+WORKDIR /src
+COPY . .
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -ldflags "-X github.com/mgechev/revive/cli.version=${VERSION} -X github.com/mgechev/revive/cli.commit=${REVISION} -X github.com/mgechev/revive/cli.date=${BUILDTIME} -X github.com/mgechev/revive/cli.builtBy=${BUILDER}"
+
 FROM scratch
-COPY revive /usr/bin/revive
-ENTRYPOINT ["/usr/bin/revive"]
+
+COPY --from=build /src/revive /revive
+
+ENTRYPOINT ["/revive"]


### PR DESCRIPTION
This PR improves the container image build process and introduces ARM64 images by using Buildx.

It also adds GitHub's [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#generating-artifact-attestations-for-your-builds) to make the images verifiable.

Closes #1069 