### PR TITLE
deep-exit: ignore testable examples

### DIFF
--- a/rule/deep_exit_test.go
+++ b/rule/deep_exit_test.go
@@ -1,0 +1,82 @@
+package rule
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"slices"
+	"testing"
+)
+
+func TestLintDeepExit_isTestExample(t *testing.T) {
+	tests := []struct {
+		name       string
+		funcDecl   string
+		isTestFile bool
+		want       bool
+	}{
+		{
+			name:       "Package level example",
+			funcDecl:   "func Example() {}",
+			isTestFile: true,
+			want:       true,
+		},
+		{
+			name:       "Function example",
+			funcDecl:   "func ExampleFunction() {}",
+			isTestFile: true,
+			want:       true,
+		},
+		{
+			name:       "Method example",
+			funcDecl:   "func ExampleType_Method() {}",
+			isTestFile: true,
+			want:       true,
+		},
+		{
+			name:       "Wrong example function",
+			funcDecl:   "func Examplemethod() {}",
+			isTestFile: true,
+			want:       false,
+		},
+		{
+			name:       "Not an example",
+			funcDecl:   "func NotAnExample() {}",
+			isTestFile: true,
+			want:       false,
+		},
+		{
+			name:       "Example with parameters",
+			funcDecl:   "func ExampleWithParams(a int) {}",
+			isTestFile: true,
+			want:       false,
+		},
+		{
+			name:       "Not a test file",
+			funcDecl:   "func Example() {}",
+			isTestFile: false,
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := token.NewFileSet()
+			node, err := parser.ParseFile(fs, "", "package main\n"+tt.funcDecl, parser.AllErrors)
+			if err != nil {
+				t.Fatal(err)
+			}
+			idx := slices.IndexFunc(node.Decls, func(decl ast.Decl) bool {
+				_, ok := decl.(*ast.FuncDecl)
+				return ok
+			})
+			fd := node.Decls[idx].(*ast.FuncDecl)
+
+			w := &lintDeepExit{isTestFile: tt.isTestFile}
+			got := w.isTestExample(fd)
+			if got != tt.want {
+				t.Errorf("isTestExample() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testdata/deep_exit_test.go
+++ b/testdata/deep_exit_test.go
@@ -1,6 +1,8 @@
 package fixtures
 
 import (
+	"errors"
+	"log"
 	"os"
 	"testing"
 )
@@ -8,4 +10,24 @@ import (
 func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags
 	os.Exit(m.Run())
+}
+
+// Testable package level example
+func Example() {
+	log.Fatal(errors.New("example"))
+}
+
+// Testable function example
+func ExampleFoo() {
+	log.Fatal(errors.New("example"))
+}
+
+// Testable method example
+func ExampleBar_Qux() {
+	log.Fatal(errors.New("example"))
+}
+
+// Not an example because it has an argument
+func ExampleBar(int) {
+	log.Fatal(errors.New("example")) // MATCH /calls to log.Fatal only in main() or init() functions/
 }


### PR DESCRIPTION
I propose to ignore testable [example functions](https://go.dev/blog/examples) in the `deep-exit` rule. There is nothing wrong with using `log.Fatal` or `log.Fatalf` in examples.

See these examples where using `log.Fatal` is normal:

- https://github.com/golang/go/blob/e5489a34ca2c31608821d3ac4ec07892fb6a2272/src/embed/example_test.go#L21
- https://github.com/google/go-github/blob/c6856bc9e29aeba0999a959f7a892098b18ff965/github/examples_test.go#L103
- https://github.com/golang/go/blob/e5489a34ca2c31608821d3ac4ec07892fb6a2272/src/image/decode_example_test.go#L28