### PR TITLE
fix: extractInstructionFromJSON returns an error

### DIFF
--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -212,7 +212,7 @@ func extractInstructionFromJSON(line string, lineNumber int) (instruction, error
 	// Use the json.Unmarshal function to parse the JSON into the struct
 	var jsonInst JSONInstruction
 	if err := json.Unmarshal([]byte(line), &jsonInst); err != nil {
-		fmt.Println("Error parsing JSON:", err)
+		return instruction{}, fmt.Errorf("parsing json instruction: %w", err)
 	}
 
 	ins := instruction{


### PR DESCRIPTION
The PR fixes the function `extractInstructionFromJSON` used for tests. It should return an error, but just prints an error and returns `nil`.