### PR TITLE
fix: rule description URL

### DIFF
--- a/formatter/default.go
+++ b/formatter/default.go
@@ -26,3 +26,7 @@ func (*Default) Format(failures <-chan lint.Failure, _ lint.Config) (string, err
 	}
 	return buf.String(), nil
 }
+
+func ruleDescriptionURL(ruleName string) string {
+	return "https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#" + ruleName
+}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -50,7 +50,7 @@ func TestFormatter(t *testing.T) {
 		{
 			formatter: &formatter.Friendly{},
 			want: `
-⚠  https://revive.run/r#rule  test failure  
+⚠  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
   test.go:2:5
 
 ⚠ 1 problem (0 errors, 1 warning)
@@ -69,7 +69,7 @@ Warnings:
 		},
 		{
 			formatter: &formatter.Plain{},
-			want:      `test.go:2:5: test failure https://revive.run/r#rule`,
+			want:      `test.go:2:5: test failure https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule`,
 		},
 		{
 			formatter: &formatter.Sarif{},
@@ -100,7 +100,7 @@ Warnings:
       ],
       "tool": {
         "driver": {
-          "informationUri": "https://revive.run",
+          "informationUri": "https://github.com/mgechev/revive",
           "name": "revive"
         }
       }
@@ -114,7 +114,7 @@ Warnings:
 			formatter: &formatter.Stylish{},
 			want: `
 test.go
-  (2, 5)  https://revive.run/r#rule  test failure  
+  (2, 5)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
 
 
  ✖ 1 problem (0 errors) (1 warnings)

--- a/formatter/friendly.go
+++ b/formatter/friendly.go
@@ -67,7 +67,7 @@ func (f *Friendly) printHeaderRow(w io.Writer, failure lint.Failure, severity li
 	if severity == lint.SeverityError {
 		emoji = getErrorEmoji()
 	}
-	fmt.Fprint(w, f.table([][]string{{emoji, "https://revive.run/r#" + failure.RuleName, color.GreenString(failure.Failure)}}))
+	fmt.Fprint(w, f.table([][]string{{emoji, ruleDescriptionURL(failure.RuleName), color.GreenString(failure.Failure)}}))
 }
 
 func (*Friendly) printFilePosition(w io.Writer, failure lint.Failure) {

--- a/formatter/plain.go
+++ b/formatter/plain.go
@@ -22,7 +22,7 @@ func (*Plain) Name() string {
 func (*Plain) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
 	var buf bytes.Buffer
 	for failure := range failures {
-		fmt.Fprintf(&buf, "%v: %s %s\n", failure.Position.Start, failure.Failure, "https://revive.run/r#"+failure.RuleName)
+		fmt.Fprintf(&buf, "%v: %s %s\n", failure.Position.Start, failure.Failure, ruleDescriptionURL(failure.RuleName))
 	}
 	return buf.String(), nil
 }

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -20,7 +20,7 @@ func (*Sarif) Name() string {
 	return "sarif"
 }
 
-const reviveSite = "https://revive.run"
+const reviveSite = "https://github.com/mgechev/revive"
 
 // Format formats the failures gotten from the lint.
 func (*Sarif) Format(failures <-chan lint.Failure, cfg lint.Config) (string, error) {

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -22,11 +22,12 @@ func (*Stylish) Name() string {
 
 func formatFailure(failure lint.Failure, severity lint.Severity) []string {
 	fString := color.CyanString(failure.Failure)
-	fName := color.RedString("https://revive.run/r#" + failure.RuleName)
+	fURL := ruleDescriptionURL(failure.RuleName)
+	fName := color.RedString(fURL)
 	lineColumn := failure.Position
 	pos := fmt.Sprintf("(%d, %d)", lineColumn.Start.Line, lineColumn.Start.Column)
 	if severity == lint.SeverityWarning {
-		fName = color.YellowString("https://revive.run/r#" + failure.RuleName)
+		fName = color.YellowString(fURL)
 	}
 	return []string{failure.GetFilename(), pos, fName, fString}
 }

--- a/revivelib/core_test.go
+++ b/revivelib/core_test.go
@@ -54,11 +54,11 @@ func TestReviveFormat(t *testing.T) {
 	}
 
 	errorMsgs := []string{
-		"(91, 3)  https://revive.run/r#unreachable-code  unreachable code after this statement",
-		"(98, 3)  https://revive.run/r#unreachable-code  unreachable code after this statement",
-		"(15, 2)  https://revive.run/r#if-return         redundant if ...; err != nil check, just return error instead.",
-		"(88, 3)  https://revive.run/r#if-return         redundant if ...; err != nil check, just return error instead.",
-		"(95, 3)  https://revive.run/r#if-return         redundant if ...; err != nil check, just return error instead.",
+		"(91, 3)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code  unreachable code after this statement",
+		"(98, 3)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code  unreachable code after this statement",
+		"(15, 2)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return         redundant if ...; err != nil check, just return error instead.",
+		"(88, 3)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return         redundant if ...; err != nil check, just return error instead.",
+		"(95, 3)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return         redundant if ...; err != nil check, just return error instead.",
 	}
 	for _, errorMsg := range errorMsgs {
 		if !strings.Contains(failures, errorMsg) {


### PR DESCRIPTION
This PR fixes the link to a rule description by replacing the string `https://revive.run/r#` with `https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#`. `revive.run` is [outdated](https://github.com/mgechev/revive.run/issues/60) and no longer contains descriptions for all rules.

Fixes #1062