### PR TITLE
refactor (rule/arguments-limits): replace AST walker by iteration over declarations

### DIFF
--- a/rule/argument_limit.go
+++ b/rule/argument_limit.go
@@ -47,13 +47,15 @@ func (r *ArgumentsLimitRule) Apply(file *lint.File, arguments lint.Arguments) []
 			numParams += len(l.Names)
 		}
 
-		if numParams > r.max {
-			failures = append(failures, lint.Failure{
-				Confidence: 1,
-				Failure:    fmt.Sprintf("maximum number of arguments per function exceeded; max %d but got %d", r.max, numParams),
-				Node:       funcDecl.Type,
-			})
+		if numParams <= r.max {
+			continue
 		}
+
+		failures = append(failures, lint.Failure{
+			Confidence: 1,
+			Failure:    fmt.Sprintf("maximum number of arguments per function exceeded; max %d but got %d", r.max, numParams),
+			Node:       funcDecl.Type,
+		})
 	}
 
 	return failures

--- a/rule/argument_limit.go
+++ b/rule/argument_limit.go
@@ -35,16 +35,26 @@ func (r *ArgumentsLimitRule) Apply(file *lint.File, arguments lint.Arguments) []
 	r.configureOnce.Do(func() { r.configure(arguments) })
 
 	var failures []lint.Failure
-	onFailure := func(failure lint.Failure) {
-		failures = append(failures, failure)
-	}
 
-	walker := lintArgsNum{
-		max:       r.max,
-		onFailure: onFailure,
-	}
+	for _, decl := range file.AST.Decls {
+		funcDecl, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
 
-	ast.Walk(walker, file.AST)
+		numParams := 0
+		for _, l := range funcDecl.Type.Params.List {
+			numParams += len(l.Names)
+		}
+
+		if numParams > r.max {
+			failures = append(failures, lint.Failure{
+				Confidence: 1,
+				Failure:    fmt.Sprintf("maximum number of arguments per function exceeded; max %d but got %d", r.max, numParams),
+				Node:       funcDecl.Type,
+			})
+		}
+	}
 
 	return failures
 }
@@ -52,33 +62,4 @@ func (r *ArgumentsLimitRule) Apply(file *lint.File, arguments lint.Arguments) []
 // Name returns the rule name.
 func (*ArgumentsLimitRule) Name() string {
 	return "argument-limit"
-}
-
-type lintArgsNum struct {
-	max       int
-	onFailure func(lint.Failure)
-}
-
-func (w lintArgsNum) Visit(n ast.Node) ast.Visitor {
-	node, ok := n.(*ast.FuncDecl)
-	if !ok {
-		return w
-	}
-
-	num := 0
-	for _, l := range node.Type.Params.List {
-		for range l.Names {
-			num++
-		}
-	}
-
-	if num > w.max {
-		w.onFailure(lint.Failure{
-			Confidence: 1,
-			Failure:    fmt.Sprintf("maximum number of arguments per function exceeded; max %d but got %d", w.max, num),
-			Node:       node.Type,
-		})
-	}
-
-	return nil // skip visiting the body of the function
 }

--- a/test/argument_limit_test.go
+++ b/test/argument_limit_test.go
@@ -7,12 +7,19 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-func TestArgumentLimitDefault(t *testing.T) {
+func TestArgumentsLimitDefault(t *testing.T) {
 	testRule(t, "argument_limit_default", &rule.ArgumentsLimitRule{}, &lint.RuleConfig{})
 }
 
-func TestArgumentLimit(t *testing.T) {
+func TestArgumentsLimit(t *testing.T) {
 	testRule(t, "argument_limit", &rule.ArgumentsLimitRule{}, &lint.RuleConfig{
 		Arguments: []any{int64(3)},
 	})
+}
+
+func BenchmarkArgumentsLimit(b *testing.B) {
+	var t *testing.T
+	for i := 0; i <= b.N; i++ {
+		testRule(t, "argument_limit_default", &rule.ArgumentsLimitRule{}, &lint.RuleConfig{})
+	}
 }


### PR DESCRIPTION
Simplifies arguments-limits rule by replacing AST walker by an iteration over global declarations