### PR TITLE
feature: add suport of validate struct tags in struct-tag rule

### DIFF
--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -414,12 +414,12 @@ func (w lintStructTagRule) checkValidateTag(options []string) (string, bool) {
 		switch opt {
 		case "keys":
 			if previousOption != "dive" {
-				return "option 'keys' must follow a 'dive' option in Validate tag", false
+				return "option 'keys' must follow a 'dive' option in validate tag", false
 			}
 			seenKeysOption = true
 		case "endkeys":
 			if !seenKeysOption {
-				return "option 'endkeys' without a previous 'keys' option in Validate tag", false
+				return "option 'endkeys' without a previous 'keys' option in validate tag", false
 			}
 			seenKeysOption = false
 		default:
@@ -445,16 +445,16 @@ func (w lintStructTagRule) checkValidateOptionsAlternatives(alternatives []strin
 			if ok || w.isUserDefined(keyValidate, badOpt) {
 				continue
 			}
-			return fmt.Sprintf("unknown option '%s' in Validate tag", badOpt), false
+			return fmt.Sprintf("unknown option '%s' in validate tag", badOpt), false
 		case 2:
 			lhs := parts[0]
 			_, ok := validateLhs[lhs]
 			if ok || w.isUserDefined(keyValidate, lhs) {
 				continue
 			}
-			return fmt.Sprintf("unknown option '%s' in Validate tag", lhs), false
+			return fmt.Sprintf("unknown option '%s' in validate tag", lhs), false
 		default:
-			return fmt.Sprintf("malformed options '%s' in Validate tag, not expected more than one '='", alternative), false
+			return fmt.Sprintf("malformed options '%s' in validate tag, not expected more than one '='", alternative), false
 		}
 	}
 	return "", true

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -448,7 +448,7 @@ func (w lintStructTagRule) checkValidateOptionsAlternatives(alternatives []strin
 			return fmt.Sprintf("unknown option '%s' in validate tag", badOpt), false
 		case 2:
 			lhs := parts[0]
-			_, ok := validateLhs[lhs]
+			_, ok := validateLHS[lhs]
 			if ok || w.isUserDefined(keyValidate, lhs) {
 				continue
 			}
@@ -669,7 +669,7 @@ var validateSingleOptions = map[string]struct{}{
 	"uuid5":                     {},
 }
 
-var validateLhs = map[string]struct{}{
+var validateLHS = map[string]struct{}{
 	"contains":             {},
 	"containsany":          {},
 	"containsfield":        {},

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -19,6 +19,7 @@ func TestStructTagWithUserOptions(t *testing.T) {
 			"url,myURLOption",
 			"datastore,myDatastoreOption",
 			"mapstructure,myMapstructureOption",
+			"validate,displayName",
 		},
 	})
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -146,3 +146,15 @@ type MapStruct struct {
 	Field1     string `mapstructure:",squash,reminder,omitempty"`
 	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option 'unknownOption' in Mapstructure tag/
 }
+
+type ValidateUser struct {
+	Username    string `validate:"required,min=3,max=32"`
+	Email       string `validate:"required,email"`
+	Password    string `validate:"required,min=8,max=32"`
+	Biography   string `validate:"min=0,max=1000"`
+	DisplayName string `validate:"displayName,min=3,max=32"` // MATCH /unknown option 'displayName' in Validate tag/
+	Complex     string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,required"`
+	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option 'keys' must follow a 'dive' option in Validate tag/
+	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option 'endkeys' without a previous 'keys' option in Validate tag/
+	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option 'endkeys' without a previous 'keys' option in Validate tag/
+}

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -152,9 +152,9 @@ type ValidateUser struct {
 	Email       string `validate:"required,email"`
 	Password    string `validate:"required,min=8,max=32"`
 	Biography   string `validate:"min=0,max=1000"`
-	DisplayName string `validate:"displayName,min=3,max=32"` // MATCH /unknown option 'displayName' in Validate tag/
+	DisplayName string `validate:"displayName,min=3,max=32"` // MATCH /unknown option 'displayName' in validate tag/
 	Complex     string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,required"`
-	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option 'keys' must follow a 'dive' option in Validate tag/
-	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option 'endkeys' without a previous 'keys' option in Validate tag/
-	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option 'endkeys' without a previous 'keys' option in Validate tag/
+	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option 'keys' must follow a 'dive' option in validate tag/
+	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option 'endkeys' without a previous 'keys' option in validate tag/
+	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option 'endkeys' without a previous 'keys' option in validate tag/
 }

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -29,3 +29,15 @@ type MapStruct struct {
 	Field1     string `mapstructure:",squash,reminder,omitempty,myMapstructureOption"`
 	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option 'unknownOption' in Mapstructure tag/
 }
+
+type ValidateUser struct {
+	Username    string `validate:"required,min=3,max=32"`
+	Email       string `validate:"required,email"`
+	Password    string `validate:"required,min=8,max=32"`
+	Biography   string `validate:"min=0,max=1000"`
+	DisplayName string `validate:"displayName,min=3,max=32"`
+	Complex     string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,required"`
+	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option 'keys' must follow a 'dive' option in Validate tag/
+	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option 'endkeys' without a previous 'keys' option in Validate tag/
+	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option 'endkeys' without a previous 'keys' option in Validate tag/
+}

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -37,7 +37,7 @@ type ValidateUser struct {
 	Biography   string `validate:"min=0,max=1000"`
 	DisplayName string `validate:"displayName,min=3,max=32"`
 	Complex     string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,required"`
-	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option 'keys' must follow a 'dive' option in Validate tag/
-	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option 'endkeys' without a previous 'keys' option in Validate tag/
-	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option 'endkeys' without a previous 'keys' option in Validate tag/
+	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option 'keys' must follow a 'dive' option in validate tag/
+	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option 'endkeys' without a previous 'keys' option in validate tag/
+	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option 'endkeys' without a previous 'keys' option in validate tag/
 }


### PR DESCRIPTION
This PR extends struct-tag rule to check validate tags as defined at https://github.com/go-playground/validator (cf https://go.dev/wiki/Well-known-struct-tags#list-of-well-known-struct-tags)