### PR TITLE
docs: range-val-* rules are irrelevant for Go 1.22+

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -756,12 +756,16 @@ _Description_: Range variables in a loop are reused at each iteration. This rule
 
 _Configuration_: N/A
 
+_Note_: This rule is irrelevant for Go 1.22+.
+
 ## range-val-in-closure
 
 _Description_: Range variables in a loop are reused at each iteration; therefore a goroutine created in a loop will point to the range variable with from the upper scope. This way, the goroutine could use the variable with an undesired value.
 This rule warns when a range value (or index) is used inside a closure
 
 _Configuration_: N/A
+
+_Note_: This rule is irrelevant for Go 1.22+.
 
 ## range
 


### PR DESCRIPTION
This PR extends the description for `range-val-address` and `range-val-in-closure` with a note that these rules are irrelevant for Go versions greater than or equal to 1.22.

Follows #993.