### PR TITLE
refactor: remove lint issues

### DIFF
--- a/internal/astutils/ast_utils.go
+++ b/internal/astutils/ast_utils.go
@@ -1,3 +1,4 @@
+// Package astutils provides utility functions for working with AST nodes
 package astutils
 
 import "go/ast"

--- a/rule/confusing_results.go
+++ b/rule/confusing_results.go
@@ -28,7 +28,6 @@ func (*ConfusingResultsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fai
 
 		lastType := ""
 		for _, result := range funcDecl.Type.Results.List {
-
 			resultTypeName := gofmt(result.Type)
 
 			if resultTypeName == lastType {

--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -24,7 +24,7 @@ func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 
 		returnIDs := map[*ast.Object]struct{}{}
 		if funcResults != nil {
-			returnIDs = r.ExtractReturnIDs(funcResults.List)
+			returnIDs = r.extractReturnIDs(funcResults.List)
 		}
 
 		onFailure := func(failure lint.Failure) {
@@ -49,7 +49,7 @@ func (*DataRaceRule) Name() string {
 	return "datarace"
 }
 
-func (*DataRaceRule) ExtractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
+func (*DataRaceRule) extractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
 	r := map[*ast.Object]struct{}{}
 	for _, f := range fields {
 		for _, id := range f.Names {


### PR DESCRIPTION
removes:
```
internal/astutils/ast_utils.go:1:1: should have a package comment
rule/datarace.go:52:1: exported method DataRaceRule.ExtractReturnIDs should have comment or be unexported
rule/confusing_results.go:30:53: extra empty line at the start of a block
```