### PR TITLE
refactor: simplify tests

### DIFF
--- a/revivelib/core_internal_test.go
+++ b/revivelib/core_internal_test.go
@@ -18,7 +18,7 @@ func TestReviveCreateInstance(t *testing.T) {
 		t.Fatal("Expected MaxOpenFiles to be 2048")
 	}
 
-	if revive.lintingRules == nil || len(revive.lintingRules) == 0 {
+	if len(revive.lintingRules) == 0 {
 		t.Fatal("Linting rules not loaded.")
 	}
 

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -40,9 +40,7 @@ func testRule(t *testing.T, filename string, rule lint.Rule, config ...*lint.Rul
 }
 
 func assertSuccess(t *testing.T, baseDir string, fi os.FileInfo, rules []lint.Rule, config map[string]lint.RuleConfig) error {
-	l := lint.New(func(file string) ([]byte, error) {
-		return os.ReadFile(file)
-	}, 0)
+	l := lint.New(os.ReadFile, 0)
 
 	filePath := filepath.Join(baseDir, fi.Name())
 	ps, err := l.Lint([][]string{{filePath}}, rules, lint.Config{
@@ -63,9 +61,7 @@ func assertSuccess(t *testing.T, baseDir string, fi os.FileInfo, rules []lint.Ru
 }
 
 func assertFailures(t *testing.T, baseDir string, fi os.FileInfo, src []byte, rules []lint.Rule, config map[string]lint.RuleConfig) error {
-	l := lint.New(func(file string) ([]byte, error) {
-		return os.ReadFile(file)
-	}, 0)
+	l := lint.New(os.ReadFile, 0)
 
 	ins := parseInstructions(t, filepath.Join(baseDir, fi.Name()), src)
 	if ins == nil {
@@ -173,7 +169,6 @@ func parseInstructions(t *testing.T, filename string, src []byte) []instruction 
 					t.Fatalf("At %v:%d: %v", filename, ln, err)
 				}
 				ins = append(ins, jsonInst)
-				break
 			case "classic":
 				match, err := extractPattern(line)
 				if err != nil {
@@ -198,9 +193,7 @@ func parseInstructions(t *testing.T, filename string, src []byte) []instruction 
 					Match:       match,
 					Replacement: repl,
 				})
-				break
 			}
-
 		}
 	}
 	return ins


### PR DESCRIPTION
This PR simplifies test code.

Explanation:

- `len(revive.lintingRules)` is `0` if `revive.lintingRules` is `nil`.
- The lambda `func(file string) ([]byte, error) { return os.ReadFile(file) }` can be simply `os.ReadFile`.
- Every case has an implicit `break` statement, which is familiar to every Go developer.