### PR TITLE
 refactor (rule/flag-param): replace AST walker by iteration over declarations

### DIFF
--- a/rule/flag_param.go
+++ b/rule/flag_param.go
@@ -13,13 +13,36 @@ type FlagParamRule struct{}
 // Apply applies the rule to given file.
 func (*FlagParamRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
-
 	onFailure := func(failure lint.Failure) {
 		failures = append(failures, failure)
 	}
 
-	w := lintFlagParamRule{onFailure: onFailure}
-	ast.Walk(w, file.AST)
+	for _, decl := range file.AST.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		isFuncWithNonEmptyBody := ok && fd.Body != nil
+		if !isFuncWithNonEmptyBody {
+			continue
+		}
+
+		boolParams := map[string]struct{}{}
+		for _, param := range fd.Type.Params.List {
+			if !isIdent(param.Type, "bool") {
+				continue
+			}
+
+			for _, paramId := range param.Names {
+				boolParams[paramId.Name] = struct{}{}
+			}
+		}
+
+		if len(boolParams) == 0 {
+			continue
+		}
+
+		cv := conditionVisitor{boolParams, fd, onFailure}
+		ast.Walk(cv, fd.Body)
+	}
+
 	return failures
 }
 
@@ -28,43 +51,10 @@ func (*FlagParamRule) Name() string {
 	return "flag-parameter"
 }
 
-type lintFlagParamRule struct {
-	onFailure func(lint.Failure)
-}
-
-func (w lintFlagParamRule) Visit(node ast.Node) ast.Visitor {
-	fd, ok := node.(*ast.FuncDecl)
-	if !ok {
-		return w
-	}
-
-	if fd.Body == nil {
-		return nil // skip whole function declaration
-	}
-
-	for _, p := range fd.Type.Params.List {
-		t := p.Type
-
-		id, ok := t.(*ast.Ident)
-		if !ok {
-			continue
-		}
-
-		if id.Name != "bool" {
-			continue
-		}
-
-		cv := conditionVisitor{p.Names, fd, w}
-		ast.Walk(cv, fd.Body)
-	}
-
-	return w
-}
-
 type conditionVisitor struct {
-	ids    []*ast.Ident
-	fd     *ast.FuncDecl
-	linter lintFlagParamRule
+	ids       map[string]struct{}
+	fd        *ast.FuncDecl
+	onFailure func(lint.Failure)
 }
 
 func (w conditionVisitor) Visit(node ast.Node) ast.Visitor {
@@ -73,28 +63,22 @@ func (w conditionVisitor) Visit(node ast.Node) ast.Visitor {
 		return w
 	}
 
-	fselect := func(n ast.Node) bool {
+	findUsesOfIds := func(n ast.Node) bool {
 		ident, ok := n.(*ast.Ident)
 		if !ok {
 			return false
 		}
 
-		for _, id := range w.ids {
-			if ident.Name == id.Name {
-				return true
-			}
-		}
-
-		return false
+		return w.ids[ident.Name] == struct{}{}
 	}
 
-	uses := pick(ifStmt.Cond, fselect)
+	uses := pick(ifStmt.Cond, findUsesOfIds)
 
 	if len(uses) < 1 {
 		return w
 	}
 
-	w.linter.onFailure(lint.Failure{
+	w.onFailure(lint.Failure{
 		Confidence: 1,
 		Node:       w.fd.Type.Params,
 		Category:   "bad practice",

--- a/rule/flag_param.go
+++ b/rule/flag_param.go
@@ -30,8 +30,8 @@ func (*FlagParamRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 				continue
 			}
 
-			for _, paramId := range param.Names {
-				boolParams[paramId.Name] = struct{}{}
+			for _, paramIdent := range param.Names {
+				boolParams[paramIdent.Name] = struct{}{}
 			}
 		}
 
@@ -52,7 +52,7 @@ func (*FlagParamRule) Name() string {
 }
 
 type conditionVisitor struct {
-	ids       map[string]struct{}
+	idents    map[string]struct{}
 	fd        *ast.FuncDecl
 	onFailure func(lint.Failure)
 }
@@ -63,16 +63,16 @@ func (w conditionVisitor) Visit(node ast.Node) ast.Visitor {
 		return w
 	}
 
-	findUsesOfIds := func(n ast.Node) bool {
+	findUsesOfIdents := func(n ast.Node) bool {
 		ident, ok := n.(*ast.Ident)
 		if !ok {
 			return false
 		}
 
-		return w.ids[ident.Name] == struct{}{}
+		return w.idents[ident.Name] == struct{}{}
 	}
 
-	uses := pick(ifStmt.Cond, findUsesOfIds)
+	uses := pick(ifStmt.Cond, findUsesOfIdents)
 
 	if len(uses) < 1 {
 		return w


### PR DESCRIPTION
Simplifies flag-param rule by replacing AST walker by an iteration over global declarations