### PR TITLE
refactor: extract getVersion function

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -16,11 +16,18 @@ import (
 	"github.com/spf13/afero"
 )
 
+const (
+	default_version = "dev"
+	default_commit  = "none"
+	default_date    = "unknown"
+	default_builder = "unknown"
+)
+
 var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-	builtBy = "unknown"
+	version = default_version
+	commit  = default_commit
+	date    = default_date
+	builtBy = default_builder
 	//AppFs is used to operations related with user config files
 	AppFs = afero.NewOsFs()
 )
@@ -37,7 +44,7 @@ func RunRevive(extraRules ...revivelib.ExtraRule) {
 	initConfig()
 
 	if versionFlag {
-		fmt.Print(getVersion())
+		fmt.Print(getVersion(builtBy, date, commit, version))
 		os.Exit(0)
 	}
 
@@ -169,17 +176,17 @@ func initConfig() {
 }
 
 // getVersion returns build info (version, commit, date and builtBy)
-func getVersion() string {
+func getVersion(builtBy, date, commit, version string) string {
 	var buildInfo string
-	if date != "unknown" && builtBy != "unknown" {
+	if date != default_date && builtBy != default_builder {
 		buildInfo = fmt.Sprintf("Built\t\t%s by %s\n", date, builtBy)
 	}
 
-	if commit != "none" {
+	if commit != default_commit {
 		buildInfo = fmt.Sprintf("Commit:\t\t%s\n%s", commit, buildInfo)
 	}
 
-	if version == "dev" {
+	if version == default_version {
 		bi, ok := debug.ReadBuildInfo()
 		if ok {
 			version = bi.Main.Version

--- a/cli/main.go
+++ b/cli/main.go
@@ -17,17 +17,17 @@ import (
 )
 
 const (
-	default_version = "dev"
-	default_commit  = "none"
-	default_date    = "unknown"
-	default_builder = "unknown"
+	defaultVersion = "dev"
+	defaultCommit  = "none"
+	defaultDate    = "unknown"
+	defaultBuilder = "unknown"
 )
 
 var (
-	version = default_version
-	commit  = default_commit
-	date    = default_date
-	builtBy = default_builder
+	version = defaultVersion
+	commit  = defaultCommit
+	date    = defaultDate
+	builtBy = defaultBuilder
 	//AppFs is used to operations related with user config files
 	AppFs = afero.NewOsFs()
 )
@@ -178,15 +178,15 @@ func initConfig() {
 // getVersion returns build info (version, commit, date and builtBy)
 func getVersion(builtBy, date, commit, version string) string {
 	var buildInfo string
-	if date != default_date && builtBy != default_builder {
+	if date != defaultDate && builtBy != defaultBuilder {
 		buildInfo = fmt.Sprintf("Built\t\t%s by %s\n", date, builtBy)
 	}
 
-	if commit != default_commit {
+	if commit != defaultCommit {
 		buildInfo = fmt.Sprintf("Commit:\t\t%s\n%s", commit, buildInfo)
 	}
 
-	if version == default_version {
+	if version == defaultVersion {
 		bi, ok := debug.ReadBuildInfo()
 		if ok {
 			version = bi.Main.Version

--- a/cli/main.go
+++ b/cli/main.go
@@ -191,7 +191,7 @@ func getVersion(builtBy, date, commit, version string) string {
 		if ok {
 			version = bi.Main.Version
 			if strings.HasPrefix(version, "v") {
-				version = bi.Main.Version[1:]
+				version = strings.TrimLeft(bi.Main.Version, "v")
 			}
 			if len(buildInfo) == 0 {
 				return fmt.Sprintf("version %s\n", version)

--- a/cli/main.go
+++ b/cli/main.go
@@ -35,6 +35,12 @@ func RunRevive(extraRules ...revivelib.ExtraRule) {
 	// move parsing flags outside of init() otherwise tests dont works properly
 	// more info: https://github.com/golang/go/issues/46869#issuecomment-865695953
 	initConfig()
+
+	if versionFlag {
+		fmt.Print(getVersion())
+		os.Exit(0)
+	}
+
 	conf, err := config.GetConfig(configPath)
 	if err != nil {
 		fail(err.Error())
@@ -160,35 +166,33 @@ func initConfig() {
 	flag.BoolVar(&setExitStatus, "set_exit_status", false, exitStatusUsage)
 	flag.IntVar(&maxOpenFiles, "max_open_files", 0, maxOpenFilesUsage)
 	flag.Parse()
+}
 
-	// Output build info (version, commit, date and builtBy)
-	if versionFlag {
-		var buildInfo string
-		if date != "unknown" && builtBy != "unknown" {
-			buildInfo = fmt.Sprintf("Built\t\t%s by %s\n", date, builtBy)
-		}
+// getVersion returns build info (version, commit, date and builtBy)
+func getVersion() string {
+	var buildInfo string
+	if date != "unknown" && builtBy != "unknown" {
+		buildInfo = fmt.Sprintf("Built\t\t%s by %s\n", date, builtBy)
+	}
 
-		if commit != "none" {
-			buildInfo = fmt.Sprintf("Commit:\t\t%s\n%s", commit, buildInfo)
-		}
+	if commit != "none" {
+		buildInfo = fmt.Sprintf("Commit:\t\t%s\n%s", commit, buildInfo)
+	}
 
-		if version == "dev" {
-			bi, ok := debug.ReadBuildInfo()
-			if ok {
-				version = bi.Main.Version
-				if strings.HasPrefix(version, "v") {
-					version = bi.Main.Version[1:]
-				}
-				if len(buildInfo) == 0 {
-					fmt.Printf("version %s\n", version)
-					os.Exit(0)
-				}
+	if version == "dev" {
+		bi, ok := debug.ReadBuildInfo()
+		if ok {
+			version = bi.Main.Version
+			if strings.HasPrefix(version, "v") {
+				version = bi.Main.Version[1:]
+			}
+			if len(buildInfo) == 0 {
+				return fmt.Sprintf("version %s\n", version)
 			}
 		}
-
-		fmt.Printf("Version:\t%s\n%s", version, buildInfo)
-		os.Exit(0)
 	}
+
+	return fmt.Sprintf("Version:\t%s\n%s", version, buildInfo)
 }
 
 func fileExist(path string) bool {

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -98,10 +98,10 @@ func TestGetVersion(t *testing.T) {
 	}{
 		{
 			name:    "Development version",
-			version: "dev",
-			commit:  "none",
-			date:    "unknown",
-			builtBy: "unknown",
+			version: default_version,
+			commit:  default_commit,
+			date:    default_date,
+			builtBy: default_builder,
 			want:    "version \n",
 		},
 		{
@@ -119,23 +119,7 @@ Built		2024-11-15 10:52 UTC by builder
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldVersion := version
-			oldCommit := commit
-			oldDate := date
-			oldBuiltBy := builtBy
-			t.Cleanup(func() {
-				version = oldVersion
-				commit = oldCommit
-				date = oldDate
-				builtBy = oldBuiltBy
-			})
-
-			version = tt.version
-			commit = tt.commit
-			date = tt.date
-			builtBy = tt.builtBy
-
-			got := getVersion()
+			got := getVersion(tt.builtBy, tt.date, tt.commit, tt.version)
 
 			if got != tt.want {
 				t.Errorf("getVersion() = %q, want %q", got, tt.want)

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -98,10 +98,10 @@ func TestGetVersion(t *testing.T) {
 	}{
 		{
 			name:    "Development version",
-			version: default_version,
-			commit:  default_commit,
-			date:    default_date,
-			builtBy: default_builder,
+			version: defaultVersion,
+			commit:  defaultCommit,
+			date:    defaultDate,
+			builtBy: defaultBuilder,
 			want:    "version \n",
 		},
 		{

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -86,3 +86,60 @@ func TestXDGConfigDirNoFile(t *testing.T) {
 		t.Errorf("got %q, wanted %q", got, want)
 	}
 }
+
+func TestGetVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		commit  string
+		date    string
+		builtBy string
+		want    string
+	}{
+		{
+			name:    "Development version",
+			version: "dev",
+			commit:  "none",
+			date:    "unknown",
+			builtBy: "unknown",
+			want:    "version \n",
+		},
+		{
+			name:    "Release version",
+			version: "v1.5.0-12-g7ee4500-dev",
+			commit:  "7ee4500e125e2d1b12653b2c8e140fec380919b4",
+			date:    "2024-11-15 10:52 UTC",
+			builtBy: "builder",
+			want: `Version:	v1.5.0-12-g7ee4500-dev
+Commit:		7ee4500e125e2d1b12653b2c8e140fec380919b4
+Built		2024-11-15 10:52 UTC by builder
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldVersion := version
+			oldCommit := commit
+			oldDate := date
+			oldBuiltBy := builtBy
+			t.Cleanup(func() {
+				version = oldVersion
+				commit = oldCommit
+				date = oldDate
+				builtBy = oldBuiltBy
+			})
+
+			version = tt.version
+			commit = tt.commit
+			date = tt.date
+			builtBy = tt.builtBy
+
+			got := getVersion()
+
+			if got != tt.want {
+				t.Errorf("getVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The PR extracts some functionality to the `getVersion()` function and adds tests for it.