### PR TITLE
chore: format sources with gofumpt

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -21,7 +21,7 @@ var (
 	commit  = "none"
 	date    = "unknown"
 	builtBy = "unknown"
-	//AppFs is used to operations related with user config files
+	// AppFs is used to operations related with user config files
 	AppFs = afero.NewOsFs()
 )
 

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -22,13 +22,13 @@ func TestXDGConfigDirIsPrefferedFirst(t *testing.T) {
 
 	xdgDirPath := "/tmp-iofs/xdg/config"
 	homeDirPath := "/tmp-iofs/home/tester"
-	AppFs.MkdirAll(xdgDirPath, 0755)
-	AppFs.MkdirAll(homeDirPath, 0755)
+	AppFs.MkdirAll(xdgDirPath, 0o755)
+	AppFs.MkdirAll(homeDirPath, 0o755)
 
-	afero.WriteFile(AppFs, xdgDirPath+"/revive.toml", []byte("\n"), 0644)
+	afero.WriteFile(AppFs, xdgDirPath+"/revive.toml", []byte("\n"), 0o644)
 	t.Setenv("XDG_CONFIG_HOME", xdgDirPath)
 
-	afero.WriteFile(AppFs, homeDirPath+"/revive.toml", []byte("\n"), 0644)
+	afero.WriteFile(AppFs, homeDirPath+"/revive.toml", []byte("\n"), 0o644)
 	t.Setenv("HOME", homeDirPath)
 
 	got := buildDefaultConfigPath()
@@ -40,11 +40,10 @@ func TestXDGConfigDirIsPrefferedFirst(t *testing.T) {
 }
 
 func TestHomeConfigDir(t *testing.T) {
-
 	homeDirPath := "/tmp-iofs/home/tester"
-	AppFs.MkdirAll(homeDirPath, 0755)
+	AppFs.MkdirAll(homeDirPath, 0o755)
 
-	afero.WriteFile(AppFs, homeDirPath+"/revive.toml", []byte("\n"), 0644)
+	afero.WriteFile(AppFs, homeDirPath+"/revive.toml", []byte("\n"), 0o644)
 	t.Setenv("HOME", homeDirPath)
 
 	got := buildDefaultConfigPath()
@@ -57,9 +56,9 @@ func TestHomeConfigDir(t *testing.T) {
 
 func TestXDGConfigDir(t *testing.T) {
 	xdgDirPath := "/tmp-iofs/xdg/config"
-	AppFs.MkdirAll(xdgDirPath, 0755)
+	AppFs.MkdirAll(xdgDirPath, 0o755)
 
-	afero.WriteFile(AppFs, xdgDirPath+"/revive.toml", []byte("\n"), 0644)
+	afero.WriteFile(AppFs, xdgDirPath+"/revive.toml", []byte("\n"), 0o644)
 	t.Setenv("XDG_CONFIG_HOME", xdgDirPath)
 
 	got := buildDefaultConfigPath()

--- a/lint/filefilter.go
+++ b/lint/filefilter.go
@@ -55,12 +55,14 @@ func (ff *FileFilter) MatchFileName(name string) bool {
 	return ff.rx.MatchString(name)
 }
 
-var fileFilterInvalidGlobRegexp = regexp.MustCompile(`[^/]\*\*[^/]`)
-var escapeRegexSymbols = ".+{}()[]^$"
+var (
+	fileFilterInvalidGlobRegexp = regexp.MustCompile(`[^/]\*\*[^/]`)
+	escapeRegexSymbols          = ".+{}()[]^$"
+)
 
 func (ff *FileFilter) prepareRegexp() error {
 	var err error
-	var src = ff.raw
+	src := ff.raw
 	if src == "TEST" {
 		src = "~_test\\.go"
 	}

--- a/lint/filefilter_test.go
+++ b/lint/filefilter_test.go
@@ -95,7 +95,6 @@ func TestFileFilter(t *testing.T) {
 				t.Fatalf("should not match %s", fn)
 			}
 		}
-
 	})
 
 	t.Run("just *", func(t *testing.T) {
@@ -109,7 +108,6 @@ func TestFileFilter(t *testing.T) {
 				t.Fatalf("should match %s", fn)
 			}
 		}
-
 	})
 
 	t.Run("just ~", func(t *testing.T) {
@@ -123,6 +121,5 @@ func TestFileFilter(t *testing.T) {
 				t.Fatalf("should match %s", fn)
 			}
 		}
-
 	})
 }

