### PR TITLE
feat: optional extension to early-return rule (#1133)

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -346,12 +346,13 @@ if !cond {
 _Configuration_: ([]string) rule flags. Available flags are:
 
 * _preserveScope_: do not suggest refactorings that would increase variable scope
+* _allowJump_: suggest a new jump (`return`, `continue` or `break` statement) if it could unnest multiple statements. By default, only relocation of _existing_ jumps (i.e. from the `else` clause) are suggested.
 
 Example:
 
 ```toml
 [rule.early-return]
-  arguments = ["preserveScope"]
+  arguments = ["preserveScope", "allowJump"]
 ```
 
 ## empty-block

--- a/internal/ifelse/args.go
+++ b/internal/ifelse/args.go
@@ -4,8 +4,15 @@ package ifelse
 // that would enlarge variable scope
 const PreserveScope = "preserveScope"
 
+// AllowJump is a configuration argument that permits early-return to
+// suggest introducing a new jump (return, continue, etc) statement
+// to reduce nesting. By default, suggestions only bring existing jumps
+// earlier.
+const AllowJump = "allowJump"
+
 // Args contains arguments common to the early-return, indent-error-flow
-// and superfluous-else rules (currently just preserveScope)
+// and superfluous-else rules
 type Args struct {
 	PreserveScope bool
+	AllowJump     bool
 }

--- a/internal/ifelse/branch.go
+++ b/internal/ifelse/branch.go
@@ -66,13 +66,7 @@ func (b Branch) String() string {
 	case Regular:
 		return "{ ... }"
 	case Panic, Exit:
-		if b.IsShort() {
-			return fmt.Sprintf("{ %v() }", b.Call)
-		}
 		return fmt.Sprintf("{ ... %v() }", b.Call)
-	}
-	if b.IsShort() {
-		return fmt.Sprintf("{ %v }", b.BranchKind)
 	}
 	return fmt.Sprintf("{ ... %v }", b.BranchKind)
 }

--- a/internal/ifelse/branch.go
+++ b/internal/ifelse/branch.go
@@ -68,16 +68,13 @@ func (b Branch) String() string {
 	case Panic, Exit:
 		if b.IsShort() {
 			return fmt.Sprintf("{ %v() }", b.Call)
-		} else {
-			return fmt.Sprintf("{ ... %v() }", b.Call)
 		}
-	default:
-		if b.IsShort() {
-			return fmt.Sprintf("{ %v }", b.BranchKind)
-		} else {
-			return fmt.Sprintf("{ ... %v }", b.BranchKind)
-		}
+		return fmt.Sprintf("{ ... %v() }", b.Call)
 	}
+	if b.IsShort() {
+		return fmt.Sprintf("{ %v }", b.BranchKind)
+	}
+	return fmt.Sprintf("{ ... %v }", b.BranchKind)
 }
 
 // LongString returns a longer form string representation
@@ -85,9 +82,8 @@ func (b Branch) LongString() string {
 	switch b.BranchKind {
 	case Panic, Exit:
 		return fmt.Sprintf("call to %v function", b.Call)
-	default:
-		return b.BranchKind.LongString()
 	}
+	return b.BranchKind.LongString()
 }
 
 // HasDecls returns whether the branch has any top-level declarations
@@ -111,25 +107,15 @@ func (b Branch) IsShort() bool {
 	case 0:
 		return true
 	case 1:
-	default:
+		return isShortStmt(b.block[0])
+	}
+	return false
+}
+
+func isShortStmt(stmt ast.Stmt) bool {
+	switch stmt.(type) {
+	case *ast.BlockStmt, *ast.IfStmt, *ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt, *ast.ForStmt, *ast.RangeStmt:
 		return false
 	}
-	switch b.block[0].(type) {
-	case *ast.BlockStmt:
-		return false
-	case *ast.IfStmt:
-		return false
-	case *ast.SwitchStmt:
-		return false
-	case *ast.TypeSwitchStmt:
-		return false
-	case *ast.SelectStmt:
-		return false
-	case *ast.ForStmt:
-		return false
-	case *ast.RangeStmt:
-		return false
-	default:
-		return true
-	}
+	return true
 }

--- a/internal/ifelse/branch_kind.go
+++ b/internal/ifelse/branch_kind.go
@@ -44,9 +44,8 @@ func (k BranchKind) Deviates() bool {
 		return false
 	case Return, Continue, Break, Goto, Panic, Exit:
 		return true
-	default:
-		panic("invalid kind")
 	}
