### PR TITLE
refactor: move functions and vars out from rule/utils.go

### DIFF
--- a/rule/blank_imports.go
+++ b/rule/blank_imports.go
@@ -73,3 +73,7 @@ func (*BlankImportsRule) fileHasValidEmbedComment(fileAst *ast.File) bool {
 
 	return false
 }
+
+// isBlank returns whether id is the blank identifier "_".
+// If id == nil, the answer is false.
+func isBlank(id *ast.Ident) bool { return id != nil && id.Name == "_" }

--- a/rule/bool_literal_in_expr.go
+++ b/rule/bool_literal_in_expr.go
@@ -70,3 +70,23 @@ func (w lintBoolLiteral) addFailure(node ast.Node, msg, cat string) {
 		Failure:    msg,
 	})
 }
+
+// isBoolOp returns true if the given token corresponds to a bool operator.
+func isBoolOp(t token.Token) bool {
+	switch t {
+	case token.LAND, token.LOR, token.EQL, token.NEQ:
+		return true
+	}
+
+	return false
+}
+
+func isExprABooleanLit(n ast.Node) (lexeme string, ok bool) {
+	oper, ok := n.(*ast.Ident)
+
+	if !ok {
+		return "", false
+	}
+
+	return oper.Name, (oper.Name == "true" || oper.Name == "false")
+}

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -53,6 +53,15 @@ func (dc *disabledChecks) isDisabled(checkName string) bool {
 	}
 }
 
+var commonMethods = map[string]bool{
+	"Error":     true,
+	"Read":      true,
+	"ServeHTTP": true,
+	"String":    true,
+	"Write":     true,
+	"Unwrap":    true,
+}
+
 // ExportedRule lints given else constructs.
 type ExportedRule struct {
 	stuttersMsg    string

--- a/rule/var_declarations.go
+++ b/rule/var_declarations.go
@@ -5,9 +5,25 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"strings"
 
 	"github.com/mgechev/revive/lint"
 )
+
+var zeroLiteral = map[string]bool{
+	"false": true, // bool
+	// runes
+	`'\x00'`: true,
+	`'\000'`: true,
+	// strings
+	`""`: true,
+	"``": true,
+	// numerics
+	"0":   true,
+	"0.":  true,
+	"0.0": true,
+	"0i":  true,
+}
 
 // VarDeclarationsRule lints given else constructs.
 type VarDeclarationsRule struct{}
@@ -119,4 +135,10 @@ func (w *lintVarDeclarations) Visit(node ast.Node) ast.Visitor {
 		return nil
 	}
 	return w
+}
+
+func validType(t types.Type) bool {
+	return t != nil &&
+		t != types.Typ[types.Invalid] &&
+		!strings.Contains(t.String(), "invalid type") // good but not foolproof
 }

--- a/rule/var_naming.go
+++ b/rule/var_naming.go
@@ -13,8 +13,15 @@ import (
 
 var anyCapsRE = regexp.MustCompile(`[A-Z]`)
 
+var allCapsRE = regexp.MustCompile(`^[A-Z0-9_]+$`)
+
 // regexp for constant names like `SOME_CONST`, `SOME_CONST_2`, `X123_3`, `_SOME_PRIVATE_CONST` (#851, #865)
 var upperCaseConstRE = regexp.MustCompile(`^_?[A-Z][A-Z\d]*(_[A-Z\d]+)*$`)
+
+var knownNameExceptions = map[string]bool{
+	"LastInsertId": true, // must match database/sql
+	"kWh":          true,
+}
 
 // VarNamingRule lints given else constructs.
 type VarNamingRule struct {


### PR DESCRIPTION
This PR moves unexported functions and variable declarations from `utils.go` to rule files, where these functions are used. This increases cohesion, readability and rules maintainability.

Now, in the `utils.go` only functions that are common for a few rules.