--- a/revivelib/core.go
+++ b/revivelib/core.go
@@ -82,7 +82,7 @@ func (r *Revive) Lint(patterns ...*LintPattern) (<-chan lint.Failure, error) {
 	if len(excludePatterns) == 0 { // if no excludes were set
 		excludePatterns = r.config.Exclude // use those from the configuration
 	}
-	
+
 	// by default if no excludes exclude vendor
 	if len(excludePatterns) == 0 {
 		excludePatterns = []string{"vendor/..."}
@@ -95,7 +95,6 @@ func (r *Revive) Lint(patterns ...*LintPattern) (<-chan lint.Failure, error) {
 
 	revive := lint.New(func(file string) ([]byte, error) {
 		contents, err := os.ReadFile(file)
-
 		if err != nil {
 			return nil, fmt.Errorf("reading file %v: %w", file, err)
 		}

--- a/revivelib/core_internal_test.go
+++ b/revivelib/core_internal_test.go
@@ -36,8 +36,7 @@ func TestReviveCreateInstance(t *testing.T) {
 	}
 }
 
-type mockRule struct {
-}
+type mockRule struct{}
 
 func (*mockRule) Name() string {
 	return "mock-rule"

--- a/rule/enforce-map-style.go
+++ b/rule/enforce-map-style.go
@@ -65,7 +65,6 @@ func (r *EnforceMapStyleRule) configure(arguments lint.Arguments) {
 
 	var err error
 	r.enforceMapStyle, err = mapStyleFromString(enforceMapStyle)
-
 	if err != nil {
 		panic(fmt.Sprintf("Invalid argument to the enforce-map-style rule: %v", err))
 	}

--- a/rule/enforce-slice-style.go
+++ b/rule/enforce-slice-style.go
@@ -69,7 +69,6 @@ func (r *EnforceSliceStyleRule) configure(arguments lint.Arguments) {
 
 	var err error
 	r.enforceSliceStyle, err = sliceStyleFromString(enforceSliceStyle)
-
 	if err != nil {
 		panic(fmt.Sprintf("Invalid argument to the enforce-slice-style rule: %v", err))
 	}

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -25,9 +25,11 @@ type disabledChecks struct {
 	Var              bool
 }
 
-const checkNamePrivateReceivers = "privateReceivers"
-const checkNamePublicInterfaces = "publicInterfaces"
-const checkNameStuttering = "stuttering"
+const (
+	checkNamePrivateReceivers = "privateReceivers"
+	checkNamePublicInterfaces = "publicInterfaces"
+	checkNameStuttering       = "stuttering"
+)
 
 // isDisabled returns true if the given check is disabled, false otherwise
 func (dc *disabledChecks) isDisabled(checkName string) bool {

--- a/rule/function-length.go
+++ b/rule/function-length.go
@@ -55,8 +55,10 @@ func (*FunctionLength) Name() string {
 	return "function-length"
 }
 
-const defaultFuncStmtsLimit = 50
-const defaultFuncLinesLimit = 75
+const (
+	defaultFuncStmtsLimit = 50
+	defaultFuncLinesLimit = 75
+)
 
 func (*FunctionLength) parseArguments(arguments lint.Arguments) (maxStmt, maxLines int64) {
 	if len(arguments) == 0 {

--- a/rule/line-length-limit.go
+++ b/rule/line-length-limit.go
@@ -38,7 +38,6 @@ func (r *LineLengthLimitRule) configure(arguments lint.Arguments) {
 	}
 
 	r.max = int(maxLength)
-
 }
 
 // Apply applies the rule to given file.

--- a/rule/max-public-structs.go
+++ b/rule/max-public-structs.go
@@ -35,7 +35,6 @@ func (r *MaxPublicStructsRule) configure(arguments lint.Arguments) {
 		panic(`invalid value passed as argument number to the "max-public-structs" rule`)
 	}
 	r.max = maxStructs
-
 }
 
 // Apply applies the rule to given file.

--- a/rule/redefines-builtin-id.go
+++ b/rule/redefines-builtin-id.go
@@ -163,7 +163,7 @@ func (w *lintRedefinesBuiltinID) Visit(node ast.Node) ast.Visitor {
 				if !isTypeOrName {
 					continue
 				}
-				
+
 				id := obj.Name
 				if ok, bt := w.isBuiltIn(id); ok {
 					w.addFailure(name, fmt.Sprintf("redefinition of the built-in %s %s", bt, id))

--- a/rule/struct-tag.go
+++ b/rule/struct-tag.go
@@ -96,14 +96,16 @@ func (w lintStructTagRule) Visit(node ast.Node) ast.Visitor {
 	return w
 }
 
-const keyASN1 = "asn1"
-const keyBSON = "bson"
-const keyDefault = "default"
-const keyJSON = "json"
-const keyProtobuf = "protobuf"
-const keyRequired = "required"
-const keyXML = "xml"
-const keyYAML = "yaml"
+const (
+	keyASN1     = "asn1"
+	keyBSON     = "bson"
+	keyDefault  = "default"
+	keyJSON     = "json"
+	keyProtobuf = "protobuf"
+	keyRequired = "required"
+	keyXML      = "xml"
+	keyYAML     = "yaml"
+)
 
 func (w lintStructTagRule) checkTagNameIfNeed(tag *structtag.Tag) (string, bool) {
 	isUnnamedTag := tag.Name == "" || tag.Name == "-"

--- a/rule/superfluous-else.go
+++ b/rule/superfluous-else.go
@@ -2,6 +2,7 @@ package rule
 
 import (
 	"fmt"
+
 	"github.com/mgechev/revive/internal/ifelse"
 	"github.com/mgechev/revive/lint"
 )

--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -79,7 +79,6 @@ func (r *VarNamingRule) applyPackageCheckRules(walker *lintNames) {
 			Category:   "naming",
 		})
 	}
-
 }
 
 // Apply applies the rule to given file.

--- a/test/comment-spacings_test.go
+++ b/test/comment-spacings_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestCommentSpacings(t *testing.T) {
 	testRule(t, "comment-spacings", &rule.CommentSpacingsRule{}, &lint.RuleConfig{
-		Arguments: []any{"myOwnDirective:", "+optional"}},
-	)
+		Arguments: []any{"myOwnDirective:", "+optional"},
+	})
 }

--- a/test/json-data-format_test.go
+++ b/test/json-data-format_test.go
@@ -9,9 +9,8 @@ import (
 
 func TestJsonDataFormat(t *testing.T) {
 	testRule(t, "json-data-format-atomic", &rule.AtomicRule{})
-
 }
+
 func TestJsonDataFormatVarNaming(t *testing.T) {
 	testRule(t, "json-data-format-var-naming", &rule.VarNamingRule{}, &lint.RuleConfig{})
-
 }

--- a/test/max-control-nesting_test.go
+++ b/test/max-control-nesting_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestMaxControlNesting(t *testing.T) {
 	testRule(t, "max-control-nesting", &rule.MaxControlNestingRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(2)}},
-	)
+		Arguments: []any{int64(2)},
+	})
 }

--- a/test/redundant-import-alias_test.go
+++ b/test/redundant-import-alias_test.go
@@ -1,8 +1,9 @@
 package test
 
 import (
-	"github.com/mgechev/revive/rule"
 	"testing"
+
+	"github.com/mgechev/revive/rule"
 )
 
 // TestRedundantImportAlias rule.

--- a/test/string-format_test.go
+++ b/test/string-format_test.go
@@ -13,19 +13,25 @@ func TestStringFormat(t *testing.T) {
 			[]any{
 				"stringFormatMethod1", // The first argument is checked by default
 				"/^[A-Z]/",
-				"must start with a capital letter"},
+				"must start with a capital letter",
+			},
 
 			[]any{
 				"stringFormatMethod2[2].d",
-				"/[^\\.]$/"}, // Must not end with a period
+				"/[^\\.]$/", // Must not end with a period
+			},
 			[]any{
 				"s.Method3[2]",
 				"!/^[Tt][Hh]/",
-				"must not start with 'th'"},
+				"must not start with 'th'",
+			},
 			[]any{
 				"s.Method4", // same as before, but called from a struct
 				"!/^[Ot][Tt]/",
-				"must not start with 'ot'"}}})
+				"must not start with 'ot'",
+			},
+		},
+	})
 }
 
 func TestStringFormatArgumentParsing(t *testing.T) {
@@ -42,121 +48,177 @@ func TestStringFormatArgumentParsing(t *testing.T) {
 		{
 			name: "Not a Slice",
 			config: lint.Arguments{
-				"this is not a slice"},
-			expectedError: stringPtr("invalid configuration for string-format: argument is not a slice [argument 0, option 0]")},
+				"this is not a slice",
+			},
+			expectedError: stringPtr("invalid configuration for string-format: argument is not a slice [argument 0, option 0]"),
+		},
 		{
 			name: "Missing Regex",
 			config: lint.Arguments{
 				[]any{
-					"method[0]"}},
-			expectedError: stringPtr("invalid configuration for string-format: less than two slices found in argument, scope and regex are required [argument 0, option 0]")},
+					"method[0]",
+				},
+			},
+			expectedError: stringPtr("invalid configuration for string-format: less than two slices found in argument, scope and regex are required [argument 0, option 0]"),
+		},
 		{
 			name: "Bad Argument Type",
 			config: lint.Arguments{
 				[]any{
-					1}},
-			expectedError: stringPtr("invalid configuration for string-format: less than two slices found in argument, scope and regex are required [argument 0, option 0]")},
+					1,
+				},
+			},
+			expectedError: stringPtr("invalid configuration for string-format: less than two slices found in argument, scope and regex are required [argument 0, option 0]"),
+		},
 		{
 			name: "Empty Scope",
 			config: lint.Arguments{
 				[]any{
 					"",
-					"//"}},
-			expectedError: stringPtr("invalid configuration for string-format: empty scope provided [argument 0, option 0]")},
+					"//",
+				},
+			},
+			expectedError: stringPtr("invalid configuration for string-format: empty scope provided [argument 0, option 0]"),
+		},
 		{
 			name: "Small or Empty Regex",
 			config: lint.Arguments{
 				[]any{
 					"method[1].a",
-					"-"}},
-			expectedError: stringPtr("invalid configuration for string-format: regex is too small (regexes should begin and end with '/') [argument 0, option 1]")},
+					"-",
+				},
+			},
+			expectedError: stringPtr("invalid configuration for string-format: regex is too small (regexes should begin and end with '/') [argument 0, option 1]"),
+		},
 		{
 			name: "Bad Scope",
 			config: lint.Arguments{
 				[]any{
 					"1.a",
-					"//"}},
-			expectedError: stringPtr("failed to parse configuration for string-format: unable to parse rule scope [argument 0, option 0, scope index 0]")},
+					"//",
+				},
+			},
+			expectedError: stringPtr("failed to parse configuration for string-format: unable to parse rule scope [argument 0, option 0, scope index 0]"),
+		},
 		{
 			name: "Bad Regex",
 			config: lint.Arguments{
 				[]any{
 					"method[1].a",
-					"/(/"}},
-			expectedError: stringPtr("failed to parse configuration for string-format: unable to compile /(/ as regexp [argument 0, option 1]")},
+					"/(/",
+				},
+			},
+			expectedError: stringPtr("failed to parse configuration for string-format: unable to compile /(/ as regexp [argument 0, option 1]"),
+		},
 		{
 			name: "Sample Config",
 			config: lint.Arguments{
 				[]any{
-					"core.WriteError[1].Message", "/^([^A-Z]$)/", "must not start with a capital letter"},
+					"core.WriteError[1].Message", "/^([^A-Z]$)/", "must not start with a capital letter",
+				},
 				[]any{
-					"fmt.Errorf[0]", "/^|[^\\.!?]$/", "must not end in punctuation"},
+					"fmt.Errorf[0]", "/^|[^\\.!?]$/", "must not end in punctuation",
+				},
 				[]any{
-					"panic", "/^[^\\n]*$/", "must not contain line breaks"}}},
+					"panic", "/^[^\\n]*$/", "must not contain line breaks",
+				},
+			},
+		},
 		{
 			name: "Underscores in Scope",
 			config: lint.Arguments{
 				[]any{
 					"some_pkg._some_function_name[5].some_member",
-					"//"}}},
+					"//",
+				},
+			},
+		},
 		{
 			name: "Underscores in Multiple Scopes",
 			config: lint.Arguments{
 				[]any{
 					"fmt.Errorf[0],core.WriteError[1].Message",
-					"//"}}},
+					"//",
+				},
+			},
+		},
 		{
 			name: "', ' Delimiter",
 			config: lint.Arguments{
 				[]any{
 					"abc, mt.Errorf",
-					"//"}}},
+					"//",
+				},
+			},
+		},
 		{
 			name: "' ,' Delimiter",
 			config: lint.Arguments{
 				[]any{
 					"abc ,mt.Errorf",
-					"//"}}},
+					"//",
+				},
+			},
+		},
 		{
 			name: "',   ' Delimiter",
 			config: lint.Arguments{
 				[]any{
 					"abc,   mt.Errorf",
-					"//"}}},
+					"//",
+				},
+			},
+		},
 		{
 			name: "',   ' Delimiter",
 			config: lint.Arguments{
 				[]any{
 					"abc,   mt.Errorf",
-					"//"}}},
+					"//",
+				},
+			},
+		},
 		{
 			name: "Empty Middle Scope",
 			config: lint.Arguments{
 				[]any{
 					"abc, ,mt.Errorf",
-					"//"}},
-			expectedError: stringPtr("failed to parse configuration for string-format: empty scope in rule scopes: [argument 0, option 0, scope index 1]")},
+					"//",
+				},
+			},
+			expectedError: stringPtr("failed to parse configuration for string-format: empty scope in rule scopes: [argument 0, option 0, scope index 1]"),
+		},
 		{
 			name: "Empty First Scope",
 			config: lint.Arguments{
 				[]any{
 					",mt.Errorf",
-					"//"}},
-			expectedError: stringPtr("failed to parse configuration for string-format: empty scope in rule scopes: [argument 0, option 0, scope index 0]")},
+					"//",
+				},
+			},
+			expectedError: stringPtr("failed to parse configuration for string-format: empty scope in rule scopes: [argument 0, option 0, scope index 0]"),
+		},
 		{
 			name: "Bad First Scope",
 			config: lint.Arguments{
 				[]any{
 					"1.a,fmt.Errorf[0]",
-					"//"}},
-			expectedError: stringPtr("failed to parse configuration for string-format: unable to parse rule scope [argument 0, option 0, scope index 0]")},
+					"//",
+				},
+			},
+			expectedError: stringPtr("failed to parse configuration for string-format: unable to parse rule scope [argument 0, option 0, scope index 0]"),
+		},
 		{
 			name: "Bad Second Scope",
 			config: lint.Arguments{
 				[]any{
 					"fmt.Errorf[0],1.a",
-					"//"}},
-			expectedError: stringPtr("failed to parse configuration for string-format: unable to parse rule scope [argument 0, option 0, scope index 1]")}}
+					"//",
+				},
+			},
+			expectedError: stringPtr("failed to parse configuration for string-format: unable to parse rule scope [argument 0, option 0, scope index 1]"),
+		},
+	}
 
 	for _, a := range tests {
 		t.Run(a.name, func(t *testing.T) {

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -107,11 +107,9 @@ func assertFailures(t *testing.T, baseDir string, fi os.FileInfo, src []byte, ru
 				}
 
 				if in.Confidence > 0 {
-
 					if in.Confidence != p.Confidence {
 						t.Errorf("Lint failed at %s:%d; got confidence %f, want %f", fi.Name(), in.Line, p.Confidence, in.Confidence)
 					}
-
 				}
 
 				// remove this problem from ps
@@ -224,11 +222,9 @@ func extractInstructionFromJSON(line string, lineNumber int) (instruction, error
 		Line:       lineNumber,
 	}
 	return ins, nil
-
 }
 
 func extractDataMode(line string) string {
-
 	if strings.HasPrefix(line, "json") {
 		return "json"
 	}
@@ -237,7 +233,6 @@ func extractDataMode(line string) string {
 	}
 
 	return ""
-
 }
 
 func extractPattern(line string) (string, error) {

--- a/test/var-naming_test.go
+++ b/test/var-naming_test.go
@@ -23,5 +23,4 @@ func TestVarNaming(t *testing.T) {
 	testRule(t, "var-naming_skipPackageNameChecks-true", &rule.VarNamingRule{}, &lint.RuleConfig{
 		Arguments: []any{[]any{}, []any{}, []any{map[string]any{"skipPackageNameChecks": true}}},
 	})
-
 }


### PR DESCRIPTION
The PR formats the source code with [`gofumpt`](https://github.com/mvdan/gofumpt):

```sh
gofumpt -w .
```

The changes are the same as in the merged PR #643.