+	panic("invalid kind")
 }
 
 // Branch returns a Branch with the given kind
@@ -71,9 +70,8 @@ func (k BranchKind) String() string {
 		return "panic()"
 	case Exit:
 		return "os.Exit()"
-	default:
-		panic("invalid kind")
 	}
+	panic("invalid kind")
 }
 
 // LongString returns a longer form string representation
@@ -95,7 +93,6 @@ func (k BranchKind) LongString() string {
 		return "a function call that panics"
 	case Exit:
 		return "a function call that exits the program"
-	default:
-		panic("invalid kind")
 	}
+	panic("invalid kind")
 }

--- a/internal/ifelse/branch_kind.go
+++ b/internal/ifelse/branch_kind.go
@@ -58,19 +58,19 @@ func (k BranchKind) String() string {
 	case Empty:
 		return ""
 	case Regular:
-		return "..."
+		return ""
 	case Return:
-		return "... return"
+		return "return"
 	case Continue:
-		return "... continue"
+		return "continue"
 	case Break:
-		return "... break"
+		return "break"
 	case Goto:
-		return "... goto"
+		return "goto"
 	case Panic:
-		return "... panic()"
+		return "panic()"
 	case Exit:
-		return "... os.Exit()"
+		return "os.Exit()"
 	default:
 		panic("invalid kind")
 	}

--- a/internal/ifelse/chain.go
+++ b/internal/ifelse/chain.go
@@ -2,9 +2,11 @@ package ifelse
 
 // Chain contains information about an if-else chain.
 type Chain struct {
-	If                   Branch // what happens at the end of the "if" block
-	Else                 Branch // what happens at the end of the "else" block
-	HasInitializer       bool   // is there an "if"-initializer somewhere in the chain?
-	HasPriorNonDeviating bool   // is there a prior "if" block that does NOT deviate control flow?
-	AtBlockEnd           bool   // whether the chain is placed at the end of the surrounding block
+	If                   Branch     // what happens at the end of the "if" block
+	HasElse              bool       // is there an "else" block?
+	Else                 Branch     // what happens at the end of the "else" block
+	HasInitializer       bool       // is there an "if"-initializer somewhere in the chain?
+	HasPriorNonDeviating bool       // is there a prior "if" block that does NOT deviate control flow?
+	AtBlockEnd           bool       // whether the chain is placed at the end of the surrounding block
+	BlockEndKind         BranchKind // control flow at end of surrounding block (e.g. "return" for function body)
 }

