### PR TITLE
docs: update "Text Editors" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,15 @@ If you want to use revive with Bazel, look at the [rules](https://github.com/atl
 
 ### Text Editors
 
-- Support for VSCode in [vscode-go](https://github.com/Microsoft/vscode-go/pull/1699).
+- Support for VSCode via [vscode-go](https://code.visualstudio.com/docs/languages/go#_build-and-diagnose) by changing the `go.lintOnSave` setting to `revive`:
+
+```json
+{
+  "go.lintTool": "revive",
+}
+```
+
 - Support for GoLand via [File Watchers](https://dev.to/s0xzwasd/configure-revive-go-linter-in-goland-2ggl).
-- Support for Atom via [linter-revive](https://github.com/morphy2k/linter-revive).
 - Support for vim via [dense-analysis/ale](https://github.com/dense-analysis/ale).
 
   ```vim

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you want to use revive with Bazel, look at the [rules](https://github.com/atl
 
 ### Text Editors
 
-- Support for VSCode via [vscode-go](https://code.visualstudio.com/docs/languages/go#_build-and-diagnose) by changing the `go.lintOnSave` setting to `revive`:
+- Support for VSCode via [vscode-go](https://code.visualstudio.com/docs/languages/go#_build-and-diagnose) by changing the `go.lintTool` setting to `revive`:
 
 ```json
 {


### PR DESCRIPTION
The PR updates "Text Editors" in README:

- Remove `Atom` from docs as it is not supported any more https://github.blog/news-insights/product-news/sunsetting-atom/
- Update VSCode with info about `go.lintTool` setting.