### PR TITLE
refactor (rule/function-result-limit): replace AST walker by iteration over declarations

### DIFF
--- a/rule/function_result_limit.go
+++ b/rule/function_result_limit.go
@@ -32,13 +32,15 @@ func (r *FunctionResultsLimitRule) Apply(file *lint.File, arguments lint.Argumen
 			num = funcDecl.Type.Results.NumFields()
 		}
 
-		if num > r.max {
-			failures = append(failures, lint.Failure{
-				Confidence: 1,
-				Failure:    fmt.Sprintf("maximum number of return results per function exceeded; max %d but got %d", r.max, num),
-				Node:       funcDecl.Type,
-			})
+		if num <= r.max {
+			continue
 		}
+
+		failures = append(failures, lint.Failure{
+			Confidence: 1,
+			Failure:    fmt.Sprintf("maximum number of return results per function exceeded; max %d but got %d", r.max, num),
+			Node:       funcDecl.Type,
+		})
 	}
 
 	return failures

--- a/rule/function_result_limit.go
+++ b/rule/function_result_limit.go
@@ -15,25 +15,6 @@ type FunctionResultsLimitRule struct {
 	configureOnce sync.Once
 }
 
-const defaultResultsLimit = 3
-
-func (r *FunctionResultsLimitRule) configure(arguments lint.Arguments) {
-	if len(arguments) < 1 {
-		r.max = defaultResultsLimit
-		return
-	}
-
-	maxResults, ok := arguments[0].(int64) // Alt. non panicking version
-	if !ok {
-		panic(fmt.Sprintf(`invalid value passed as return results number to the "function-result-limit" rule; need int64 but got %T`, arguments[0]))
-	}
-	if maxResults < 0 {
-		panic(`the value passed as return results number to the "function-result-limit" rule cannot be negative`)
-	}
-
-	r.max = int(maxResults)
-}
-
 // Apply applies the rule to given file.
 func (r *FunctionResultsLimitRule) Apply(file *lint.File, arguments lint.Arguments) []lint.Failure {
 	r.configureOnce.Do(func() { r.configure(arguments) })
@@ -66,4 +47,23 @@ func (r *FunctionResultsLimitRule) Apply(file *lint.File, arguments lint.Argumen
 // Name returns the rule name.
 func (*FunctionResultsLimitRule) Name() string {
 	return "function-result-limit"
+}
+
+const defaultResultsLimit = 3
+
+func (r *FunctionResultsLimitRule) configure(arguments lint.Arguments) {
+	if len(arguments) < 1 {
+		r.max = defaultResultsLimit
+		return
+	}
+
+	maxResults, ok := arguments[0].(int64) // Alt. non panicking version
+	if !ok {
+		panic(fmt.Sprintf(`invalid value passed as return results number to the "function-result-limit" rule; need int64 but got %T`, arguments[0]))
+	}
+	if maxResults < 0 {
+		panic(`the value passed as return results number to the "function-result-limit" rule cannot be negative`)
+	}
+
+	r.max = int(maxResults)
 }


### PR DESCRIPTION
Simplifies function-result-limit rule by replacing AST walker by an iteration over global declarations