--- a/internal/ifelse/func.go
+++ b/internal/ifelse/func.go
@@ -42,10 +42,8 @@ func ExprCall(expr *ast.ExprStmt) (Call, bool) {
 
 // String returns the function name with package qualifier (if any)
 func (f Call) String() string {
-	switch {
-	case f.Pkg != "":
+	if f.Pkg != "" {
 		return fmt.Sprintf("%s.%s", f.Pkg, f.Name)
-	default:
-		return f.Name
 	}
+	return f.Name
 }

--- a/internal/ifelse/rule.go
+++ b/internal/ifelse/rule.go
@@ -31,8 +31,11 @@ type Rule interface {
 func Apply(rule Rule, node ast.Node, target Target, args lint.Arguments) []lint.Failure {
 	v := &visitor{rule: rule, target: target}
 	for _, arg := range args {
-		if arg == PreserveScope {
+		switch arg {
+		case PreserveScope:
 			v.args.PreserveScope = true
+		case AllowJump:
+			v.args.AllowJump = true
 		}
 	}
 	ast.Walk(v, node)
@@ -47,59 +50,90 @@ type visitor struct {
 }
 
 func (v *visitor) Visit(node ast.Node) ast.Visitor {
-	block, ok := node.(*ast.BlockStmt)
-	if !ok {
-		return v
-	}
-
-	for i, stmt := range block.List {
-		if ifStmt, ok := stmt.(*ast.IfStmt); ok {
-			v.visitChain(ifStmt, Chain{AtBlockEnd: i == len(block.List)-1})
-			continue
+	switch stmt := node.(type) {
+	case *ast.FuncDecl:
+		if stmt.Body != nil {
+			v.visitBlock(stmt.Body.List, Return)
 		}
-		ast.Walk(v, stmt)
+	case *ast.FuncLit:
+		v.visitBlock(stmt.Body.List, Return)
+	case *ast.ForStmt:
+		v.visitBlock(stmt.Body.List, Continue)
+	case *ast.RangeStmt:
+		v.visitBlock(stmt.Body.List, Continue)
+	case *ast.CaseClause:
+		v.visitBlock(stmt.Body, Break)
+	case *ast.BlockStmt:
+		v.visitBlock(stmt.List, Regular)
+	default:
+		return v
 	}
 	return nil
 }
 
-func (v *visitor) visitChain(ifStmt *ast.IfStmt, chain Chain) {
-	// look for other if-else chains nested inside this if { } block
-	ast.Walk(v, ifStmt.Body)
-
-	if ifStmt.Else == nil {
-		// no else branch
-		return
+func (v *visitor) visitBlock(stmts []ast.Stmt, endKind BranchKind) {
+	for i, stmt := range stmts {
+		ifStmt, ok := stmt.(*ast.IfStmt)
+		if !ok {
+			ast.Walk(v, stmt)
+			continue
+		}
+		var chain Chain
+		if i == len(stmts)-1 {
+			chain.AtBlockEnd = true
+			chain.BlockEndKind = endKind
+		}
+		v.visitIf(ifStmt, chain)
 	}
+}
+
+func (v *visitor) visitIf(ifStmt *ast.IfStmt, chain Chain) {
+	// look for other if-else chains nested inside this if { } block
+	v.visitBlock(ifStmt.Body.List, chain.BlockEndKind)
 
 	if as, ok := ifStmt.Init.(*ast.AssignStmt); ok && as.Tok == token.DEFINE {
 		chain.HasInitializer = true
 	}
 	chain.If = BlockBranch(ifStmt.Body)
 
+	if ifStmt.Else == nil {
+		if v.args.AllowJump {
+			v.checkRule(ifStmt, chain)
+		}
+		return
+	}
+
 	switch elseBlock := ifStmt.Else.(type) {
 	case *ast.IfStmt:
 		if !chain.If.Deviates() {
 			chain.HasPriorNonDeviating = true
 		}
-		v.visitChain(elseBlock, chain)
+		v.visitIf(elseBlock, chain)
 	case *ast.BlockStmt:
 		// look for other if-else chains nested inside this else { } block
-		ast.Walk(v, elseBlock)
+		v.visitBlock(elseBlock.List, chain.BlockEndKind)
 
+		chain.HasElse = true
 		chain.Else = BlockBranch(elseBlock)
-		if failMsg := v.rule.CheckIfElse(chain, v.args); failMsg != "" {
-			if chain.HasInitializer {
-				// if statement has a := initializer, so we might need to move the assignment
-				// onto its own line in case the body references it
-				failMsg += " (move short variable declaration to its own line if necessary)"
-			}
-			v.failures = append(v.failures, lint.Failure{
-				Confidence: 1,
-				Node:       v.target.node(ifStmt),
-				Failure:    failMsg,
-			})
-		}
+		v.checkRule(ifStmt, chain)
 	default:
-		panic("invalid node type for else")
+		panic("unexpected node type for else")
 	}
+}
+
+func (v *visitor) checkRule(ifStmt *ast.IfStmt, chain Chain) {
+	failMsg := v.rule.CheckIfElse(chain, v.args)
+	if failMsg == "" {
+		return
+	}
+	if chain.HasInitializer {
+		// if statement has a := initializer, so we might need to move the assignment
+		// onto its own line in case the body references it
+		failMsg += " (move short variable declaration to its own line if necessary)"
+	}
+	v.failures = append(v.failures, lint.Failure{
+		Confidence: 1,
+		Node:       v.target.node(ifStmt),
+		Failure:    failMsg,
+	})
 }

--- a/internal/ifelse/target.go
+++ b/internal/ifelse/target.go
@@ -19,7 +19,6 @@ func (t Target) node(ifStmt *ast.IfStmt) ast.Node {
 		return ifStmt
 	case TargetElse:
 		return ifStmt.Else
-	default:
-		panic("bad target")
 	}
+	panic("bad target")
 }

--- a/rule/early_return.go
+++ b/rule/early_return.go
@@ -13,7 +13,7 @@ type EarlyReturnRule struct{}
 
 // Apply applies the rule to given file.
 func (e *EarlyReturnRule) Apply(file *lint.File, args lint.Arguments) []lint.Failure {
-	return ifelse.Apply(e, file.AST, ifelse.TargetIf, args)
+	return ifelse.Apply(e.checkIfElse, file.AST, ifelse.TargetIf, args)
 }
 
 // Name returns the rule name.
@@ -21,41 +21,40 @@ func (*EarlyReturnRule) Name() string {
 	return "early-return"
 }
 
-// CheckIfElse evaluates the rule against an ifelse.Chain and returns a failure message if applicable.
-func (*EarlyReturnRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) string {
+func (*EarlyReturnRule) checkIfElse(chain ifelse.Chain, args ifelse.Args) (string, bool) {
 	if chain.HasElse {
 		if !chain.Else.BranchKind.Deviates() {
 			// this rule only applies if the else-block deviates control flow
-			return ""
+			return "", false
 		}
 	} else if !args.AllowJump || !chain.AtBlockEnd || !chain.BlockEndKind.Deviates() || chain.If.IsShort() {
 		// this kind of refactor requires introducing a new indented "return", "continue" or "break" statement,
 		// so ignore unless we are able to outdent multiple statements in exchange.
-		return ""
+		return "", false
 	}
 
 	if chain.HasPriorNonDeviating && !chain.If.IsEmpty() {
 		// if we de-indent this block then a previous branch
 		// might flow into it, affecting program behaviour
-		return ""
+		return "", false
 	}
 
 	if chain.HasElse && chain.If.Deviates() {
 		// avoid overlapping with superfluous-else
-		return ""
+		return "", false
 	}
 
 	if args.PreserveScope && !chain.AtBlockEnd && (chain.HasInitializer || chain.If.HasDecls()) {
 		// avoid increasing variable scope
-		return ""
+		return "", false
 	}
 
 	if !chain.HasElse {
-		return fmt.Sprintf("if c { ... } can be rewritten if !c { %v } ... to reduce nesting", chain.BlockEndKind)
+		return fmt.Sprintf("if c { ... } can be rewritten if !c { %v } ... to reduce nesting", chain.BlockEndKind), true
 	}
 
 	if chain.If.IsEmpty() {
-		return fmt.Sprintf("if c { } else %[1]v can be simplified to if !c %[1]v", chain.Else)
+		return fmt.Sprintf("if c { } else %[1]v can be simplified to if !c %[1]v", chain.Else), true
 	}
-	return fmt.Sprintf("if c { ... } else %[1]v can be simplified to if !c %[1]v ...", chain.Else)
+	return fmt.Sprintf("if c { ... } else %[1]v can be simplified to if !c %[1]v ...", chain.Else), true
 }

--- a/rule/indent_error_flow.go
+++ b/rule/indent_error_flow.go
@@ -20,6 +20,10 @@ func (*IndentErrorFlowRule) Name() string {
 
 // CheckIfElse evaluates the rule against an ifelse.Chain and returns a failure message if applicable.
 func (*IndentErrorFlowRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) string {
+	if !chain.HasElse {
+		return ""
+	}
+
 	if !chain.If.Deviates() {
 		// this rule only applies if the if-block deviates control flow
 		return ""
@@ -36,7 +40,7 @@ func (*IndentErrorFlowRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) st
 		return ""
 	}
 
-	if args.PreserveScope && !chain.AtBlockEnd && (chain.HasInitializer || chain.Else.HasDecls) {
+	if args.PreserveScope && !chain.AtBlockEnd && (chain.HasInitializer || chain.Else.HasDecls()) {
 		// avoid increasing variable scope
 		return ""
 	}

--- a/rule/superfluous_else.go
+++ b/rule/superfluous_else.go
@@ -22,6 +22,10 @@ func (*SuperfluousElseRule) Name() string {
 
 // CheckIfElse evaluates the rule against an ifelse.Chain and returns a failure message if applicable.
 func (*SuperfluousElseRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) string {
+	if !chain.HasElse {
+		return ""
+	}
+
 	if !chain.If.Deviates() {
 		// this rule only applies if the if-block deviates control flow
 		return ""
@@ -38,7 +42,7 @@ func (*SuperfluousElseRule) CheckIfElse(chain ifelse.Chain, args ifelse.Args) st
 		return ""
 	}
 
-	if args.PreserveScope && !chain.AtBlockEnd && (chain.HasInitializer || chain.Else.HasDecls) {
+	if args.PreserveScope && !chain.AtBlockEnd && (chain.HasInitializer || chain.Else.HasDecls()) {
 		// avoid increasing variable scope
 		return ""
 	}

--- a/test/early_return_test.go
+++ b/test/early_return_test.go
@@ -12,4 +12,5 @@ import (
 func TestEarlyReturn(t *testing.T) {
 	testRule(t, "early_return", &rule.EarlyReturnRule{})
 	testRule(t, "early_return_scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{ifelse.PreserveScope}})
+	testRule(t, "early_return_jump", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{ifelse.AllowJump}})
 }

--- a/testdata/early_return.go
+++ b/testdata/early_return.go
@@ -5,7 +5,7 @@ package fixtures
 import "os"
 
 func earlyRet() bool {
-	if cond { //   MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
+	if cond { //   MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
 		println()
 		println()
 		println()
@@ -13,20 +13,20 @@ func earlyRet() bool {
 		return false
 	}
 
-	if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
+	if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
 		println()
 	} else {
 		return false
 	}
 
-	if cond { //MATCH /if c { } else { ... return } can be simplified to if !c { ... return }/
+	if cond { //MATCH /if c { } else { return } can be simplified to if !c { return }/
 	} else {
 		return false
 	}
 
 	if cond {
 		println()
-	} else if cond { //MATCH /if c { } else { ... return } can be simplified to if !c { ... return }/
+	} else if cond { //MATCH /if c { } else { return } can be simplified to if !c { return }/
 	} else {
 		return false
 	}
@@ -47,7 +47,7 @@ func earlyRet() bool {
 		return false
 	}
 
-	if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
+	if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
 		println()
 		println()
 		println()
@@ -64,7 +64,7 @@ func earlyRet() bool {
 	}
 
 	if cond {
-		if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
+		if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
 			println()
 		} else {
 			return false
@@ -74,7 +74,7 @@ func earlyRet() bool {
 	if cond {
 		println()
 	} else {
-		if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
+		if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
 			println()
 		} else {
 			return false
@@ -86,7 +86,7 @@ func earlyRet() bool {
 	} else if cond {
 		println()
 	} else {
-		if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
+		if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
 			println()
 		} else {
 			return false
@@ -94,7 +94,7 @@ func earlyRet() bool {
 	}
 
 	for {
-		if cond { //MATCH /if c { ... } else { ... continue } can be simplified to if !c { ... continue } .../
+		if cond { //MATCH /if c { ... } else { continue } can be simplified to if !c { continue } .../
 			println()
 		} else {
 			continue
@@ -102,34 +102,43 @@ func earlyRet() bool {
 	}
 
 	for {
-		if cond { //MATCH /if c { ... } else { ... break } can be simplified to if !c { ... break } .../
+		if cond { //MATCH /if c { ... } else { break } can be simplified to if !c { break } .../
 			println()
 		} else {
 			break
 		}
 	}
 
-	if cond { //MATCH /if c { ... } else { ... panic() } can be simplified to if !c { ... panic() } .../
+	if cond { //MATCH /if c { ... } else { panic() } can be simplified to if !c { panic() } .../
 		println()
 	} else {
 		panic("!")
 	}
 
-	if cond { //MATCH /if c { ... } else { ... goto } can be simplified to if !c { ... goto } .../
+	if cond { //MATCH /if c { ... } else { goto } can be simplified to if !c { goto } .../
 		println()
 	} else {
 		goto X
 	}
 
-	if x, ok := foo(); ok { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } ... (move short variable declaration to its own line if necessary)/
+	if x, ok := foo(); ok { //MATCH /if c { ... } else { return } can be simplified to if !c { return } ... (move short variable declaration to its own line if necessary)/
 		println(x)
 	} else {
 		return false
 	}
 
-	if cond { //MATCH /if c { ... } else { ... os.Exit() } can be simplified to if !c { ... os.Exit() } .../
+	if cond { //MATCH /if c { ... } else { os.Exit() } can be simplified to if !c { os.Exit() } .../
 		println()
 	} else {
 		os.Exit(0)
+	}
+
+	for {
+		// inversion is not suggested here without allowJump option enabled
+		if cond {
+			println()
+			println()
+			println()
+		}
 	}
 }

--- a/testdata/early_return.go
+++ b/testdata/early_return.go
@@ -5,7 +5,7 @@ package fixtures
 import "os"
 
 func earlyRet() bool {
-	if cond { //   MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
+	if cond { //   MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
 		println()
 		println()
 		println()
@@ -13,20 +13,20 @@ func earlyRet() bool {
 		return false
 	}
 
-	if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
+	if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
 		println()
 	} else {
 		return false
 	}
 
-	if cond { //MATCH /if c { } else { return } can be simplified to if !c { return }/
+	if cond { //MATCH /if c { } else { ... return } can be simplified to if !c { ... return }/
 	} else {
 		return false
 	}
 
 	if cond {
 		println()
-	} else if cond { //MATCH /if c { } else { return } can be simplified to if !c { return }/
+	} else if cond { //MATCH /if c { } else { ... return } can be simplified to if !c { ... return }/
 	} else {
 		return false
 	}
@@ -47,7 +47,7 @@ func earlyRet() bool {
 		return false
 	}
 
-	if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
+	if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
 		println()
 		println()
 		println()
@@ -64,7 +64,7 @@ func earlyRet() bool {
 	}
 
 	if cond {
-		if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
+		if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
 			println()
 		} else {
 			return false
@@ -74,7 +74,7 @@ func earlyRet() bool {
 	if cond {
 		println()
 	} else {
-		if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
+		if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
 			println()
 		} else {
 			return false
@@ -86,7 +86,7 @@ func earlyRet() bool {
 	} else if cond {
 		println()
 	} else {
-		if cond { //MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
+		if cond { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
 			println()
 		} else {
 			return false
@@ -94,7 +94,7 @@ func earlyRet() bool {
 	}
 
 	for {
-		if cond { //MATCH /if c { ... } else { continue } can be simplified to if !c { continue } .../
+		if cond { //MATCH /if c { ... } else { ... continue } can be simplified to if !c { ... continue } .../
 			println()
 		} else {
 			continue
@@ -102,32 +102,32 @@ func earlyRet() bool {
 	}
 
 	for {
-		if cond { //MATCH /if c { ... } else { break } can be simplified to if !c { break } .../
+		if cond { //MATCH /if c { ... } else { ... break } can be simplified to if !c { ... break } .../
 			println()
 		} else {
 			break
 		}
 	}
 
-	if cond { //MATCH /if c { ... } else { panic() } can be simplified to if !c { panic() } .../
+	if cond { //MATCH /if c { ... } else { ... panic() } can be simplified to if !c { ... panic() } .../
 		println()
 	} else {
 		panic("!")
 	}
 
-	if cond { //MATCH /if c { ... } else { goto } can be simplified to if !c { goto } .../
+	if cond { //MATCH /if c { ... } else { ... goto } can be simplified to if !c { ... goto } .../
 		println()
 	} else {
 		goto X
 	}
 
-	if x, ok := foo(); ok { //MATCH /if c { ... } else { return } can be simplified to if !c { return } ... (move short variable declaration to its own line if necessary)/
+	if x, ok := foo(); ok { //MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } ... (move short variable declaration to its own line if necessary)/
 		println(x)
 	} else {
 		return false
 	}
 
-	if cond { //MATCH /if c { ... } else { os.Exit() } can be simplified to if !c { os.Exit() } .../
+	if cond { //MATCH /if c { ... } else { ... os.Exit() } can be simplified to if !c { ... os.Exit() } .../
 		println()
 	} else {
 		os.Exit(0)

--- a/testdata/early_return_jump.go
+++ b/testdata/early_return_jump.go
@@ -1,0 +1,115 @@
+// Test data for the early-return rule with allowJump option enabled
+
+package fixtures
+
+func fn1() {
+	if cond { //MATCH /if c { ... } can be rewritten if !c { return } ... to reduce nesting/
+		println()
+		println()
+		println()
+	}
+}
+
+func fn2() {
+	for {
+		if cond { //MATCH /if c { ... } can be rewritten if !c { continue } ... to reduce nesting/
+			println()
+			println()
+			println()
+		}
+	}
+}
+
+func fn3() {
+	for {
+		// can't flip cond2 here because the cond1 branch would flow into it
+		if cond1 {
+			println()
+		} else if cond2 {
+			println()
+			println()
+			println()
+		}
+	}
+}
+
+func fn4() {
+	for {
+		// cond1 branch continues here so this is ok
+		if cond1 {
+			println()
+			continue
+		} else if cond2 { //MATCH /if c { ... } can be rewritten if !c { continue } ... to reduce nesting/
+			println()
+			println()
+			println()
+		}
+	}
+}
+
+func fn5() {
+	for {
+		// no point flipping cond here we only unnest one statement and need to introduce one new nested statement (continue) to do it
+		if cond {
+			println()
+		}
+	}
+}
+
+func fn6() {
+	for {
+		if x, ok := foo(); ok { //MATCH /if c { ... } can be rewritten if !c { continue } ... to reduce nesting (move short variable declaration to its own line if necessary)/
+			println(x)
+			println(x)
+			println(x)
+		}
+	}
+}
+
+func fn7() {
+	for i := 0; i < 10; i++ {
+		if cond { //MATCH /if c { ... } can be rewritten if !c { continue } ... to reduce nesting/
+			println()
+			println()
+			println()
+		}
+	}
+}
+
+func fn8() {
+	for range c {
+		if cond { //MATCH /if c { ... } can be rewritten if !c { continue } ... to reduce nesting/
+			println()
+			println()
+			println()
+		}
+	}
+}
+
+func fn9() {
+	fn := func() {
+		if cond { //MATCH /if c { ... } can be rewritten if !c { return } ... to reduce nesting/
+			println()
+			println()
+			println()
+		}
+	}
+	fn()
+}
+
+func fn10() {
+	switch {
+	case cond:
+		if foo() { //MATCH /if c { ... } can be rewritten if !c { break } ... to reduce nesting/
+			println()
+			println()
+			println()
+		}
+	default:
+		if bar() { //MATCH /if c { ... } can be rewritten if !c { break } ... to reduce nesting/
+			println()
+			println()
+			println()
+		}
+	}
+}

--- a/testdata/early_return_scope.go
+++ b/testdata/early_return_scope.go
@@ -4,7 +4,7 @@ package fixtures
 
 func fn1() {
 	// No initializer, match as normal
-	if cond { //   MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
+	if cond { //   MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
 		fn2()
 	} else {
 		return
@@ -13,7 +13,7 @@ func fn1() {
 
 func fn2() {
 	// Moving the declaration of x here is fine since it goes out of scope either way
-	if x := fn1(); x != nil { //   MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } ... (move short variable declaration to its own line if necessary)/
+	if x := fn1(); x != nil { //   MATCH /if c { ... } else { return } can be simplified to if !c { return } ... (move short variable declaration to its own line if necessary)/
 		fn2()
 	} else {
 		return
@@ -56,7 +56,7 @@ func fn5() {
 }
 
 func fn6() {
-	if cond { //   MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
+	if cond { //   MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
 		x := fn2()
 		fn3(x)
 	} else {

--- a/testdata/early_return_scope.go
+++ b/testdata/early_return_scope.go
@@ -4,7 +4,7 @@ package fixtures
 
 func fn1() {
 	// No initializer, match as normal
-	if cond { //   MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
+	if cond { //   MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
 		fn2()
 	} else {
 		return
@@ -13,7 +13,7 @@ func fn1() {
 
 func fn2() {
 	// Moving the declaration of x here is fine since it goes out of scope either way
-	if x := fn1(); x != nil { //   MATCH /if c { ... } else { return } can be simplified to if !c { return } ... (move short variable declaration to its own line if necessary)/
+	if x := fn1(); x != nil { //   MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } ... (move short variable declaration to its own line if necessary)/
 		fn2()
 	} else {
 		return
@@ -56,7 +56,7 @@ func fn5() {
 }
 
 func fn6() {
-	if cond { //   MATCH /if c { ... } else { return } can be simplified to if !c { return } .../
+	if cond { //   MATCH /if c { ... } else { ... return } can be simplified to if !c { ... return } .../
 		x := fn2()
 		fn3(x)
 	} else {


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
This PR implements an extension to the `early-return` proposed in [#1133](https://github.com/mgechev/revive/issues/1133). Specifically, it suggest a rewrite of the form
```
if x {
  y
}
```
to
```
if !x {
   return|break|continue
}
y
```
In cases where
- the `if` statement is at the end of the surrounding function body, `for` loop, or `switch` / `select` branch
- it has no `else` clause attached
- the `if` block body consists of multiple statements
- the other common prerequisites for `early-return` are met
- the new behaviour has been opted into via a configuration argument

<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the GitHub Action build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

Closes #1133