### PR TITLE
refactor: use toml.Unmarshal instead of toml.Decode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -165,7 +165,7 @@ func parseConfig(path string, config *lint.Config) error {
 	if err != nil {
 		return errors.New("cannot read the config file")
 	}
-	_, err = toml.Decode(string(file), config)
+	err = toml.Unmarshal(file, config)
 	if err != nil {
 		return fmt.Errorf("cannot parse the config file: %v", err)
 	}


### PR DESCRIPTION
The PR refactors `parseConfig` implementation to use [`toml.Unmarshal`](https://pkg.go.dev/github.com/BurntSushi/toml#Unmarshal) instead of [`toml.Decode`](https://pkg.go.dev/github.com/BurntSushi/toml#Decode). The first accepts the `data` as `[]byte`, the second as `string`. This removes one conversion between from `[]byte` to `string`.

Benchmark says that this refactoring saves one allocation without increasing `parseConfig` complexity.

<details><summary>Benchmarks</summary>
<p>

```go
func BenchmarkParseConfig(b *testing.B) {
	var config lint.Config

	configPath := filepath.Join("..", "full.toml")

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		err := parseConfig(configPath, &config)
		if err != nil {
			b.Fatalf("failed to parse config: %v", err)
		}
	}
}

func BenchmarkParseConfigString(b *testing.B) {
	var config lint.Config

	configPath := filepath.Join("..", "full.toml")

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		err := parseConfigString(configPath, &config)
		if err != nil {
			b.Fatalf("failed to parse config: %v", err)
		}
	}
}
```

```sh
❯ go test -benchmem -bench=. ./...
goos: darwin
goarch: arm64
pkg: github.com/mgechev/revive/config
cpu: Apple M1 Pro
BenchmarkParseConfig-8              5030            213835 ns/op          158632 B/op       1789 allocs/op
BenchmarkParseConfigString-8        5779            210645 ns/op          161789 B/op       1790 allocs/op
PASS
ok      github.com/mgechev/revive/config        2.752s
```

</p>
</details> 