### PR TITLE
feature: add suport of mapstructure struct tags in struct-tag rule

### DIFF
--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -98,16 +98,17 @@ func (w lintStructTagRule) Visit(node ast.Node) ast.Visitor {
 }
 
 const (
-	keyASN1      = "asn1"
-	keyBSON      = "bson"
-	keyDatastore = "datastore"
-	keyDefault   = "default"
-	keyJSON      = "json"
-	keyProtobuf  = "protobuf"
-	keyRequired  = "required"
-	keyURL       = "url"
-	keyXML       = "xml"
-	keyYAML      = "yaml"
+	keyASN1         = "asn1"
+	keyBSON         = "bson"
+	keyDatastore    = "datastore"
+	keyDefault      = "default"
+	keyJSON         = "json"
+	keyMapstructure = "mapstructure"
+	keyProtobuf     = "protobuf"
+	keyRequired     = "required"
+	keyURL          = "url"
+	keyXML          = "xml"
+	keyYAML         = "yaml"
 )
 
 func (w lintStructTagRule) checkTagNameIfNeed(tag *structtag.Tag) (string, bool) {
@@ -193,6 +194,11 @@ func (w lintStructTagRule) checkTaggedField(f *ast.Field) {
 			}
 		case keyJSON:
 			msg, ok := w.checkJSONTag(tag.Name, tag.Options)
+			if !ok {
+				w.addFailure(f.Tag, msg)
+			}
+		case keyMapstructure:
+			msg, ok := w.checkMapstructureTag(tag.Options)
 			if !ok {
 				w.addFailure(f.Tag, msg)
 			}
@@ -373,6 +379,21 @@ func (w lintStructTagRule) checkDatastoreTag(options []string) (string, bool) {
 				continue
 			}
 			return fmt.Sprintf("unknown option '%s' in Datastore tag", opt), false
+		}
+	}
+
+	return "", true
+}
+
+func (w lintStructTagRule) checkMapstructureTag(options []string) (string, bool) {
+	for _, opt := range options {
+		switch opt {
+		case "omitempty", "reminder", "squash":
+		default:
+			if w.isUserDefined(keyMapstructure, opt) {
+				continue
+			}
+			return fmt.Sprintf("unknown option '%s' in Mapstructure tag", opt), false
 		}
 	}
 

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -18,6 +18,7 @@ func TestStructTagWithUserOptions(t *testing.T) {
 			"bson,gnu",
 			"url,myURLOption",
 			"datastore,myDatastoreOption",
+			"mapstructure,myMapstructureOption",
 		},
 	})
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -141,3 +141,8 @@ type Fields struct {
 	Field      string `datastore:",noindex,flatten,omitempty"`
 	OtherField string `datastore:",unknownOption"` // MATCH /unknown option 'unknownOption' in Datastore tag/
 }
+
+type MapStruct struct {
+	Field1     string `mapstructure:",squash,reminder,omitempty"`
+	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option 'unknownOption' in Mapstructure tag/
+}

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -24,3 +24,8 @@ type Fields struct {
 	Field      string `datastore:",noindex,flatten,omitempty,myDatastoreOption"`
 	OtherField string `datastore:",unknownOption"` // MATCH /unknown option 'unknownOption' in Datastore tag/
 }
+
+type MapStruct struct {
+	Field1     string `mapstructure:",squash,reminder,omitempty,myMapstructureOption"`
+	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option 'unknownOption' in Mapstructure tag/
+}


### PR DESCRIPTION
This PR extends struct-tag rule to check mapstructure tags as defined at https://pkg.go.dev/github.com/mitchellh/mapstructure (cf https://go.dev/wiki/Well-known-struct-tags#list-of-well-known-struct-tags)