### PR TITLE
chore: check go.mod and gofmt in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,6 +5,32 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
+  go-mod:
+    name: Check go.mod
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Check go.mod
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod
+          git diff --exit-code go.sum
+
+  gofmt:
+    name: Check unformatted Go code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run gofmt
+        run: |
+          find . -type f -name '*.go' -not -path './testdata/*' -exec gofmt -w {} +
+          git diff --exit-code
 
   lint:
     name: Lint


### PR DESCRIPTION
This PR extends GitHub Actions:

- Check if there is any dirty change for `go mod tidy`.
- Check if `gofmt` produced any changes.

Avoid situations like https://github.com/mgechev/revive/pull/1060#discussion_r1934230894 and https://github.com/mgechev/revive/pull/1060#discussion_r1934234389

`Check go mod` Copied from https://github.com/golangci/golangci-lint/blob/87da074ca5995c356532643f2713fd0175702711/.github/workflows/pr.yml#L16-L28