### PR TITLE
fix: 'package-comments' false positive for CRLF sources

### DIFF
--- a/lint/file.go
+++ b/lint/file.go
@@ -29,6 +29,11 @@ func (f *File) Content() []byte {
 	return f.content
 }
 
+// IsCRLFTerminated returns if the file is terminated with CRLF.
+func (f *File) IsCRLFTerminated() bool {
+	return bytes.HasSuffix(f.content, []byte("\r\n"))
+}
+
 // NewFile creates a new file
 func NewFile(name string, content []byte, pkg *Package) (*File, error) {
 	f, err := parser.ParseFile(pkg.fset, name, content, parser.ParseComments)

--- a/test/package_comments_test.go
+++ b/test/package_comments_test.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
+)
+
+func TestPackageCommentsIssue607NotMatch(t *testing.T) {
+	testRule(t, "package_comments/issue607_not_match", &rule.PackageCommentsRule{}, &lint.RuleConfig{})
+}
+
+func TestPackageCommentsIssue607Match(t *testing.T) {
+	testRule(t, "package_comments/issue607_match", &rule.PackageCommentsRule{}, &lint.RuleConfig{})
+}

--- a/testdata/package_comments/.gitattributes
+++ b/testdata/package_comments/.gitattributes
@@ -1,0 +1,2 @@
+# Files in these directory must have Windows line endings
+*.* text eol=crlf

--- a/testdata/package_comments/issue607_match.go
+++ b/testdata/package_comments/issue607_match.go
@@ -1,0 +1,8 @@
+/*
+Package fixtures has a multi-line comment.
+Its line endings have a carriage return.
+*/
+
+package fixtures
+
+// MATCH:5 /package comment is detached; there should be no blank lines between it and the package statement/

--- a/testdata/package_comments/issue607_not_match.go
+++ b/testdata/package_comments/issue607_not_match.go
@@ -1,0 +1,5 @@
+/*
+Package fixtures has a multi-line comment.
+Its line endings have a carriage return.
+*/
+package fixtures


### PR DESCRIPTION
Fixes #607 