### PR TITLE
refactor: change to t.Fatal(err)

### DIFF
--- a/revivelib/core_internal_test.go
+++ b/revivelib/core_internal_test.go
@@ -62,7 +62,7 @@ func getMockRevive(t *testing.T) *Revive {
 		NewExtraRule(&mockRule{}, lint.RuleConfig{}),
 	)
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	return revive

--- a/revivelib/core_test.go
+++ b/revivelib/core_test.go
@@ -98,7 +98,7 @@ func getMockRevive(t *testing.T) *revivelib.Revive {
 		revivelib.NewExtraRule(&mockRule{}, lint.RuleConfig{}),
 	)
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	return revive


### PR DESCRIPTION
The PR replaces `t.Fatal(err.Error())` with `t.Fatal(err)` for to simplify tests and for consistency with other statements.