### PR TITLE
feature: add support for URL struct tags in struct-tag rule

### DIFF
--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -102,6 +102,7 @@ const (
 	keyJSON     = "json"
 	keyProtobuf = "protobuf"
 	keyRequired = "required"
+	keyURL      = "url"
 	keyXML      = "xml"
 	keyYAML     = "yaml"
 )
@@ -195,6 +196,11 @@ func (w lintStructTagRule) checkTaggedField(f *ast.Field) {
 		case keyRequired:
 			if tag.Name != "true" && tag.Name != "false" {
 				w.addFailure(f.Tag, "required should be 'true' or 'false'")
+			}
+		case keyURL:
+			msg, ok := w.checkURLTag(tag.Options)
+			if !ok {
+				w.addFailure(f.Tag, msg)
 			}
 		case keyXML:
 			msg, ok := w.checkXMLTag(tag.Options)
@@ -316,6 +322,28 @@ func (w lintStructTagRule) checkYAMLTag(options []string) (string, bool) {
 				continue
 			}
 			return fmt.Sprintf("unknown option '%s' in YAML tag", opt), false
+		}
+	}
+
+	return "", true
+}
+
+func (w lintStructTagRule) checkURLTag(options []string) (string, bool) {
+	var delimiter = ""
+	for _, opt := range options {
+		switch opt {
+		case "int", "omitempty", "numbered", "brackets":
+		case "comma", "semicolon", "space":
+			if delimiter == "" {
+				delimiter = opt
+				continue
+			}
+			return fmt.Sprintf("can not set both '%s' and '%s' as delimiters in URL tag", opt, delimiter), false
+		default:
+			if w.isUserDefined(keyURL, opt) {
+				continue
+			}
+			return fmt.Sprintf("unknown option '%s' in URL tag", opt), false
 		}
 	}
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -333,6 +333,7 @@ func (w lintStructTagRule) checkURLTag(options []string) (string, bool) {
 	for _, opt := range options {
 		switch opt {
 		case "int", "omitempty", "numbered", "brackets":
+		case "unix", "unixmilli", "unixnano": // TODO : check that the field is of type time.Time
 		case "comma", "semicolon", "space":
 			if delimiter == "" {
 				delimiter = opt

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -13,6 +13,6 @@ func TestStructTag(t *testing.T) {
 
 func TestStructTagWithUserOptions(t *testing.T) {
 	testRule(t, "struct_tag_user_options", &rule.StructTagRule{}, &lint.RuleConfig{
-		Arguments: []any{"json,inline,outline", "bson,gnu"},
+		Arguments: []any{"json,inline,outline", "bson,gnu", "url,myURLOption"},
 	})
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -122,3 +122,16 @@ type Simple struct {
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
+
+type RequestQueryOption struct {
+	Properties           []string `url:"properties,comma,omitempty"`
+	CustomProperties     []string `url:"-"`
+	Associations         []string `url:"associations,brackets,omitempty"`
+	Associations2        []string `url:"associations2,semicolon,omitempty"`
+	Associations3        []string `url:"associations3,space,brackets,omitempty"`
+	Associations4        []string `url:"associations4,numbered,omitempty"`
+	Associations5        []string `url:"associations5,space,semicolon,omitempty"` // MATCH /can not set both 'semicolon' and 'space' as delimiters in URL tag/
+	PaginateAssociations bool     `url:"paginateAssociations,int,omitempty"`
+	Archived             bool     `url:"archived,myURLOption"` // MATCH /unknown option 'myURLOption' in URL tag/
+	IDProperty           string   `url:"idProperty,omitempty"`
+}

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -13,3 +13,9 @@ type RangeAllocation struct {
 	Range             string `bson:"range,flow"` // MATCH /unknown option 'flow' in BSON tag/
 	Data              []byte `bson:"data,inline"`
 }
+
+type RequestQueryOptions struct {
+	Properties       []string `url:"properties,commmma,omitempty"` // MATCH /unknown option 'commmma' in URL tag/
+	CustomProperties []string `url:"-"`
+	Archived         bool     `url:"archived,myURLOption"`
+}


### PR DESCRIPTION
This PR extends struct-tag rule to check URL tags as defined at https://github.com/google/go-querystring (cf https://go.dev/wiki/Well-known-struct-tags#list-of-well-known-struct-tags)