### PR TITLE
fix: running revive in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,3 +18,4 @@ jobs:
       uses: morphy2k/revive-action@v2
       with:
         config: revive.toml
+        path: ./...

--- a/rule/string_format.go
+++ b/rule/string_format.go
@@ -143,7 +143,8 @@ func (w *lintStringFormatRule) parseArgument(argument any, ruleNum int) (scopes 
 			return stringFormatSubruleScopes{}, regex, false, "", w.parseScopeError("unable to parse rule scope", ruleNum, 0, scopeNum)
 		} else if len(matches) != 4 {
 			// The rule's scope matched the parsing regex, but an unexpected number of submatches was returned, probably a bug
-			return stringFormatSubruleScopes{}, regex, false, "", w.parseScopeError(fmt.Sprintf("unexpected number of submatches when parsing scope: %d, expected 4", len(matches)), ruleNum, 0, scopeNum)
+			return stringFormatSubruleScopes{}, regex, false, "",
+				w.parseScopeError(fmt.Sprintf("unexpected number of submatches when parsing scope: %d, expected 4", len(matches)), ruleNum, 0, scopeNum)
 		}
 		scope.funcName = matches[1]
 		if len(matches[2]) > 0 {


### PR DESCRIPTION
Without providing the `path`, revive doesn't analyze all files. The resulting command is:

```sh
revive -formatter ndjson -config revive.toml
```

It looks like there's a bug in morphy2k/revive-action#156.

Now, we have a warning in the codebase:

<img width="1463" alt="image" src="https://github.com/user-attachments/assets/e1a7f59f-910f-4d4e-a8c2-2add201f04c9" />

Which I fixed in the second commit.