### PR TITLE
fix: revive hangs on Windows if go.mod is not found

### DIFF
--- a/lint/linter.go
+++ b/lint/linter.go
@@ -184,7 +184,9 @@ func detectGoMod(dir string) (rootDir string, ver *goversion.Version, err error)
 func retrieveModFile(dir string) (string, error) {
 	const lookingForFile = "go.mod"
 	for {
-		if dir == "." || dir == "/" {
+		// filepath.Dir returns 'C:\' on Windows, and '/' on Unix
+		isRootDir := (dir == filepath.VolumeName(dir)+string(filepath.Separator))
+		if dir == "." || isRootDir {
 			return "", fmt.Errorf("did not found %q file", lookingForFile)
 		}
 

--- a/lint/linter_test.go
+++ b/lint/linter_test.go
@@ -1,6 +1,44 @@
 package lint
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRetrieveModFile(t *testing.T) {
+	t.Run("go.mod file exists", func(t *testing.T) {
+		nestedDir := filepath.Join(t.TempDir(), "nested", "dir", "structure")
+		err := os.MkdirAll(nestedDir, 0o755)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		modFilePath := filepath.Join(nestedDir, "go.mod")
+		err = os.WriteFile(modFilePath, []byte("module example.com/test"), 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		foundPath, err := retrieveModFile(nestedDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if foundPath != modFilePath {
+			t.Fatalf("expected %q, got %q", modFilePath, foundPath)
+		}
+	})
+
+	t.Run("go.mod file does not exist", func(t *testing.T) {
+		_, err := retrieveModFile(t.TempDir())
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedErrMsg := `did not found "go.mod" file`
+		if err.Error() != expectedErrMsg {
+			t.Fatalf("expected error message %q, got %q", expectedErrMsg, err.Error())
+		}
+	})
+}
 
 // TestIsGenerated tests isGenerated function.
 func TestIsGenerated(t *testing.T) { //revive:disable-line:exported


### PR DESCRIPTION
The PR fixes #1120.

The problem is the `retrieveModFile` function, which hangs forever when `go.mod` is not found. `filepath.Dir` returns `C:/` on Windows, but the implementation expects `"."` or `"/"`.

The bug appeared after changing `path.Dir` to `filepath.Dir` in #1073. We can revert to using `path.Dir`, but a better solution is to add `strings.TrimPrefix(dir, filepath.VolumeName(dir))` for Windows.