### PR TITLE
refactor: simplify config.GetFormatter; add tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -242,15 +242,14 @@ func GetConfig(configPath string) (*lint.Config, error) {
 // GetFormatter yields the formatter for lint failures
 func GetFormatter(formatterName string) (lint.Formatter, error) {
 	formatters := getFormatters()
-	result := formatters["default"]
-	if formatterName != "" {
-		f, ok := formatters[formatterName]
-		if !ok {
-			return nil, fmt.Errorf("unknown formatter %v", formatterName)
-		}
-		result = f
+	if formatterName == "" {
+		return formatters["default"], nil
 	}
-	return result, nil
+	f, ok := formatters[formatterName]
+	if !ok {
+		return nil, fmt.Errorf("unknown formatter %v", formatterName)
+	}
+	return f, nil
 }
 
 func defaultConfig() *lint.Config {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -173,3 +173,30 @@ func TestGetGlobalSeverity(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFormatter(t *testing.T) {
+	t.Run("default formatter", func(t *testing.T) {
+		formatter, err := GetFormatter("")
+		if err != nil {
+			t.Fatalf("Unexpected error %q", err)
+		}
+		if formatter == nil || formatter.Name() != "default" {
+			t.Errorf("Expected formatter %q, got %v", "default", formatter)
+		}
+	})
+	t.Run("unknown formatter", func(t *testing.T) {
+		_, err := GetFormatter("unknown")
+		if err == nil || err.Error() != "unknown formatter unknown" {
+			t.Errorf("Expected error %q, got: %q", "unknown formatter unknown", err)
+		}
+	})
+	t.Run("checkstyle formatter", func(t *testing.T) {
+		formatter, err := GetFormatter("checkstyle")
+		if err != nil {
+			t.Fatalf("Unexpected error: %q", err)
+		}
+		if formatter == nil || formatter.Name() != "checkstyle" {
+			t.Errorf("Expected formatter %q, got %v", "checkstyle", formatter)
+		}
+	})
+}


### PR DESCRIPTION
The PR adds tests for the `config.GetFormatter` and simplifies it.