### PR TITLE
fix: ast_utils.FuncSignatureIs panics with types names other than ast.Ident

### DIFF
--- a/internal/astutils/ast_utils.go
+++ b/internal/astutils/ast_utils.go
@@ -1,6 +1,9 @@
 package astutils
 
-import "go/ast"
+import (
+	"fmt"
+	"go/ast"
+)
 
 // FuncSignatureIs returns true if the given func decl satisfies a signature characterized
 // by the given name, parameters types and return types; false otherwise.
@@ -45,7 +48,7 @@ func getTypeNames(fields *ast.FieldList) []string {
 	}
 
 	for _, field := range fields.List {
-		typeName := field.Type.(*ast.Ident).Name
+		typeName := getFieldTypeName(field.Type)
 		if field.Names == nil { // unnamed field
 			result = append(result, typeName)
 			continue
@@ -57,4 +60,17 @@ func getTypeNames(fields *ast.FieldList) []string {
 	}
 
 	return result
+}
+
+func getFieldTypeName(typ ast.Expr) string {
+	switch f := typ.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		return f.Sel.Name + "." + getFieldTypeName(f.X)
+	case *ast.StarExpr:
+		return "*" + getFieldTypeName(f.X)
+	default:
+		panic(fmt.Sprintf("not supported type %T", typ))
+	}
 }

--- a/testdata/golint/sort.go
+++ b/testdata/golint/sort.go
@@ -36,3 +36,8 @@ type Vv []int
 
 func (vv Vv) Len() (result int)               { return len(w) }      // MATCH /exported method Vv.Len should have comment or be unexported/
 func (vv Vv) Less(i int, j int) (result bool) { return w[i] < w[j] } // MATCH /exported method Vv.Less should have comment or be unexported/
+
+// X is ...
+type X []int
+
+func (x X) Less(i *pkg.tip) (result bool) { return len(x) } // MATCH /exported method X.Less should have comment or be unexported/


### PR DESCRIPTION
Fixes panic of ast_utils.FuncSignatureIs with type names of types other than ast.Ident (ast.SelectorExpression, ast.StarExpression)

The bug makes revive panic if the code under analysis has a method named Less, Len, or Swap with parameters of types represented as ast.SelectorExpression or ast.StarExpression in the AST.