### PR TITLE
feature: add support of datastore struct tags in struct-tag rule

### DIFF
--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -98,15 +98,16 @@ func (w lintStructTagRule) Visit(node ast.Node) ast.Visitor {
 }
 
 const (
-	keyASN1     = "asn1"
-	keyBSON     = "bson"
-	keyDefault  = "default"
-	keyJSON     = "json"
-	keyProtobuf = "protobuf"
-	keyRequired = "required"
-	keyURL      = "url"
-	keyXML      = "xml"
-	keyYAML     = "yaml"
+	keyASN1      = "asn1"
+	keyBSON      = "bson"
+	keyDatastore = "datastore"
+	keyDefault   = "default"
+	keyJSON      = "json"
+	keyProtobuf  = "protobuf"
+	keyRequired  = "required"
+	keyURL       = "url"
+	keyXML       = "xml"
+	keyYAML      = "yaml"
 )
 
 func (w lintStructTagRule) checkTagNameIfNeed(tag *structtag.Tag) (string, bool) {
@@ -178,6 +179,11 @@ func (w lintStructTagRule) checkTaggedField(f *ast.Field) {
 			}
 		case keyBSON:
 			msg, ok := w.checkBSONTag(tag.Options)
+			if !ok {
+				w.addFailure(f.Tag, msg)
+			}
+		case keyDatastore:
+			msg, ok := w.checkDatastoreTag(tag.Options)
 			if !ok {
 				w.addFailure(f.Tag, msg)
 			}
@@ -352,6 +358,21 @@ func (w lintStructTagRule) checkURLTag(options []string) (string, bool) {
 				continue
 			}
 			return fmt.Sprintf("unknown option '%s' in URL tag", opt), false
+		}
+	}
+
+	return "", true
+}
+
+func (w lintStructTagRule) checkDatastoreTag(options []string) (string, bool) {
+	for _, opt := range options {
+		switch opt {
+		case "flatten", "noindex", "omitempty":
+		default:
+			if w.isUserDefined(keyDatastore, opt) {
+				continue
+			}
+			return fmt.Sprintf("unknown option '%s' in Datastore tag", opt), false
 		}
 	}
 

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -13,7 +13,12 @@ func TestStructTag(t *testing.T) {
 
 func TestStructTagWithUserOptions(t *testing.T) {
 	testRule(t, "struct_tag_user_options", &rule.StructTagRule{}, &lint.RuleConfig{
-		Arguments: []any{"json,inline,outline", "bson,gnu", "url,myURLOption"},
+		Arguments: []any{
+			"json,inline,outline",
+			"bson,gnu",
+			"url,myURLOption",
+			"datastore,myDatastoreOption",
+		},
 	})
 }
 

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -136,3 +136,8 @@ type RequestQueryOption struct {
 	Archived             bool     `url:"archived,myURLOption"` // MATCH /unknown option 'myURLOption' in URL tag/
 	IDProperty           string   `url:"idProperty,omitempty"`
 }
+
+type Fields struct {
+	Field      string `datastore:",noindex,flatten,omitempty"`
+	OtherField string `datastore:",unknownOption"` // MATCH /unknown option 'unknownOption' in Datastore tag/
+}

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -19,3 +19,8 @@ type RequestQueryOptions struct {
 	CustomProperties []string `url:"-"`
 	Archived         bool     `url:"archived,myURLOption"`
 }
+
+type Fields struct {
+	Field      string `datastore:",noindex,flatten,omitempty,myDatastoreOption"`
+	OtherField string `datastore:",unknownOption"` // MATCH /unknown option 'unknownOption' in Datastore tag/
+}


### PR DESCRIPTION
This PR extends struct-tag rule to check datastore tags as defined at https://pkg.go.dev/cloud.google.com/go/datastore (cf https://go.dev/wiki/Well-known-struct-tags#list-of-well-known-struct-tags)