### PR TITLE
fix: return configure rule error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -151,7 +151,7 @@ func GetLintingRules(config *lint.Config, extraRules []lint.Rule) ([]lint.Rule, 
 
 		if r, ok := r.(lint.ConfigurableRule); ok {
 			if err := r.Configure(ruleConfig.Arguments); err != nil {
-				return nil, fmt.Errorf("cannot configure rule: %s", name)
+				return nil, fmt.Errorf("cannot configure rule: %q: %w", name, err)
 			}
 		}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -88,6 +88,7 @@ func TestGetLintingRules(t *testing.T) {
 	tt := map[string]struct {
 		confPath       string
 		wantRulesCount int
+		wantErr        string
 	}{
 		"no rules": {
 			confPath:       "testdata/noRules.toml",
@@ -105,6 +106,10 @@ func TestGetLintingRules(t *testing.T) {
 			confPath:       "testdata/enable2.toml",
 			wantRulesCount: 2,
 		},
+		"var-naming configure error": {
+			confPath: "testdata/varNamingConfigureError.toml",
+			wantErr:  `cannot configure rule: "var-naming": invalid argument to the var-naming rule. Expecting a allowlist of type slice with initialisms, got string`,
+		},
 	}
 
 	for name, tc := range tt {
@@ -114,6 +119,13 @@ func TestGetLintingRules(t *testing.T) {
 				t.Fatalf("Unexpected error while loading conf: %v", err)
 			}
 			rules, err := GetLintingRules(cfg, []lint.Rule{})
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("Expected error %q, got %q", tc.wantErr, err)
+				}
+				return
+			}
+
 			switch {
 			case err != nil:
 				t.Fatalf("Unexpected error\n\t%v", err)

--- a/config/testdata/varNamingConfigureError.toml
+++ b/config/testdata/varNamingConfigureError.toml
@@ -1,0 +1,4 @@
+enableAllRules = false
+
+[rule.var-naming]
+  arguments = ["ID", "VM"]


### PR DESCRIPTION
This PR changes `config.GetLintingRule` to return a configure rule error.

The PR adds a test for the `var-naming` because this rule mentioned in the documentation about ["Configurable rules"](https://github.com/mgechev/revive#configurable-rules).
