### PR TITLE
refactor: get rid of mitchellh/go-homedir package

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/mgechev/revive/config"
 	"github.com/mgechev/revive/revivelib"
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
 )
 
@@ -128,7 +127,7 @@ func buildDefaultConfigPath() string {
 	configFileName := "revive.toml"
 	configDirFile := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), configFileName)
 
-	if homeDir, err := homedir.Dir(); err == nil {
+	if homeDir, err := os.UserHomeDir(); err == nil {
 		homeDirFile = filepath.Join(homeDir, configFileName)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/fatih/structtag v1.2.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/afero v1.11.0
 	golang.org/x/mod v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517 h1:zpIH83+oKzcpryru8ceC6BxnoG8TBrhgAvRg8obzup0=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This PR replaces the archived `github.com/mitchellh/go-homedir` package dependency with `os`.

The repository https://github.com/mitchellh/go-homedir has been archived by the owner on Jul 22, 2024. For our needs, `homedir.Dir` can be replaced with `os.UserHomeDir` since Go 1.20. See mitchellh/go-homedir#34 for more details.