### PR TITLE
refactor: fix revive.early-return issues

### DIFF
--- a/rule/dot-imports.go
+++ b/rule/dot-imports.go
@@ -59,16 +59,16 @@ func (r *DotImportsRule) configure(arguments lint.Arguments) {
 	}
 
 	if allowedPkgArg, ok := args["allowedPackages"]; ok {
-		if pkgs, ok := allowedPkgArg.([]any); ok {
-			for _, p := range pkgs {
-				if pkg, ok := p.(string); ok {
-					r.allowedPackages.add(pkg)
-				} else {
-					panic(fmt.Sprintf("Invalid argument to the dot-imports rule, string expected. Got '%v' (%T)", p, p))
-				}
-			}
-		} else {
+		pkgs, ok := allowedPkgArg.([]any)
+		if !ok {
 			panic(fmt.Sprintf("Invalid argument to the dot-imports rule, []string expected. Got '%v' (%T)", allowedPkgArg, allowedPkgArg))
+		}
+		for _, p := range pkgs {
+			pkg, ok := p.(string)
+			if !ok {
+				panic(fmt.Sprintf("Invalid argument to the dot-imports rule, string expected. Got '%v' (%T)", p, p))
+			}
+			r.allowedPackages.add(pkg)
 		}
 	}
 }

--- a/rule/var-naming.go
+++ b/rule/var-naming.go
@@ -264,17 +264,17 @@ func (w *lintNames) Visit(n ast.Node) ast.Visitor {
 }
 
 func getList(arg any, argName string) []string {
-	temp, ok := arg.([]any)
+	args, ok := arg.([]any)
 	if !ok {
 		panic(fmt.Sprintf("Invalid argument to the var-naming rule. Expecting a %s of type slice with initialisms, got %T", argName, arg))
 	}
 	var list []string
-	for _, v := range temp {
-		if val, ok := v.(string); ok {
-			list = append(list, val)
-		} else {
+	for _, v := range args {
+		val, ok := v.(string)
+		if !ok {
 			panic(fmt.Sprintf("Invalid %s values of the var-naming rule. Expecting slice of strings but got element of type %T", val, arg))
 		}
+		list = append(list, val)
 	}
 	return list
 }


### PR DESCRIPTION
This PR simplifies code a bit by applying suggestions from the `early-return` rule.