### PR TITLE
refactor: use "path/filepath" instead of "path"

### DIFF
--- a/lint/linter.go
+++ b/lint/linter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"go/token"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -175,7 +174,7 @@ func detectGoMod(dir string) (rootDir string, ver *goversion.Version, err error)
 	}
 
 	ver, err = goversion.NewVersion(modAst.Go.Version)
-	return path.Dir(modFileName), ver, err
+	return filepath.Dir(modFileName), ver, err
 }
 
 func retrieveModFile(dir string) (string, error) {
@@ -185,11 +184,11 @@ func retrieveModFile(dir string) (string, error) {
 			return "", fmt.Errorf("did not found %q file", lookingForFile)
 		}
 
-		lookingForFilePath := path.Join(dir, lookingForFile)
+		lookingForFilePath := filepath.Join(dir, lookingForFile)
 		info, err := os.Stat(lookingForFilePath)
 		if err != nil || info.IsDir() {
 			// lets check the parent dir
-			dir = path.Dir(dir)
+			dir = filepath.Dir(dir)
 			continue
 		}
 

--- a/test/golint_test.go
+++ b/test/golint_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"flag"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -53,7 +53,7 @@ func TestAll(t *testing.T) {
 			continue
 		}
 		t.Run(fi.Name(), func(t *testing.T) {
-			filePath := path.Join(baseDir, fi.Name())
+			filePath := filepath.Join(baseDir, fi.Name())
 			src, err := os.ReadFile(filePath)
 			if err != nil {
 				t.Fatalf("Failed reading %s: %v", fi.Name(), err)
@@ -64,7 +64,7 @@ func TestAll(t *testing.T) {
 				t.Fatalf("Failed reading %s: %v", fi.Name(), err)
 			}
 
-			if err := assertFailures(t, path.Dir(baseDir), fileInfo, src, rules, map[string]lint.RuleConfig{}); err != nil {
+			if err := assertFailures(t, filepath.Dir(baseDir), fileInfo, src, rules, map[string]lint.RuleConfig{}); err != nil {
 				t.Errorf("Linting %s: %v", fi.Name(), err)
 			}
 		})

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 	"go/types"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,9 +19,9 @@ import (
 )
 
 func testRule(t *testing.T, filename string, rule lint.Rule, config ...*lint.RuleConfig) {
-	baseDir := path.Join("../testdata/" + path.Dir(filename))
-	filename = path.Base(filename) + ".go"
-	fullFilePath := path.Join(baseDir, filename)
+	baseDir := filepath.Join("..", "testdata", filepath.Dir(filename))
+	filename = filepath.Base(filename) + ".go"
+	fullFilePath := filepath.Join(baseDir, filename)
 	src, err := os.ReadFile(fullFilePath)
 	if err != nil {
 		t.Fatalf("Bad filename path in test for %s: %v", rule.Name(), err)
@@ -46,7 +46,7 @@ func assertSuccess(t *testing.T, baseDir string, fi os.FileInfo, rules []lint.Ru
 		return os.ReadFile(file)
 	}, 0)
 
-	filePath := path.Join(baseDir, fi.Name())
+	filePath := filepath.Join(baseDir, fi.Name())
 	ps, err := l.Lint([][]string{{filePath}}, rules, lint.Config{
 		Rules: config,
 	})
@@ -69,12 +69,12 @@ func assertFailures(t *testing.T, baseDir string, fi os.FileInfo, src []byte, ru
 		return os.ReadFile(file)
 	}, 0)
 
-	ins := parseInstructions(t, path.Join(baseDir, fi.Name()), src)
+	ins := parseInstructions(t, filepath.Join(baseDir, fi.Name()), src)
 	if ins == nil {
 		return fmt.Errorf("Test file %v does not have instructions", fi.Name())
 	}
 
-	ps, err := l.Lint([][]string{{path.Join(baseDir, fi.Name())}}, rules, lint.Config{
+	ps, err := l.Lint([][]string{{filepath.Join(baseDir, fi.Name())}}, rules, lint.Config{
 		Rules: config,
 	})
 	if err != nil {


### PR DESCRIPTION
The PR replaces the usages of [`path`](https://pkg.go.dev/path) package with [`path/filepath`](https://pkg.go.dev/path/filepath).

Because `path.Join` is for URL paths, and `filepath.Join` is for file paths.