### PR TITLE
adds check on filenames to banned-characters rule

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -126,7 +126,7 @@ _Configuration_: N/A
 
 ## banned-characters
 
-_Description_: Checks given banned characters in identifiers(func, var, const). Comments are not checked.
+_Description_: Checks given banned characters in identifiers (func, var, const). Comments are not checked. The rule also warns on filenames with non-ASCII characters; this helps preventing attacks like the one described [here](https://www.arp242.net/jia-tan-go.html).
 
 _Configuration_: This rule requires a slice of strings, the characters to ban.
 

--- a/test/banned-characters_test.go
+++ b/test/banned-characters_test.go
@@ -15,3 +15,7 @@ func TestBannedCharacters(t *testing.T) {
 		Arguments: []any{"Ω", "Σ", "σ", "1"},
 	})
 }
+
+func TestBannedCharactersInFilename(t *testing.T) {
+	testRule(t, "banned-character_tеѕt", &rule.BannedCharsRule{}, &lint.RuleConfig{})
+}

--- a/testdata/banned-character_tеѕt.go
+++ b/testdata/banned-character_tеѕt.go
@@ -1,0 +1,4 @@
+package main
+
+// MATCH:1 /Non ASCII character е (U+0435) found in filename "../testdata/banned-character_tеѕt.go"/
+// MATCH:1 /Non ASCII character ѕ (U+0455) found in filename "../testdata/banned-character_tеѕt.go"/


### PR DESCRIPTION
Closes #1090 by adding filename checks to the `banned-characters` rule.
