### PR TITLE
unused-param,unused-receiver: fix panic message

### DIFF
--- a/rule/unused_param.go
+++ b/rule/unused_param.go
@@ -21,28 +21,27 @@ type UnusedParamRule struct {
 func (r *UnusedParamRule) configure(args lint.Arguments) {
 	// while by default args is an array, i think it's good to provide structures inside it by default, not arrays or primitives
 	// it's more compatible to JSON nature of configurations
-	var allowedRegexStr string
+	var allowRegexStr string
 	if len(args) == 0 {
-		allowedRegexStr = "^_$"
+		allowRegexStr = "^_$"
 		r.failureMsg = "parameter '%s' seems to be unused, consider removing or renaming it as _"
 	} else {
 		// Arguments = [{}]
 		options := args[0].(map[string]any)
-		// Arguments = [{allowedRegex="^_"}]
+		// Arguments = [{allowRegex="^_"}]
 
-		if allowedRegexParam, ok := options["allowRegex"]; ok {
-			allowedRegexStr, ok = allowedRegexParam.(string)
+		if allowRegexParam, ok := options["allowRegex"]; ok {
+			allowRegexStr, ok = allowRegexParam.(string)
 			if !ok {
-				panic(fmt.Errorf("error configuring %s rule: allowedRegex is not string but [%T]", r.Name(), allowedRegexParam))
+				panic(fmt.Errorf("error configuring %s rule: allowRegex is not string but [%T]", r.Name(), allowRegexParam))
 			}
 		}
 	}
 	var err error
-	r.allowRegex, err = regexp.Compile(allowedRegexStr)
+	r.allowRegex, err = regexp.Compile(allowRegexStr)
 	if err != nil {
-		panic(fmt.Errorf("error configuring %s rule: allowedRegex is not valid regex [%s]: %v", r.Name(), allowedRegexStr, err))
+		panic(fmt.Errorf("error configuring %s rule: allowRegex is not valid regex [%s]: %v", r.Name(), allowRegexStr, err))
 	}
-
 	if r.failureMsg == "" {
 		r.failureMsg = "parameter '%s' seems to be unused, consider removing or renaming it to match " + r.allowRegex.String()
 	}

--- a/rule/unused_receiver.go
+++ b/rule/unused_receiver.go
@@ -21,26 +21,26 @@ type UnusedReceiverRule struct {
 func (r *UnusedReceiverRule) configure(args lint.Arguments) {
 	// while by default args is an array, i think it's good to provide structures inside it by default, not arrays or primitives
 	// it's more compatible to JSON nature of configurations
-	var allowedRegexStr string
+	var allowRegexStr string
 	if len(args) == 0 {
-		allowedRegexStr = "^_$"
+		allowRegexStr = "^_$"
 		r.failureMsg = "method receiver '%s' is not referenced in method's body, consider removing or renaming it as _"
 	} else {
 		// Arguments = [{}]
 		options := args[0].(map[string]any)
-		// Arguments = [{allowedRegex="^_"}]
+		// Arguments = [{allowRegex="^_"}]
 
-		if allowedRegexParam, ok := options["allowRegex"]; ok {
-			allowedRegexStr, ok = allowedRegexParam.(string)
+		if allowRegexParam, ok := options["allowRegex"]; ok {
+			allowRegexStr, ok = allowRegexParam.(string)
 			if !ok {
-				panic(fmt.Errorf("error configuring [unused-receiver] rule: allowedRegex is not string but [%T]", allowedRegexParam))
+				panic(fmt.Errorf("error configuring [unused-receiver] rule: allowRegex is not string but [%T]", allowRegexParam))
 			}
 		}
 	}
 	var err error
-	r.allowRegex, err = regexp.Compile(allowedRegexStr)
+	r.allowRegex, err = regexp.Compile(allowRegexStr)
 	if err != nil {
-		panic(fmt.Errorf("error configuring [unused-receiver] rule: allowedRegex is not valid regex [%s]: %v", allowedRegexStr, err))
+		panic(fmt.Errorf("error configuring [unused-receiver] rule: allowRegex is not valid regex [%s]: %v", allowRegexStr, err))
 	}
 	if r.failureMsg == "" {
 		r.failureMsg = "method receiver '%s' is not referenced in method's body, consider removing or renaming it to match " + r.allowRegex.String()


### PR DESCRIPTION
The option for `unused-param` and `unused-receiver` rules is `"allowRegex"`, not `"allowedRegex"`.