### PR TITLE
chore: migrate goreleaser config to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 ---
+version: 2
 archives:
   - id: revive
     name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
@@ -27,5 +28,5 @@ changelog:
 checksum:
   name_template: checksums.txt
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 project_name: revive


### PR DESCRIPTION
This PR updates the GoReleaser configuration to v2.

Fixes #1104 