### PR TITLE
docs: fix rule descriptions

### DIFF
--- a/rule/add_constant.go
+++ b/rule/add_constant.go
@@ -31,7 +31,7 @@ func (wl allowList) add(kind, list string) {
 	}
 }
 
-// AddConstantRule lints unused params in functions.
+// AddConstantRule suggests using constants instead of magic numbers and string literals.
 type AddConstantRule struct {
 	allowList       allowList
 	ignoreFunctions []*regexp.Regexp

--- a/rule/argument_limit.go
+++ b/rule/argument_limit.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ArgumentsLimitRule lints given else constructs.
+// ArgumentsLimitRule lints the number of arguments a function can receive.
 type ArgumentsLimitRule struct {
 	max int
 

--- a/rule/atomic.go
+++ b/rule/atomic.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// AtomicRule lints given else constructs.
+// AtomicRule lints usages of the `sync/atomic` package.
 type AtomicRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/bare_return.go
+++ b/rule/bare_return.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// BareReturnRule lints given else constructs.
+// BareReturnRule lints bare returns.
 type BareReturnRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/blank_imports.go
+++ b/rule/blank_imports.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// BlankImportsRule lints given else constructs.
+// BlankImportsRule lints blank imports.
 type BlankImportsRule struct{}
 
 // Name returns the rule name.

--- a/rule/cognitive_complexity.go
+++ b/rule/cognitive_complexity.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/tools/go/ast/astutil"
 )
 
-// CognitiveComplexityRule lints given else constructs.
+// CognitiveComplexityRule sets restriction for maximum cognitive complexity.
 type CognitiveComplexityRule struct {
 	maxComplexity int
 

--- a/rule/comments_density.go
+++ b/rule/comments_density.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// CommentsDensityRule lints given else constructs.
+// CommentsDensityRule enforces a minimum comment / code relation.
 type CommentsDensityRule struct {
 	minimumCommentsDensity int64
 

--- a/rule/context_as_argument.go
+++ b/rule/context_as_argument.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ContextAsArgumentRule lints given else constructs.
+// ContextAsArgumentRule suggests that `context.Context` should be the first argument of a function.
 type ContextAsArgumentRule struct {
 	allowTypesLUT map[string]struct{}
 

--- a/rule/context_keys_type.go
+++ b/rule/context_keys_type.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ContextKeysType lints given else constructs.
+// ContextKeysType disallows the usage of basic types in `context.WithValue`.
 type ContextKeysType struct{}
 
 // Apply applies the rule to given file.

--- a/rule/cyclomatic.go
+++ b/rule/cyclomatic.go
@@ -11,7 +11,7 @@ import (
 
 // Based on https://github.com/fzipp/gocyclo
 
-// CyclomaticRule lints given else constructs.
+// CyclomaticRule sets restriction for maximum cyclomatic complexity.
 type CyclomaticRule struct {
 	maxComplexity int
 

--- a/rule/defer.go
+++ b/rule/defer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// DeferRule lints unused params in functions.
+// DeferRule lints gotchas in defer statements.
 type DeferRule struct {
 	allow map[string]bool
 

--- a/rule/dot_imports.go
+++ b/rule/dot_imports.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// DotImportsRule lints given else constructs.
+// DotImportsRule forbids . imports.
 type DotImportsRule struct {
 	allowedPackages allowPackages
 

--- a/rule/duplicated_imports.go
+++ b/rule/duplicated_imports.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// DuplicatedImportsRule lints given else constructs.
+// DuplicatedImportsRule looks for packages that are imported two or more times.
 type DuplicatedImportsRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/empty_block.go
+++ b/rule/empty_block.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// EmptyBlockRule lints given else constructs.
+// EmptyBlockRule warns on empty code blocks.
 type EmptyBlockRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/error_naming.go
+++ b/rule/error_naming.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ErrorNamingRule lints given else constructs.
+// ErrorNamingRule lints naming of error variables.
 type ErrorNamingRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/error_return.go
+++ b/rule/error_return.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ErrorReturnRule lints given else constructs.
+// ErrorReturnRule ensures that the error return parameter is the last parameter.
 type ErrorReturnRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/error_strings.go
+++ b/rule/error_strings.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ErrorStringsRule lints given else constructs.
+// ErrorStringsRule lints error strings.
 type ErrorStringsRule struct {
 	errorFunctions map[string]map[string]struct{}
 

--- a/rule/errorf.go
+++ b/rule/errorf.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ErrorfRule lints given else constructs.
+// ErrorfRule suggests using `fmt.Errorf` instead of `errors.New(fmt.Sprintf())`.
 type ErrorfRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -62,7 +62,7 @@ var commonMethods = map[string]bool{
 	"Unwrap":    true,
 }
 
-// ExportedRule lints given else constructs.
+// ExportedRule lints naming and commenting conventions on exported symbols.
 type ExportedRule struct {
 	stuttersMsg    string
 	disabledChecks disabledChecks

--- a/rule/file_header.go
+++ b/rule/file_header.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// FileHeaderRule lints given else constructs.
+// FileHeaderRule lints the header that each file should have.
 type FileHeaderRule struct {
 	header string
 

--- a/rule/flag_param.go
+++ b/rule/flag_param.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// FlagParamRule lints given else constructs.
+// FlagParamRule warns on boolean parameters that create a control coupling.
 type FlagParamRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/function_result_limit.go
+++ b/rule/function_result_limit.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// FunctionResultsLimitRule lints given else constructs.
+// FunctionResultsLimitRule limits the maximum number of results a function can return.
 type FunctionResultsLimitRule struct {
 	max int
 

--- a/rule/get_return.go
+++ b/rule/get_return.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// GetReturnRule lints given else constructs.
+// GetReturnRule warns on getters that do not yield any result.
 type GetReturnRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/if_return.go
+++ b/rule/if_return.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// IfReturnRule lints given else constructs.
+// IfReturnRule searches for redundant `if` when returning an error.
 type IfReturnRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/import_shadowing.go
+++ b/rule/import_shadowing.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ImportShadowingRule lints given else constructs.
+// ImportShadowingRule spots identifiers that shadow an import.
 type ImportShadowingRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/imports_blocklist.go
+++ b/rule/imports_blocklist.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ImportsBlocklistRule lints given else constructs.
+// ImportsBlocklistRule disallows importing the specified packages.
 type ImportsBlocklistRule struct {
 	blocklist []*regexp.Regexp
 

--- a/rule/increment_decrement.go
+++ b/rule/increment_decrement.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// IncrementDecrementRule lints given else constructs.
+// IncrementDecrementRule lints `i += 1` and `i -= 1` constructs.
 type IncrementDecrementRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/indent_error_flow.go
+++ b/rule/indent_error_flow.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// IndentErrorFlowRule lints given else constructs.
+// IndentErrorFlowRule prevents redundant else statements.
 type IndentErrorFlowRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/line_length_limit.go
+++ b/rule/line_length_limit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// LineLengthLimitRule lints given else constructs.
+// LineLengthLimitRule lints number of characters in a line.
 type LineLengthLimitRule struct {
 	max int
 

--- a/rule/max_control_nesting.go
+++ b/rule/max_control_nesting.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// MaxControlNestingRule lints given else constructs.
+// MaxControlNestingRule sets restriction for maximum nesting of control structures.
 type MaxControlNestingRule struct {
 	max int64
 

--- a/rule/max_public_structs.go
+++ b/rule/max_public_structs.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// MaxPublicStructsRule lints given else constructs.
+// MaxPublicStructsRule lints the number of public structs in a file.
 type MaxPublicStructsRule struct {
 	max int64
 

--- a/rule/modifies_param.go
+++ b/rule/modifies_param.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ModifiesParamRule lints given else constructs.
+// ModifiesParamRule warns on assignments to function parameters.
 type ModifiesParamRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/optimize_operands_order.go
+++ b/rule/optimize_operands_order.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// OptimizeOperandsOrderRule lints given else constructs.
+// OptimizeOperandsOrderRule checks inefficient conditional expressions.
 type OptimizeOperandsOrderRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/range.go
+++ b/rule/range.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// RangeRule lints given else constructs.
+// RangeRule prevents redundant variables when iterating over a collection.
 type RangeRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/range_val_in_closure.go
+++ b/rule/range_val_in_closure.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// RangeValInClosureRule lints given else constructs.
+// RangeValInClosureRule warns if range value is used in a closure dispatched as goroutine.
 type RangeValInClosureRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/receiver_naming.go
+++ b/rule/receiver_naming.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// ReceiverNamingRule lints given else constructs.
+// ReceiverNamingRule lints a receiver name.
 type ReceiverNamingRule struct {
 	receiverNameMaxLength int
 

--- a/rule/redundant_import_alias.go
+++ b/rule/redundant_import_alias.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// RedundantImportAlias lints given else constructs.
+// RedundantImportAlias warns on import aliases matching the imported package name.
 type RedundantImportAlias struct{}
 
 // Apply applies the rule to given file.

--- a/rule/time_naming.go
+++ b/rule/time_naming.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// TimeNamingRule lints given else constructs.
+// TimeNamingRule lints the name of a time variable.
 type TimeNamingRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/unconditional_recursion.go
+++ b/rule/unconditional_recursion.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// UnconditionalRecursionRule lints given else constructs.
+// UnconditionalRecursionRule warns on function calls that will lead to infinite recursion.
 type UnconditionalRecursionRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/unexported_return.go
+++ b/rule/unexported_return.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// UnexportedReturnRule lints given else constructs.
+// UnexportedReturnRule warns when a public return is from unexported type.
 type UnexportedReturnRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/unhandled_error.go
+++ b/rule/unhandled_error.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// UnhandledErrorRule lints given else constructs.
+// UnhandledErrorRule warns on unhandled errors returned by function calls.
 type UnhandledErrorRule struct {
 	ignoreList []*regexp.Regexp
 

--- a/rule/unused_receiver.go
+++ b/rule/unused_receiver.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// UnusedReceiverRule lints unused params in functions.
+// UnusedReceiverRule lints unused receivers in functions.
 type UnusedReceiverRule struct {
 	// regex to check if some name is valid for unused parameter, "^_$" by default
 	allowRegex *regexp.Regexp

--- a/rule/use_any.go
+++ b/rule/use_any.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// UseAnyRule lints given else constructs.
+// UseAnyRule proposes to replace `interface{}` with its alias `any`.
 type UseAnyRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/var_declarations.go
+++ b/rule/var_declarations.go
@@ -25,7 +25,7 @@ var zeroLiteral = map[string]bool{
 	"0i":  true,
 }
 
-// VarDeclarationsRule lints given else constructs.
+// VarDeclarationsRule reduces redundancies around variable declaration.
 type VarDeclarationsRule struct{}
 
 // Apply applies the rule to given file.

--- a/rule/var_naming.go
+++ b/rule/var_naming.go
@@ -23,7 +23,7 @@ var knownNameExceptions = map[string]bool{
 	"kWh":          true,
 }
 
-// VarNamingRule lints given else constructs.
+// VarNamingRule lints the name of a variable.
 type VarNamingRule struct {
 	allowList             []string
 	blockList             []string


### PR DESCRIPTION
The PR fixes inaccurate rule comments. It appears that the descriptions were copied and pasted from the `SuperfluousElseRule`.