### PR TITLE
fix: unconditional-recursion false positive when the function is called right after its declaration (#1212)

### DIFF
--- a/testdata/unconditional_recursion.go
+++ b/testdata/unconditional_recursion.go
@@ -199,3 +199,10 @@ func nr902() {
 		nr902() // MATCH /unconditional recursive call/
 	}()
 }
+
+// Test for issue #1212
+func NewFactory() int {
+	return 0
+}
+
+var defaultFactory = NewFactory()


### PR DESCRIPTION
The root cause of the bug was that the analyzer  (AST walker) was not reinitialized at the end of function bodies. Thus, if the function was called outside the body (like in the example below) the analyzer raised a failure.

```go
func foo() int {
	return 0
}

var f = foo()
```

The fix is: iterate over global declarations of the file and create an analyzer for each function declaration (instead of create a single analyzer for the whole file) Like that, each analyzer is scoped within a single function body.

Closes #1212
