### PR TITLE
refactor (rule/datarace): replace AST walker by iteration over declarations

### DIFF
--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -11,14 +11,35 @@ import (
 type DataRaceRule struct{}
 
 // Apply applies the rule to given file.
-func (*DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	isGo122 := file.Pkg.IsAtLeastGo122()
 	var failures []lint.Failure
-	onFailure := func(failure lint.Failure) {
-		failures = append(failures, failure)
-	}
-	w := lintDataRaces{onFailure: onFailure, go122for: file.Pkg.IsAtLeastGo122()}
+	for _, decl := range file.AST.Decls {
+		funcDecl, ok := decl.(*ast.FuncDecl)
+		if !ok || funcDecl.Body == nil {
+			continue // not function declaration or empty function
+		}
 
-	ast.Walk(w, file.AST)
+		funcResults := funcDecl.Type.Results
+
+		returnIDs := map[*ast.Object]struct{}{}
+		if funcResults != nil {
+			returnIDs = r.ExtractReturnIDs(funcResults.List)
+		}
+
+		onFailure := func(failure lint.Failure) {
+			failures = append(failures, failure)
+		}
+
+		fl := &lintFunctionForDataRaces{
+			onFailure: onFailure,
+			returnIDs: returnIDs,
+			rangeIDs:  map[*ast.Object]struct{}{},
+			go122for:  isGo122,
+		}
+
+		ast.Walk(fl, funcDecl.Body)
+	}
 
 	return failures
 }
@@ -28,33 +49,7 @@ func (*DataRaceRule) Name() string {
 	return "datarace"
 }
 
-type lintDataRaces struct {
-	onFailure func(failure lint.Failure)
-	go122for  bool
-}
-
-func (w lintDataRaces) Visit(n ast.Node) ast.Visitor {
-	node, ok := n.(*ast.FuncDecl)
-	if !ok {
-		return w // not function declaration
-	}
-	if node.Body == nil {
-		return nil // empty body
-	}
-
-	results := node.Type.Results
-
-	returnIDs := map[*ast.Object]struct{}{}
-	if results != nil {
-		returnIDs = w.ExtractReturnIDs(results.List)
-	}
-	fl := &lintFunctionForDataRaces{onFailure: w.onFailure, returnIDs: returnIDs, rangeIDs: map[*ast.Object]struct{}{}, go122for: w.go122for}
-	ast.Walk(fl, node.Body)
-
-	return nil
-}
-
-func (lintDataRaces) ExtractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
+func (*DataRaceRule) ExtractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
 	r := map[*ast.Object]struct{}{}
 	for _, f := range fields {
 		for _, id := range f.Names {


### PR DESCRIPTION
Simplifies datarace rule by replacing AST walker by an iteration over global declarations
