### PR TITLE
chore: fix typo in test name

### DIFF
--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -14,7 +14,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestXDGConfigDirIsPrefferedFirst(t *testing.T) {
+func TestXDGConfigDirIsPreferredFirst(t *testing.T) {
 	t.Cleanup(func() {
 		// reset fs after test
 		AppFs = afero.NewMemMapFs()


### PR DESCRIPTION
The PR corrects a grammar mistake in the test name: `TestXDGConfigDirIsPrefferedFirst` -> `TestXDGConfigDirIsPreferredFirst`.