### PR TITLE
refactor: remove redundant defer

### DIFF
--- a/lint/linter.go
+++ b/lint/linter.go
@@ -109,7 +109,7 @@ func (l *Linter) Lint(packages [][]string, ruleSet []Rule, config Config) (<-cha
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
-			defer wg.Done()
+			wg.Done()
 		}(packages[n], perPkgVersions[n])
 	}
 

--- a/lint/package.go
+++ b/lint/package.go
@@ -189,7 +189,7 @@ func (p *Package) lint(rules []Rule, config Config, failures chan Failure) {
 		wg.Add(1)
 		go (func(file *File) {
 			file.lint(rules, config, failures)
-			defer wg.Done()
+			wg.Done()
 		})(file)
 	}
 	wg.Wait()


### PR DESCRIPTION
`defer wg.Done()` called at the end of a function block, so it is need to use `defer`.