### PR TITLE
fix: flag-parameter rule wrongly detects var definition 

### DIFF
--- a/rule/flag_param.go
+++ b/rule/flag_param.go
@@ -69,6 +69,11 @@ func (w conditionVisitor) Visit(node ast.Node) ast.Visitor {
 			return false
 		}
 
+		_, ok = w.idents[ident.Name]
+		if !ok {
+			return false
+		}
+
 		return w.idents[ident.Name] == struct{}{}
 	}
 

--- a/testdata/flag_param.go
+++ b/testdata/flag_param.go
@@ -1,11 +1,19 @@
 package fixtures
 
-func foo(a bool, b int) { // MATCH /parameter 'a' seems to be a control flag, avoid control coupling/
+func fooFlagP(a bool, b int) { // MATCH /parameter 'a' seems to be a control flag, avoid control coupling/
 	if a {
 
 	}
 }
 
-func foo(a bool, b int) {
+func barFlagP(a bool, b int) {
 	str := mystruct{a, b}
+}
+
+// issue #1211
+func bazFlagP(a int, b bool) {
+	lBool := true
+	if lBool {
+		// do something
+	}
 }


### PR DESCRIPTION
Closes #1211 
