### PR TITLE
refactor: modifies linting machinery to use Failure as a mean to signal erros in rules application

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/afero v1.11.0
 	golang.org/x/mod v0.22.0
+	golang.org/x/sync v0.10.0
 	golang.org/x/tools v0.28.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=

--- a/lint/failure.go
+++ b/lint/failure.go
@@ -37,3 +37,18 @@ type Failure struct {
 func (f *Failure) GetFilename() string {
 	return f.Position.Start.Filename
 }
+
+const internalFailure = "REVIVE_INTERNAL"
+
+// IsInternal returns true if this failure is internal, false otherwise.
+func (f *Failure) IsInternal() bool {
+	return f.Category == internalFailure
+}
+
+// NewInternalFailure yields an internal failure with the given message as failure message.
+func NewInternalFailure(message string) Failure {
+	return Failure{
+		Category: internalFailure,
+		Failure:  message,
+	}
+}

--- a/lint/file.go
+++ b/lint/file.go
@@ -111,6 +111,7 @@ func (f *File) lint(rules []Rule, config Config, failures chan Failure) error {
 			if failure.IsInternal() {
 				return errors.New(failure.Failure)
 			}
+
 			if failure.RuleName == "" {
 				failure.RuleName = currentRule.Name()
 			}

--- a/lint/file.go
+++ b/lint/file.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"bytes"
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/printer"
@@ -96,7 +97,7 @@ func (f *File) isMain() bool {
 
 const directiveSpecifyDisableReason = "specify-disable-reason"
 
-func (f *File) lint(rules []Rule, config Config, failures chan Failure) {
+func (f *File) lint(rules []Rule, config Config, failures chan Failure) error {
 	rulesConfig := config.Rules
 	_, mustSpecifyDisableReason := config.Directives[directiveSpecifyDisableReason]
 	disabledIntervals := f.disabledIntervals(rules, mustSpecifyDisableReason, failures)
@@ -107,6 +108,9 @@ func (f *File) lint(rules []Rule, config Config, failures chan Failure) {
 		}
 		currentFailures := currentRule.Apply(f, ruleConfig.Arguments)
 		for idx, failure := range currentFailures {
+			if failure.IsInternal() {
+				return errors.New(failure.Failure)
+			}
 			if failure.RuleName == "" {
 				failure.RuleName = currentRule.Name()
 			}
@@ -122,6 +126,7 @@ func (f *File) lint(rules []Rule, config Config, failures chan Failure) {
 			}
 		}
 	}
+	return nil
 }
 
 type enableDisableConfig struct {

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -152,9 +152,7 @@ func (l *Linter) lintPackage(filenames []string, gover *goversion.Version, ruleS
 		return nil
 	}
 
-	pkg.lint(ruleSet, config, failures)
-
-	return nil
+	return pkg.lint(ruleSet, config, failures)
 }
 
 func detectGoMod(dir string) (rootDir string, ver *goversion.Version, err error) {

--- a/rule/add_constant.go
+++ b/rule/add_constant.go
@@ -206,7 +206,6 @@ func (w *lintAddConstantRule) isStructTag(n *ast.BasicLit) bool {
 }
 
 func (r *AddConstantRule) configure(arguments lint.Arguments) error {
-	println(">>>> configuring")
 	r.strLitLimit = defaultStrLitLimit
 	r.allowList = newAllowList()
 	if len(arguments) == 0 {


### PR DESCRIPTION
This is PR adds the necessary modifications in the linting machinery to allow removing panics from rules.

It leverages the failure mechanism to communicate errors thus no need to change the rules interface.
It has the nice property of not requiring all rules to be modified at once.
