### PR TITLE
fix (1217): getting parameter type names panics in presence of generi…

### DIFF
--- a/internal/astutils/ast_utils.go
+++ b/internal/astutils/ast_utils.go
@@ -71,6 +71,8 @@ func getFieldTypeName(typ ast.Expr) string {
 		return f.Sel.Name + "." + getFieldTypeName(f.X)
 	case *ast.StarExpr:
 		return "*" + getFieldTypeName(f.X)
+	case *ast.IndexExpr:
+		return getFieldTypeName(f.X) + "[" + getFieldTypeName(f.Index) + "]"
 	default:
 		panic(fmt.Sprintf("not supported type %T", typ))
 	}

--- a/testdata/golint/sort.go
+++ b/testdata/golint/sort.go
@@ -41,3 +41,6 @@ func (vv Vv) Less(i int, j int) (result bool) { return w[i] < w[j] } // MATCH /e
 type X []int
 
 func (x X) Less(i *pkg.tip) (result bool) { return len(x) } // MATCH /exported method X.Less should have comment or be unexported/
+
+// Test for issue #1217
+func (s *synchronized[T]) Swap(other Synchronized[T]) {}


### PR DESCRIPTION
Closes #1217 by adding support for generic parameter declarations when retrieving the parameter type name.