### PR TITLE
refactor: simplify rule implementation with sync.Once

### DIFF
--- a/rule/add_constant.go
+++ b/rule/add_constant.go
@@ -36,12 +36,13 @@ type AddConstantRule struct {
 	allowList       allowList
 	ignoreFunctions []*regexp.Regexp
 	strLitLimit     int
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 // Apply applies the rule to given file.
 func (r *AddConstantRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 
@@ -201,9 +202,6 @@ func (w *lintAddConstantRule) isStructTag(n *ast.BasicLit) bool {
 }
 
 func (r *AddConstantRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
 	if r.allowList == nil {
 		r.strLitLimit = defaultStrLitLimit
 		r.allowList = newAllowList()

--- a/rule/argument_limit.go
+++ b/rule/argument_limit.go
@@ -11,18 +11,13 @@ import (
 // ArgumentsLimitRule lints given else constructs.
 type ArgumentsLimitRule struct {
 	max int
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultArgumentsLimit = 8
 
 func (r *ArgumentsLimitRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.max != 0 {
-		return
-	}
-
 	if len(arguments) < 1 {
 		r.max = defaultArgumentsLimit
 		return
@@ -37,7 +32,7 @@ func (r *ArgumentsLimitRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *ArgumentsLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 	onFailure := func(failure lint.Failure) {

--- a/rule/banned_characters.go
+++ b/rule/banned_characters.go
@@ -12,14 +12,13 @@ import (
 // BannedCharsRule checks if a file contains banned characters.
 type BannedCharsRule struct {
 	bannedCharList []string
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const bannedCharsRuleName = "banned-characters"
 
 func (r *BannedCharsRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
 	if r.bannedCharList == nil && len(arguments) > 0 {
 		checkNumberOfArguments(1, arguments, bannedCharsRuleName)
 		r.bannedCharList = r.getBannedCharsList(arguments)
@@ -28,7 +27,8 @@ func (r *BannedCharsRule) configure(arguments lint.Arguments) {
 
 // Apply applied the rule to the given file.
 func (r *BannedCharsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 	onFailure := func(failure lint.Failure) {

--- a/rule/cognitive_complexity.go
+++ b/rule/cognitive_complexity.go
@@ -13,18 +13,13 @@ import (
 // CognitiveComplexityRule lints given else constructs.
 type CognitiveComplexityRule struct {
 	maxComplexity int
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultMaxCognitiveComplexity = 7
 
 func (r *CognitiveComplexityRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.maxComplexity != 0 {
-		return // already configured
-	}
-
 	if len(arguments) < 1 {
 		r.maxComplexity = defaultMaxCognitiveComplexity
 		return
@@ -40,7 +35,7 @@ func (r *CognitiveComplexityRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *CognitiveComplexityRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 

--- a/rule/comment_spacings.go
+++ b/rule/comment_spacings.go
@@ -11,17 +11,12 @@ import (
 // CommentSpacingsRule check the whether there is a space between
 // the comment symbol( // ) and the start of the comment text
 type CommentSpacingsRule struct {
-	allowList []string
-	sync.Mutex
+	allowList     []string
+
+	configureOnce sync.Once
 }
 
 func (r *CommentSpacingsRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.allowList != nil {
-		return // already configured
-	}
-
 	r.allowList = []string{}
 	for _, arg := range arguments {
 		allow, ok := arg.(string) // Alt. non panicking version

--- a/rule/cyclomatic.go
+++ b/rule/cyclomatic.go
@@ -14,18 +14,13 @@ import (
 // CyclomaticRule lints given else constructs.
 type CyclomaticRule struct {
 	maxComplexity int
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultMaxCyclomaticComplexity = 10
 
 func (r *CyclomaticRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.maxComplexity != 0 {
-		return // already configured
-	}
-
 	if len(arguments) < 1 {
 		r.maxComplexity = defaultMaxCyclomaticComplexity
 		return
@@ -40,7 +35,7 @@ func (r *CyclomaticRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *CyclomaticRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 	fileAst := file.AST

--- a/rule/defer.go
+++ b/rule/defer.go
@@ -10,23 +10,18 @@ import (
 
 // DeferRule lints unused params in functions.
 type DeferRule struct {
-	allow map[string]bool
-	sync.Mutex
+	allow         map[string]bool
+
+	configureOnce sync.Once
 }
 
 func (r *DeferRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.allow != nil {
-		return // already configured
-	}
-
 	r.allow = r.allowFromArgs(arguments)
 }
 
 // Apply applies the rule to given file.
 func (r *DeferRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 	onFailure := func(failure lint.Failure) {

--- a/rule/dot_imports.go
+++ b/rule/dot_imports.go
@@ -10,13 +10,14 @@ import (
 
 // DotImportsRule lints given else constructs.
 type DotImportsRule struct {
-	sync.Mutex
 	allowedPackages allowPackages
+
+	configureOnce sync.Once
 }
 
 // Apply applies the rule to given file.
 func (r *DotImportsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 
@@ -41,9 +42,6 @@ func (*DotImportsRule) Name() string {
 }
 
 func (r *DotImportsRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
 	if r.allowedPackages != nil {
 		return
 	}

--- a/rule/enforce_map_style.go
+++ b/rule/enforce_map_style.go
@@ -39,20 +39,12 @@ func mapStyleFromString(s string) (enforceMapStyleType, error) {
 
 // EnforceMapStyleRule implements a rule to enforce `make(map[type]type)` over `map[type]type{}`.
 type EnforceMapStyleRule struct {
-	configured      bool
 	enforceMapStyle enforceMapStyleType
-	sync.Mutex
+
+	configureOnce   sync.Once
 }
 
 func (r *EnforceMapStyleRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
-	if r.configured {
-		return
-	}
-	r.configured = true
-
 	if len(arguments) < 1 {
 		r.enforceMapStyle = enforceMapStyleTypeAny
 		return
@@ -72,7 +64,7 @@ func (r *EnforceMapStyleRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *EnforceMapStyleRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	if r.enforceMapStyle == enforceMapStyleTypeAny {
 		// this linter is not configured

--- a/rule/enforce_repeated_arg_type_style.go
+++ b/rule/enforce_repeated_arg_type_style.go
@@ -41,22 +41,13 @@ func repeatedArgTypeStyleFromString(s string) enforceRepeatedArgTypeStyleType {
 
 // EnforceRepeatedArgTypeStyleRule implements a rule to enforce repeated argument type style.
 type EnforceRepeatedArgTypeStyleRule struct {
-	configured      bool
 	funcArgStyle    enforceRepeatedArgTypeStyleType
 	funcRetValStyle enforceRepeatedArgTypeStyleType
 
-	sync.Mutex
+	configureOnce sync.Once
 }
 
 func (r *EnforceRepeatedArgTypeStyleRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
-	if r.configured {
-		return
-	}
-	r.configured = true
-
 	r.funcArgStyle = enforceRepeatedArgTypeStyleTypeAny
 	r.funcRetValStyle = enforceRepeatedArgTypeStyleTypeAny
 
@@ -94,7 +85,7 @@ func (r *EnforceRepeatedArgTypeStyleRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to a given file.
 func (r *EnforceRepeatedArgTypeStyleRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	if r.funcArgStyle == enforceRepeatedArgTypeStyleTypeAny && r.funcRetValStyle == enforceRepeatedArgTypeStyleTypeAny {
 		// This linter is not configured, return no failures.

--- a/rule/enforce_slice_style.go
+++ b/rule/enforce_slice_style.go
@@ -43,20 +43,12 @@ func sliceStyleFromString(s string) (enforceSliceStyleType, error) {
 
 // EnforceSliceStyleRule implements a rule to enforce `make([]type)` over `[]type{}`.
 type EnforceSliceStyleRule struct {
-	configured        bool
 	enforceSliceStyle enforceSliceStyleType
-	sync.Mutex
+
+	configureOnce     sync.Once
 }
 
 func (r *EnforceSliceStyleRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
-	if r.configured {
-		return
-	}
-	r.configured = true
-
 	if len(arguments) < 1 {
 		r.enforceSliceStyle = enforceSliceStyleTypeAny
 		return
@@ -76,7 +68,7 @@ func (r *EnforceSliceStyleRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *EnforceSliceStyleRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	if r.enforceSliceStyle == enforceSliceStyleTypeAny {
 		// this linter is not configured

--- a/rule/error_strings.go
+++ b/rule/error_strings.go
@@ -15,13 +15,11 @@ import (
 // ErrorStringsRule lints given else constructs.
 type ErrorStringsRule struct {
 	errorFunctions map[string]map[string]struct{}
-	sync.Mutex
+
+	configureOnce  sync.Once
 }
 
 func (r *ErrorStringsRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
 	if r.errorFunctions != nil {
 		return
 	}
@@ -60,7 +58,7 @@ func (r *ErrorStringsRule) configure(arguments lint.Arguments) {
 func (r *ErrorStringsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	fileAst := file.AST
 	walker := lintErrorStrings{

--- a/rule/file_header.go
+++ b/rule/file_header.go
@@ -11,7 +11,8 @@ import (
 // FileHeaderRule lints given else constructs.
 type FileHeaderRule struct {
 	header string
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 var (
@@ -20,12 +21,6 @@ var (
 )
 
 func (r *FileHeaderRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.header != "" {
-		return // already configured
-	}
-
 	if len(arguments) < 1 {
 		return
 	}
@@ -39,7 +34,7 @@ func (r *FileHeaderRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *FileHeaderRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	if r.header == "" {
 		return nil

--- a/rule/file_length_limit.go
+++ b/rule/file_length_limit.go
@@ -20,12 +20,13 @@ type FileLengthLimitRule struct {
 	skipComments bool
 	// skipBlankLines indicates whether to skip blank lines when counting lines.
 	skipBlankLines bool
-	sync.Mutex
+
+	configureOnce  sync.Once
 }
 
 // Apply applies the rule to given file.
 func (r *FileLengthLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	if r.max <= 0 {
 		// when max is negative or 0 the rule is disabled
@@ -75,13 +76,6 @@ func (r *FileLengthLimitRule) Apply(file *lint.File, arguments lint.Arguments) [
 }
 
 func (r *FileLengthLimitRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
-	if r.max != 0 {
-		return // already configured
-	}
-
 	if len(arguments) < 1 {
 		return // use default
 	}

--- a/rule/function_length.go
+++ b/rule/function_length.go
@@ -11,20 +11,13 @@ import (
 
 // FunctionLength lint.
 type FunctionLength struct {
-	maxStmt    int
-	maxLines   int
-	configured bool
-	sync.Mutex
+	maxStmt  int
+	maxLines int
+
+	configureOnce sync.Once
 }
 
 func (r *FunctionLength) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.configured {
-		return
-	}
-
-	r.configured = true
 	maxStmt, maxLines := r.parseArguments(arguments)
 	r.maxStmt = int(maxStmt)
 	r.maxLines = int(maxLines)
@@ -32,7 +25,7 @@ func (r *FunctionLength) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *FunctionLength) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 

--- a/rule/function_result_limit.go
+++ b/rule/function_result_limit.go
@@ -11,18 +11,13 @@ import (
 // FunctionResultsLimitRule lints given else constructs.
 type FunctionResultsLimitRule struct {
 	max int
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultResultsLimit = 3
 
 func (r *FunctionResultsLimitRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.max != 0 {
-		return // already configured
-	}
-
 	if len(arguments) < 1 {
 		r.max = defaultResultsLimit
 		return
@@ -41,7 +36,7 @@ func (r *FunctionResultsLimitRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *FunctionResultsLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 

--- a/rule/import_alias_naming.go
+++ b/rule/import_alias_naming.go
@@ -10,10 +10,10 @@ import (
 
 // ImportAliasNamingRule lints import alias naming.
 type ImportAliasNamingRule struct {
-	configured  bool
 	allowRegexp *regexp.Regexp
 	denyRegexp  *regexp.Regexp
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultImportAliasNamingAllowRule = "^[a-z][a-z0-9]{0,}$"
@@ -21,12 +21,6 @@ const defaultImportAliasNamingAllowRule = "^[a-z][a-z0-9]{0,}$"
 var defaultImportAliasNamingAllowRegexp = regexp.MustCompile(defaultImportAliasNamingAllowRule)
 
 func (r *ImportAliasNamingRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.configured {
-		return
-	}
-
 	if len(arguments) == 0 {
 		r.allowRegexp = defaultImportAliasNamingAllowRegexp
 		return
@@ -57,7 +51,7 @@ func (r *ImportAliasNamingRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *ImportAliasNamingRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 

--- a/rule/imports_blocklist.go
+++ b/rule/imports_blocklist.go
@@ -11,29 +11,25 @@ import (
 // ImportsBlocklistRule lints given else constructs.
 type ImportsBlocklistRule struct {
 	blocklist []*regexp.Regexp
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 var replaceImportRegexp = regexp.MustCompile(`/?\*\*/?`)
 
 func (r *ImportsBlocklistRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
+	r.blocklist = make([]*regexp.Regexp, 0)
 
-	if r.blocklist == nil {
-		r.blocklist = make([]*regexp.Regexp, 0)
-
-		for _, arg := range arguments {
-			argStr, ok := arg.(string)
-			if !ok {
-				panic(fmt.Sprintf("Invalid argument to the imports-blocklist rule. Expecting a string, got %T", arg))
-			}
-			regStr, err := regexp.Compile(fmt.Sprintf(`(?m)"%s"$`, replaceImportRegexp.ReplaceAllString(argStr, `(\W|\w)*`)))
-			if err != nil {
-				panic(fmt.Sprintf("Invalid argument to the imports-blocklist rule. Expecting %q to be a valid regular expression, got: %v", argStr, err))
-			}
-			r.blocklist = append(r.blocklist, regStr)
+	for _, arg := range arguments {
+		argStr, ok := arg.(string)
+		if !ok {
+			panic(fmt.Sprintf("Invalid argument to the imports-blocklist rule. Expecting a string, got %T", arg))
 		}
+		regStr, err := regexp.Compile(fmt.Sprintf(`(?m)"%s"$`, replaceImportRegexp.ReplaceAllString(argStr, `(\W|\w)*`)))
+		if err != nil {
+			panic(fmt.Sprintf("Invalid argument to the imports-blocklist rule. Expecting %q to be a valid regular expression, got: %v", argStr, err))
+		}
+		r.blocklist = append(r.blocklist, regStr)
 	}
 }
 
@@ -48,7 +44,7 @@ func (r *ImportsBlocklistRule) isBlocklisted(path string) bool {
 
 // Apply applies the rule to given file.
 func (r *ImportsBlocklistRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 

--- a/rule/line_length_limit.go
+++ b/rule/line_length_limit.go
@@ -15,18 +15,13 @@ import (
 // LineLengthLimitRule lints given else constructs.
 type LineLengthLimitRule struct {
 	max int
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultLineLengthLimit = 80
 
 func (r *LineLengthLimitRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.max != 0 {
-		return // already configured
-	}
-
 	if len(arguments) < 1 {
 		r.max = defaultLineLengthLimit
 		return
@@ -42,7 +37,7 @@ func (r *LineLengthLimitRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *LineLengthLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 

--- a/rule/max_control_nesting.go
+++ b/rule/max_control_nesting.go
@@ -11,14 +11,15 @@ import (
 // MaxControlNestingRule lints given else constructs.
 type MaxControlNestingRule struct {
 	max int64
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultMaxControlNesting = 5
 
 // Apply applies the rule to given file.
 func (r *MaxControlNestingRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 
@@ -107,12 +108,6 @@ func (w *lintMaxControlNesting) walkControlledBlock(b ast.Node) {
 }
 
 func (r *MaxControlNestingRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if !(r.max < 1) {
-		return // max already configured
-	}
-
 	if len(arguments) < 1 {
 		r.max = defaultMaxControlNesting
 		return

--- a/rule/max_public_structs.go
+++ b/rule/max_public_structs.go
@@ -11,18 +11,13 @@ import (
 // MaxPublicStructsRule lints given else constructs.
 type MaxPublicStructsRule struct {
 	max int64
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultMaxPublicStructs = 5
 
 func (r *MaxPublicStructsRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.max == 0 {
-		return // already configured
-	}
-
 	if len(arguments) < 1 {
 		r.max = defaultMaxPublicStructs
 		return
@@ -39,7 +34,7 @@ func (r *MaxPublicStructsRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *MaxPublicStructsRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
-	r.configure(arguments)
+	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
 

--- a/rule/receiver_naming.go
+++ b/rule/receiver_naming.go
@@ -12,18 +12,13 @@ import (
 // ReceiverNamingRule lints given else constructs.
 type ReceiverNamingRule struct {
 	receiverNameMaxLength int
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 const defaultReceiverNameMaxLength = -1 // thus will not check
 
 func (r *ReceiverNamingRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-	if r.receiverNameMaxLength != 0 {
-		return
-	}
-
 	r.receiverNameMaxLength = defaultReceiverNameMaxLength
 	if len(arguments) < 1 {
 		return
@@ -50,7 +45,7 @@ func (r *ReceiverNamingRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *ReceiverNamingRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
-	r.configure(args)
+	r.configureOnce.Do(func() { r.configure(args) })
 
 	var failures []lint.Failure
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -14,13 +14,11 @@ import (
 // StructTagRule lints struct tags.
 type StructTagRule struct {
 	userDefined map[string][]string // map: key -> []option
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 func (r *StructTagRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
 	mustConfigure := r.userDefined == nil && len(arguments) > 0
 	if !mustConfigure {
 		return
@@ -47,7 +45,7 @@ func (r *StructTagRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *StructTagRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
-	r.configure(args)
+	r.configureOnce.Do(func() { r.configure(args) })
 
 	var failures []lint.Failure
 	onFailure := func(failure lint.Failure) {

--- a/rule/unchecked_type_assertion.go
+++ b/rule/unchecked_type_assertion.go
@@ -15,20 +15,15 @@ const (
 
 // UncheckedTypeAssertionRule lints missing or ignored `ok`-value in dynamic type casts.
 type UncheckedTypeAssertionRule struct {
-	sync.Mutex
 	acceptIgnoredAssertionResult bool
-	configured                   bool
+
+	configureOnce sync.Once
 }
 
 func (u *UncheckedTypeAssertionRule) configure(arguments lint.Arguments) {
-	u.Lock()
-	defer u.Unlock()
-
-	if len(arguments) == 0 || u.configured {
+	if len(arguments) == 0 {
 		return
 	}
-
-	u.configured = true
 
 	args, ok := arguments[0].(map[string]any)
 	if !ok {
@@ -50,7 +45,7 @@ func (u *UncheckedTypeAssertionRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (u *UncheckedTypeAssertionRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
-	u.configure(args)
+	u.configureOnce.Do(func() { u.configure(args) })
 
 	var failures []lint.Failure
 

--- a/rule/unhandled_error.go
+++ b/rule/unhandled_error.go
@@ -14,17 +14,11 @@ import (
 // UnhandledErrorRule lints given else constructs.
 type UnhandledErrorRule struct {
 	ignoreList []*regexp.Regexp
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 func (r *UnhandledErrorRule) configure(arguments lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
-	if r.ignoreList != nil {
-		return // already configured
-	}
-
 	for _, arg := range arguments {
 		argStr, ok := arg.(string)
 		if !ok {
@@ -47,7 +41,7 @@ func (r *UnhandledErrorRule) configure(arguments lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *UnhandledErrorRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
-	r.configure(args)
+	r.configureOnce.Do(func() { r.configure(args) })
 
 	var failures []lint.Failure
 

--- a/rule/unused_param.go
+++ b/rule/unused_param.go
@@ -11,22 +11,14 @@ import (
 
 // UnusedParamRule lints unused params in functions.
 type UnusedParamRule struct {
-	configured bool
 	// regex to check if some name is valid for unused parameter, "^_$" by default
 	allowRegex *regexp.Regexp
 	failureMsg string
-	sync.Mutex
+
+	configureOnce sync.Once
 }
 
 func (r *UnusedParamRule) configure(args lint.Arguments) {
-	r.Lock()
-	defer r.Unlock()
-
-	if r.configured {
-		return
-	}
-	r.configured = true
-
 	// while by default args is an array, i think it's good to provide structures inside it by default, not arrays or primitives
 	// it's more compatible to JSON nature of configurations
 	var allowedRegexStr string
@@ -58,7 +50,7 @@ func (r *UnusedParamRule) configure(args lint.Arguments) {
 
 // Apply applies the rule to given file.
 func (r *UnusedParamRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
-	r.configure(args)
+	r.configureOnce.Do(func() { r.configure(args) })
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {


### PR DESCRIPTION
This PR refactors rules implementation by using `sync.Once` instead of `sync.Mutex`.