### PR TITLE
feature: add support for omitzero in rule struct-tag

### DIFF
--- a/lint/package.go
+++ b/lint/package.go
@@ -38,6 +38,7 @@ var (
 	go115 = goversion.Must(goversion.NewVersion("1.15"))
 	go121 = goversion.Must(goversion.NewVersion("1.21"))
 	go122 = goversion.Must(goversion.NewVersion("1.22"))
+	go124 = goversion.Must(goversion.NewVersion("1.24"))
 )
 
 // Files return package's files.
@@ -208,6 +209,11 @@ func (p *Package) IsAtLeastGo121() bool {
 // IsAtLeastGo122 returns true if the Go version for this package is 1.22 or higher, false otherwise
 func (p *Package) IsAtLeastGo122() bool {
 	return p.goVersion.GreaterThanOrEqual(go122)
+}
+
+// IsAtLeastGo124 returns true if the Go version for this package is 1.24 or higher, false otherwise
+func (p *Package) IsAtLeastGo124() bool {
+	return p.goVersion.GreaterThanOrEqual(go124)
 }
 
 func getSortableMethodFlagForFunction(fn *ast.FuncDecl) sortableMethodsFlags {

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -16,3 +16,7 @@ func TestStructTagWithUserOptions(t *testing.T) {
 		Arguments: []any{"json,inline,outline", "bson,gnu"},
 	})
 }
+
+func TestStructTagAfterGo1_24(t *testing.T) {
+	testRule(t, "go1.24/struct_tag", &rule.StructTagRule{})
+}

--- a/testdata/go1.24/go.mod
+++ b/testdata/go1.24/go.mod
@@ -1,0 +1,3 @@
+module github.com/mgechev/revive/testdata
+
+go 1.24

--- a/testdata/go1.24/struct_tag.go
+++ b/testdata/go1.24/struct_tag.go
@@ -25,7 +25,7 @@ type decodeAndValidateRequest struct {
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
 	Tiret       string `json:"-,"`
 	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in JSON tag/
-	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /unknown option 'omitzero' in JSON tag/
+	ForOmitzero string `json:"forOmitZero,omitzero"` // 'omitzero' is valid in go 1.24
 }
 
 type RangeAllocation struct {


### PR DESCRIPTION
Go 1.24 introduces `omitzero` struct tag for JSON. This PR modifies `struct-tag` rule to support `omitzero` in code bases compiling in Go 1.24 or higher.