### PR TITLE
refactor: fix 'use-any' revive issues

### DIFF
--- a/lint/config.go
+++ b/lint/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Arguments is type used for the arguments of a rule.
-type Arguments = []interface{}
+type Arguments = []any
 
 // FileFilters is type used for modeling file filters to apply to rules.
 type FileFilters = []*FileFilter

--- a/lint/file.go
+++ b/lint/file.go
@@ -49,7 +49,7 @@ func (f *File) ToPosition(pos token.Pos) token.Position {
 }
 
 // Render renders a node.
-func (f *File) Render(x interface{}) string {
+func (f *File) Render(x any) string {
 	var buf bytes.Buffer
 	if err := printer.Fprint(&buf, f.Pkg.fset, x); err != nil {
 		panic(err)

--- a/revive.toml
+++ b/revive.toml
@@ -41,5 +41,6 @@ warningCode = 1
 [rule.unreachable-code]
 [rule.unused-parameter]
 [rule.useless-break]
+[rule.use-any]
 [rule.var-declaration]
 [rule.var-naming]


### PR DESCRIPTION
The PR enables `use-any` rule in the project's revive config and replaces `interface{}` with `any`.