### PR TITLE
rename unused parameter

### DIFF
--- a/rule/redundant_build_tag.go
+++ b/rule/redundant_build_tag.go
@@ -12,7 +12,7 @@ type RedundantBuildTagRule struct{}
 // Apply triggers if an old build tag `// +build` is found after a new one `//go:build`.
 // `//go:build` comments are automatically added by gofmt when Go 1.17+ is used.
 // See https://pkg.go.dev/cmd/go#hdr-Build_constraints
-func (*RedundantBuildTagRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
+func (*RedundantBuildTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	for _, group := range file.AST.Comments {
 		hasGoBuild := false
 		for _, comment := range group.List {


### PR DESCRIPTION
Renames `arguments` into `_` in redundant-build-tag rule