### PR TITLE
fix: change "GO" to "Go" in the use-any rule

### DIFF
--- a/rule/use-any.go
+++ b/rule/use-any.go
@@ -47,7 +47,7 @@ func (w lintUseAny) Visit(n ast.Node) ast.Visitor {
 		Node:       n,
 		Confidence: 1,
 		Category:   "naming",
-		Failure:    "since GO 1.18 'interface{}' can be replaced by 'any'",
+		Failure:    "since Go 1.18 'interface{}' can be replaced by 'any'",
 	})
 
 	return w

--- a/testdata/use-any.go
+++ b/testdata/use-any.go
@@ -1,19 +1,19 @@
 package pkg
 
-var i interface{} // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
+var i interface{} // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
 
-type t interface{}   // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
-type a = interface{} // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
+type t interface{}   // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
+type a = interface{} // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
 
-func any1(a interface{}) { // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
-	m1 := map[interface{}]string{}     // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
-	m2 := map[int]interface{}{}        // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
-	a := []interface{}{}               // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
-	m3 := make(map[int]interface{}, 1) // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
-	a2 := make([]interface{}, 2)       // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
+func any1(a interface{}) { // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
+	m1 := map[interface{}]string{}     // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
+	m2 := map[int]interface{}{}        // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
+	a := []interface{}{}               // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
+	m3 := make(map[int]interface{}, 1) // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
+	a2 := make([]interface{}, 2)       // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
 }
 
-func any2(a int) interface{} {} // MATCH /since GO 1.18 'interface{}' can be replaced by 'any'/
+func any2(a int) interface{} {} // MATCH /since Go 1.18 'interface{}' can be replaced by 'any'/
 
 var ni interface{ Close() }
 


### PR DESCRIPTION
The PR changes the failure message for the `use-any` rule from `since GO 1.18 'interface{}' can be replaced by 'any'` to `since Go 1.18 'interface{}' can be replaced by 'any'`.

See ["Is the language called Go or Golang?"](https://go.dev/doc/faq#go_or_golang)