### PR TITLE
test: remove useless comments

### DIFF
--- a/test/atomic_test.go
+++ b/test/atomic_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// Atomic rule.
 func TestAtomic(t *testing.T) {
 	testRule(t, "atomic", &rule.AtomicRule{})
 }

--- a/test/bool_literal_in_expr_test.go
+++ b/test/bool_literal_in_expr_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// BoolLiteral rule.
 func TestBoolLiteral(t *testing.T) {
 	testRule(t, "bool_literal_in_expr", &rule.BoolLiteralRule{})
 }

--- a/test/call_to_gc_test.go
+++ b/test/call_to_gc_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestCallToGC test call-to-gc rule
 func TestCallToGC(t *testing.T) {
 	testRule(t, "call_to_gc", &rule.CallToGCRule{})
 }

--- a/test/confusing_naming_test.go
+++ b/test/confusing_naming_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestConfusingNaming rule.
 func TestConfusingNaming(t *testing.T) {
 	testRule(t, "confusing_naming1", &rule.ConfusingNamingRule{})
 }

--- a/test/constant_logical_expr_test.go
+++ b/test/constant_logical_expr_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// ConstantLogicalExpr rule.
 func TestConstantLogicalExpr(t *testing.T) {
 	testRule(t, "constant_logical_expr", &rule.ConstantLogicalExprRule{})
 }

--- a/test/defer_test.go
+++ b/test/defer_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// Defer rule.
 func TestDefer(t *testing.T) {
 	testRule(t, "defer", &rule.DeferRule{})
 }

--- a/test/early_return_test.go
+++ b/test/early_return_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestEarlyReturn tests early-return rule.
 func TestEarlyReturn(t *testing.T) {
 	testRule(t, "early_return", &rule.EarlyReturnRule{})
 	testRule(t, "early_return_scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{ifelse.PreserveScope}})

--- a/test/empty_block_test.go
+++ b/test/empty_block_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestEmptyBlock rule.
 func TestEmptyBlock(t *testing.T) {
 	testRule(t, "empty_block", &rule.EmptyBlockRule{})
 }

--- a/test/empty_lines_test.go
+++ b/test/empty_lines_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestEmptyLines rule.
 func TestEmptyLines(t *testing.T) {
 	testRule(t, "empty_lines", &rule.EmptyLinesRule{})
 }

--- a/test/identical_branches_test.go
+++ b/test/identical_branches_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// IdenticalBranches rule.
 func TestIdenticalBranches(t *testing.T) {
 	testRule(t, "identical_branches", &rule.IdenticalBranchesRule{})
 }

--- a/test/if_return_test.go
+++ b/test/if_return_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestIfReturn rule.
 func TestIfReturn(t *testing.T) {
 	testRule(t, "if_return", &rule.IfReturnRule{})
 }

--- a/test/modifies_param_test.go
+++ b/test/modifies_param_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestModifiesParam rule.
 func TestModifiesParam(t *testing.T) {
 	testRule(t, "modifies_param", &rule.ModifiesParamRule{})
 }

--- a/test/redefines_builtin_id_test.go
+++ b/test/redefines_builtin_id_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// Tests RedefinesBuiltinID rule.
 func TestRedefinesBuiltinID(t *testing.T) {
 	testRule(t, "redefines_builtin_id", &rule.RedefinesBuiltinIDRule{})
 }

--- a/test/redundant_import_alias_test.go
+++ b/test/redundant_import_alias_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 )
 
-// TestRedundantImportAlias rule.
 func TestRedundantImportAlias(t *testing.T) {
 	testRule(t, "redundant_import_alias", &rule.RedundantImportAlias{})
 }

--- a/test/string_of_int_test.go
+++ b/test/string_of_int_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// String-of-int rule.
 func TestStringOfInt(t *testing.T) {
 	testRule(t, "string_of_int", &rule.StringOfIntRule{})
 }

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestStructTag tests struct-tag rule
 func TestStructTag(t *testing.T) {
 	testRule(t, "struct_tag", &rule.StructTagRule{})
 }

--- a/test/superfluous_else_test.go
+++ b/test/superfluous_else_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestSuperfluousElse rule.
 func TestSuperfluousElse(t *testing.T) {
 	testRule(t, "superfluous_else", &rule.SuperfluousElseRule{})
 	testRule(t, "superfluous_else_scope", &rule.SuperfluousElseRule{}, &lint.RuleConfig{Arguments: []any{ifelse.PreserveScope}})

--- a/test/time_equal_test.go
+++ b/test/time_equal_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestTimeEqual rule.
 func TestTimeEqual(t *testing.T) {
 	testRule(t, "time_equal", &rule.TimeEqualRule{})
 }

--- a/test/time_naming_test.go
+++ b/test/time_naming_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestTimeNamingRule rule.
 func TestTimeNaming(t *testing.T) {
 	testRule(t, "time_naming", &rule.TimeNamingRule{})
 }

--- a/test/unnecessary_stmt_test.go
+++ b/test/unnecessary_stmt_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// TestUnnecessaryStmt rule.
 func TestUnnecessaryStmt(t *testing.T) {
 	testRule(t, "unnecessary_stmt", &rule.UnnecessaryStmtRule{})
 }

--- a/test/useless_break_test.go
+++ b/test/useless_break_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mgechev/revive/rule"
 )
 
-// UselessBreak rule.
 func TestUselessBreak(t *testing.T) {
 	testRule(t, "useless_break", &rule.UselessBreak{})
 }


### PR DESCRIPTION
The PR removes redundant comments in the `test` package that do not add much value to code readability.