### PR TITLE
refactor: code cleanup

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -132,11 +132,12 @@ func buildDefaultConfigPath() string {
 		homeDirFile = filepath.Join(homeDir, configFileName)
 	}
 
-	if fileExist(configDirFile) {
+	switch {
+	case fileExist(configDirFile):
 		result = configDirFile
-	} else if fileExist(homeDirFile) {
+	case fileExist(homeDirFile):
 		result = homeDirFile
-	} else {
+	default:
 		result = ""
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -242,15 +242,15 @@ func GetConfig(configPath string) (*lint.Config, error) {
 // GetFormatter yields the formatter for lint failures
 func GetFormatter(formatterName string) (lint.Formatter, error) {
 	formatters := getFormatters()
-	fmtr := formatters["default"]
+	result := formatters["default"]
 	if formatterName != "" {
 		f, ok := formatters[formatterName]
 		if !ok {
 			return nil, fmt.Errorf("unknown formatter %v", formatterName)
 		}
-		fmtr = f
+		result = f
 	}
-	return fmtr, nil
+	return result, nil
 }
 
 func defaultConfig() *lint.Config {

--- a/formatter/friendly.go
+++ b/formatter/friendly.go
@@ -57,7 +57,7 @@ func (f *Friendly) Format(failures <-chan lint.Failure, config lint.Config) (str
 	return buf.String(), nil
 }
 
-func (f *Friendly) printFrisendlyFailure(sb *strings.Builder, failure lint.Failure, severity lint.Severity) {
+func (f *Friendly) printFriendlyFailure(sb *strings.Builder, failure lint.Failure, severity lint.Severity) {
 	f.printHeaderRow(sb, failure, severity)
 	f.printFilePosition(sb, failure)
 	sb.WriteString("\n\n")

--- a/formatter/plain.go
+++ b/formatter/plain.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/mgechev/revive/lint"
 )
@@ -20,9 +20,9 @@ func (*Plain) Name() string {
 
 // Format formats the failures gotten from the lint.
 func (*Plain) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
-	var buf bytes.Buffer
+	var sb strings.Builder
 	for failure := range failures {
-		fmt.Fprintf(&buf, "%v: %s %s\n", failure.Position.Start, failure.Failure, ruleDescriptionURL(failure.RuleName))
+		sb.WriteString(fmt.Sprintf("%v: %s %s\n", failure.Position.Start, failure.Failure, ruleDescriptionURL(failure.RuleName)))
 	}
-	return buf.String(), nil
+	return sb.String(), nil
 }

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -78,11 +78,12 @@ func (*Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string
 
 	suffix := fmt.Sprintf(" %d %s (%d errors) (%d warnings)", total, ps, totalErrors, total-totalErrors)
 
-	if total > 0 && totalErrors > 0 {
+	switch {
+	case total > 0 && totalErrors > 0:
 		suffix = color.RedString("\n ✖" + suffix)
-	} else if total > 0 && totalErrors == 0 {
+	case total > 0 && totalErrors == 0:
 		suffix = color.YellowString("\n ✖" + suffix)
-	} else {
+	default:
 		suffix, output = "", ""
 	}
 

--- a/formatter/unix.go
+++ b/formatter/unix.go
@@ -1,8 +1,8 @@
 package formatter
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/mgechev/revive/lint"
 )
@@ -22,9 +22,9 @@ func (*Unix) Name() string {
 
 // Format formats the failures gotten from the lint.
 func (*Unix) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
-	var buf bytes.Buffer
+	var sb strings.Builder
 	for failure := range failures {
-		fmt.Fprintf(&buf, "%v: [%s] %s\n", failure.Position.Start, failure.RuleName, failure.Failure)
+		sb.WriteString(fmt.Sprintf("%v: [%s] %s\n", failure.Position.Start, failure.RuleName, failure.Failure))
 	}
-	return buf.String(), nil
+	return sb.String(), nil
 }

--- a/lint/file.go
+++ b/lint/file.go
@@ -191,13 +191,14 @@ func (f *File) disabledIntervals(rules []Rule, mustSpecifyDisableReason bool, fa
 	handleRules := func(_, modifier string, isEnabled bool, line int, ruleNames []string) []DisabledInterval {
 		var result []DisabledInterval
 		for _, name := range ruleNames {
-			if modifier == "line" {
+			switch modifier {
+			case "line":
 				handleConfig(isEnabled, line, name)
 				handleConfig(!isEnabled, line, name)
-			} else if modifier == "next-line" {
+			case "next-line":
 				handleConfig(isEnabled, line+1, name)
 				handleConfig(!isEnabled, line+1, name)
-			} else {
+			default:
 				handleConfig(isEnabled, line, name)
 			}
 		}
@@ -260,20 +261,21 @@ func (File) filterFailures(failures []Failure, disabledIntervals disabledInterva
 		intervals, ok := disabledIntervals[failure.RuleName]
 		if !ok {
 			result = append(result, failure)
-		} else {
-			include := true
-			for _, interval := range intervals {
-				intStart := interval.From.Line
-				intEnd := interval.To.Line
-				if (fStart >= intStart && fStart <= intEnd) ||
-					(fEnd >= intStart && fEnd <= intEnd) {
-					include = false
-					break
-				}
+			continue
+		}
+
+		include := true
+		for _, interval := range intervals {
+			intStart := interval.From.Line
+			intEnd := interval.To.Line
+			if (fStart >= intStart && fStart <= intEnd) ||
+				(fEnd >= intStart && fEnd <= intEnd) {
+				include = false
+				break
 			}
-			if include {
-				result = append(result, failure)
-			}
+		}
+		if include {
+			result = append(result, failure)
 		}
 	}
 	return result

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -54,8 +54,8 @@ func (l Linter) readFile(path string) (result []byte, err error) {
 }
 
 var (
-	genHdr           = []byte("// Code generated ")
-	genFtr           = []byte(" DO NOT EDIT.")
+	generatedPrefix  = []byte("// Code generated ")
+	generatedSuffix  = []byte(" DO NOT EDIT.")
 	defaultGoVersion = goversion.Must(goversion.NewVersion("1.0"))
 )
 
@@ -209,7 +209,7 @@ func isGenerated(src []byte) bool {
 	sc := bufio.NewScanner(bytes.NewReader(src))
 	for sc.Scan() {
 		b := sc.Bytes()
-		if bytes.HasPrefix(b, genHdr) && bytes.HasSuffix(b, genFtr) && len(b) >= len(genHdr)+len(genFtr) {
+		if bytes.HasPrefix(b, generatedPrefix) && bytes.HasSuffix(b, generatedSuffix) && len(b) >= len(generatedPrefix)+len(generatedSuffix) {
 			return true
 		}
 	}

--- a/lint/package.go
+++ b/lint/package.go
@@ -89,11 +89,11 @@ func (p *Package) TypeCheck() error {
 	p.Lock()
 	defer p.Unlock()
 
-	// If type checking has already been performed
-	// skip it.
-	if p.typesInfo != nil || p.typesPkg != nil {
+	alreadyTypeChecked := p.typesInfo != nil || p.typesPkg != nil
+	if alreadyTypeChecked {
 		return nil
 	}
+
 	config := &types.Config{
 		// By setting a no-op error reporter, the type checker does as much work as possible.
 		Error:    func(error) {},

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -17,11 +17,6 @@ type Rule interface {
 	Apply(*File, Arguments) []Failure
 }
 
-// AbstractRule defines an abstract rule.
-type AbstractRule struct {
-	Failures []Failure
-}
-
 // ToFailurePosition returns the failure position.
 func ToFailurePosition(start, end token.Pos, file *File) FailurePosition {
 	return FailurePosition{

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -19,15 +19,13 @@ func GetLogger() (*log.Logger, error) {
 	var writer io.Writer
 	var err error
 
+	writer = io.Discard // by default, suppress all logging output
 	debugModeEnabled := os.Getenv("DEBUG") == "1"
 	if debugModeEnabled {
 		writer, err = os.Create("revive.log")
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		// Suppress all logging output if debug mode is disabled
-		writer = io.Discard
 	}
 
 	logger = log.New(writer, "", log.LstdFlags)
@@ -38,7 +36,7 @@ func GetLogger() (*log.Logger, error) {
 		logger.SetFlags(0)
 	}
 
-	logger.Println("Logger initialised")
+	logger.Println("Logger initialized")
 
 	return logger, nil
 }


### PR DESCRIPTION
This PR:
1. removes unused code
2. replaces byte buffers with string builders when possible
3. removes if-then-else chains with switch and/or reduce nesting
4. renames some local variables