### PR TITLE
Filename-format rule: fix filename extension regex: ".go" to "\\.go".

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -521,7 +521,7 @@ Example:
 ```
 
 ## filename-format
-_Description_: enforces conventions on source file names. By default, the rule enforces filenames of the form `^[_A-Za-z0-9][_A-Za-z0-9-]*.go$`: Optionally, the rule can be configured to enforce other forms.
+_Description_: enforces conventions on source file names. By default, the rule enforces filenames of the form `^[_A-Za-z0-9][_A-Za-z0-9-]*\.go$`: Optionally, the rule can be configured to enforce other forms.
 
 _Configuration_: (string) regular expression for source filenames.
 
@@ -529,7 +529,7 @@ Example:
 
 ```toml
 [rule.filename-format]
-    arguments=["^[_a-z][_a-z0-9]*.go$"]
+    arguments=["^[_a-z][_a-z0-9]*\\.go$"]
 ```
 
 ## flag-parameter

--- a/revive.toml
+++ b/revive.toml
@@ -21,7 +21,7 @@ warningCode = 1
 [rule.exported]
 [rule.filename-format]
     # Override the default pattern to forbid .go files with uppercase letters and dashes.
-    arguments=["^[_a-z][_a-z0-9]*.go$"]
+    arguments=["^[_a-z][_a-z0-9]*\\.go$"]
 [rule.increment-decrement]
 [rule.indent-error-flow]
 [rule.line-length-limit]

--- a/rule/filename_format.go
+++ b/rule/filename_format.go
@@ -53,7 +53,7 @@ func (*FilenameFormatRule) Name() string {
 	return "filename-format"
 }
 
-var defaultFormat = regexp.MustCompile("^[_A-Za-z0-9][_A-Za-z0-9-]*.go$")
+var defaultFormat = regexp.MustCompile(`^[_A-Za-z0-9][_A-Za-z0-9-]*\.go$`)
 
 func (r *FilenameFormatRule) configure(arguments lint.Arguments) {
 	argsCount := len(arguments)

--- a/testdata/filenamе_with_non_ascii_char.go
+++ b/testdata/filenamе_with_non_ascii_char.go
@@ -1,3 +1,3 @@
 package main
 
-// MATCH:1 /Filename filenamе_with_non_ascii_char.go is not of the format ^[_A-Za-z0-9][_A-Za-z0-9-]*.go$. Non ASCII character е (U+0435) found./
+// MATCH:1 /Filename filenamе_with_non_ascii_char.go is not of the format ^[_A-Za-z0-9][_A-Za-z0-9-]*\.go$. Non ASCII character е (U+0435) found./


### PR DESCRIPTION
Just a quick fix for an obvious issue with the filename regex. Filename extension's dot wasn't escaped so, for example, "awesome$go" was considered a valid filename.