### PR TITLE
chore: Improve sortables detection

### DIFF
--- a/internal/astutils/ast_utils.go
+++ b/internal/astutils/ast_utils.go
@@ -1,0 +1,60 @@
+package astutils
+
+import "go/ast"
+
+// FuncSignatureIs returns true if the given func decl satisfies a signature characterized
+// by the given name, parameters types and return types; false otherwise.
+//
+// Example: to check if a function declaration has the signature Foo(int, string) (bool,error)
+// call to FuncSignatureIs(funcDecl,"Foo",[]string{"int","string"},[]string{"bool","error"})
+func FuncSignatureIs(funcDecl *ast.FuncDecl, wantName string, wantParametersTypes, wantResultsTypes []string) bool {
+	if wantName != funcDecl.Name.String() {
+		return false // func name doesn't match expected one
+	}
+
+	funcParametersTypes := getTypeNames(funcDecl.Type.Params)
+	if len(wantParametersTypes) != len(funcParametersTypes) {
+		return false // func has not the expected number of parameters
+	}
+
+	funcResultsTypes := getTypeNames(funcDecl.Type.Results)
+	if len(wantResultsTypes) != len(funcResultsTypes) {
+		return false // func has not the expected number of return values
+	}
+
+	for i, wantType := range wantParametersTypes {
+		if wantType != funcParametersTypes[i] {
+			return false // type of a func's parameter does not match the type of the corresponding expected parameter
+		}
+	}
+
+	for i, wantType := range wantResultsTypes {
+		if wantType != funcResultsTypes[i] {
+			return false // type of a func's return value does not match the type of the corresponding expected return value
+		}
+	}
+
+	return true
+}
+
+func getTypeNames(fields *ast.FieldList) []string {
+	result := []string{}
+
+	if fields == nil {
+		return result
+	}
+
+	for _, field := range fields.List {
+		typeName := field.Type.(*ast.Ident).Name
+		if field.Names == nil { // unnamed field
+			result = append(result, typeName)
+			continue
+		}
+
+		for range field.Names { // add one type name for each field name
+			result = append(result, typeName)
+		}
+	}
+
+	return result
+}

--- a/lint/package.go
+++ b/lint/package.go
@@ -10,6 +10,7 @@ import (
 
 	goversion "github.com/hashicorp/go-version"
 
+	"github.com/mgechev/revive/internal/astutils"
 	"github.com/mgechev/revive/internal/typeparams"
 )
 
@@ -211,67 +212,13 @@ func (p *Package) IsAtLeastGo122() bool {
 
 func getSortableMethodFlagForFunction(fn *ast.FuncDecl) sortableMethodsFlags {
 	switch {
-	case funcSignatureIs(fn, "Len", []string{}, []string{"int"}):
+	case astutils.FuncSignatureIs(fn, "Len", []string{}, []string{"int"}):
 		return bfLen
-	case funcSignatureIs(fn, "Less", []string{"int", "int"}, []string{"bool"}):
+	case astutils.FuncSignatureIs(fn, "Less", []string{"int", "int"}, []string{"bool"}):
 		return bfLess
-	case funcSignatureIs(fn, "Swap", []string{"int", "int"}, []string{}):
+	case astutils.FuncSignatureIs(fn, "Swap", []string{"int", "int"}, []string{}):
 		return bfSwap
 	default:
 		return 0
 	}
-}
-
-// funcSignatureIs returns true if the given func decl satisfies has a signature characterized
-// by the given name, parameters types and return types; false otherwise
-func funcSignatureIs(funcDecl *ast.FuncDecl, wantName string, wantParametersTypes, wantResultsTypes []string) bool {
-	if wantName != funcDecl.Name.String() {
-		return false // func name doesn't match expected one
-	}
-
-	funcParametersTypes := getTypeNames(funcDecl.Type.Params)
-	if len(wantParametersTypes) != len(funcParametersTypes) {
-		return false // func has not the expected number of parameters
-	}
-
-	funcResultsTypes := getTypeNames(funcDecl.Type.Results)
-	if len(wantResultsTypes) != len(funcResultsTypes) {
-		return false // func has not the expected number of return values
-	}
-
-	for i, wantType := range wantParametersTypes {
-		if wantType != funcParametersTypes[i] {
-			return false // type of a func's parameter does not match the type of the corresponding expected parameter
-		}
-	}
-
-	for i, wantType := range wantResultsTypes {
-		if wantType != funcResultsTypes[i] {
-			return false // type of a func's return value does not match the type of the corresponding expected return value
-		}
-	}
-
-	return true
-}
-
-func getTypeNames(fields *ast.FieldList) []string {
-	result := []string{}
-
-	if fields == nil {
-		return result
-	}
-
-	for _, field := range fields.List {
-		typeName := field.Type.(*ast.Ident).Name
-		if field.Names == nil { // unnamed field
-			result = append(result, typeName)
-			continue
-		}
-
-		for range field.Names { // add one type name for each field name
-			result = append(result, typeName)
-		}
-	}
-
-	return result
 }

--- a/testdata/golint/sort.go
+++ b/testdata/golint/sort.go
@@ -17,4 +17,8 @@ func (u U) Len() int           { return len(u) }
 func (u U) Less(i, j int) bool { return u[i] < u[j] }
 func (u U) Swap(i, j int)      { u[i], u[j] = u[j], u[i] }
 
+func (u U) Len() (result int)               { return len(u) }
+func (u U) Less(i int, j int) (result bool) { return u[i] < u[j] }
+func (u U) Swap(i int, j int)               { u[i], u[j] = u[j], u[i] }
+
 func (u U) Other() {} // MATCH /exported method U.Other should have comment or be unexported/

--- a/testdata/golint/sort.go
+++ b/testdata/golint/sort.go
@@ -17,8 +17,22 @@ func (u U) Len() int           { return len(u) }
 func (u U) Less(i, j int) bool { return u[i] < u[j] }
 func (u U) Swap(i, j int)      { u[i], u[j] = u[j], u[i] }
 
-func (u U) Len() (result int)               { return len(u) }
-func (u U) Less(i int, j int) (result bool) { return u[i] < u[j] }
-func (u U) Swap(i int, j int)               { u[i], u[j] = u[j], u[i] }
-
 func (u U) Other() {} // MATCH /exported method U.Other should have comment or be unexported/
+
+// V is ...
+type V []int
+
+func (v V) Len() (result int)               { return len(w) }
+func (v V) Less(i int, j int) (result bool) { return w[i] < w[j] }
+func (v V) Swap(i int, j int)               { v[i], v[j] = v[j], v[i] }
+
+// W is ...
+type W []int
+
+func (w W) Swap(i int, j int) {} // MATCH /exported method W.Swap should have comment or be unexported/
+
+// Vv is ...
+type Vv []int
+
+func (vv Vv) Len() (result int)               { return len(w) }      // MATCH /exported method Vv.Len should have comment or be unexported/
+func (vv Vv) Less(i int, j int) (result bool) { return w[i] < w[j] } // MATCH /exported method Vv.Less should have comment or be unexported/


### PR DESCRIPTION
This PR resolves TODO comment that proposed to check sortable methods signatures.

* Ensures that only methods with the correct signature are identified as implementing required behavior (`sort.Interface`).
* Prevents accidental false positives from methods that happen to have the same name but differ in their functionality.