### PR TITLE
refactor: remove unused parameter in unexported function

### DIFF
--- a/rule/string-format.go
+++ b/rule/string-format.go
@@ -295,7 +295,7 @@ func (r *stringFormatSubrule) apply(call *ast.CallExpr, scope *stringFormatSubru
 		return
 	}
 
-	r.generateFailure(unquoted, lit)
+	r.generateFailure(lit)
 }
 
 func (r *stringFormatSubrule) stringIsOK(s string) bool {
@@ -307,7 +307,7 @@ func (r *stringFormatSubrule) stringIsOK(s string) bool {
 	return matches
 }
 
-func (r *stringFormatSubrule) generateFailure(s string, node ast.Node) {
+func (r *stringFormatSubrule) generateFailure(node ast.Node) {
 	var failure string
 	switch {
 	case len(r.errorMessage) > 0:


### PR DESCRIPTION
The PR removes unused parameter in the `stringFormatSubrule.generateFailure` unexported function to fix the warning:

```
❯ revive -config revive.toml ./...
rule/string-format.go:310:47: parameter 's' seems to be unused, consider removing or renaming it as _
```