### PR TITLE
fix: error-strings custom funcs overwrites defaults

### DIFF
--- a/rule/error_strings.go
+++ b/rule/error_strings.go
@@ -37,13 +37,20 @@ func (r *ErrorStringsRule) Configure(arguments lint.Arguments) error {
 
 	var invalidCustomFunctions []string
 	for _, argument := range arguments {
-		if functionName, ok := argument.(string); ok {
-			fields := strings.Split(strings.TrimSpace(functionName), ".")
-			if len(fields) != 2 || len(fields[0]) == 0 || len(fields[1]) == 0 {
-				invalidCustomFunctions = append(invalidCustomFunctions, functionName)
-				continue
-			}
-			r.errorFunctions[fields[0]] = map[string]struct{}{fields[1]: {}}
+		pkgFunction, ok := argument.(string)
+		if !ok {
+			continue
+		}
+		pkg, function, ok := strings.Cut(strings.TrimSpace(pkgFunction), ".")
+		if !ok || pkg == "" || function == "" {
+			invalidCustomFunctions = append(invalidCustomFunctions, pkgFunction)
+			continue
+		}
+		functions, ok := r.errorFunctions[pkg]
+		if !ok {
+			r.errorFunctions[pkg] = map[string]struct{}{function: {}}
+		} else {
+			functions[function] = struct{}{}
 		}
 	}
 	if len(invalidCustomFunctions) != 0 {

--- a/rule/error_strings.go
+++ b/rule/error_strings.go
@@ -47,7 +47,7 @@ func (r *ErrorStringsRule) Configure(arguments lint.Arguments) error {
 			continue
 		}
 		if _, ok := r.errorFunctions[pkg]; !ok {
-			r.errorFunctions[pkg] = make(map[string]struct{})
+			r.errorFunctions[pkg] = map[string]struct{}{}
 		}
 		r.errorFunctions[pkg][function] = struct{}{}
 	}

--- a/rule/error_strings.go
+++ b/rule/error_strings.go
@@ -46,12 +46,10 @@ func (r *ErrorStringsRule) Configure(arguments lint.Arguments) error {
 			invalidCustomFunctions = append(invalidCustomFunctions, pkgFunction)
 			continue
 		}
-		functions, ok := r.errorFunctions[pkg]
-		if !ok {
-			r.errorFunctions[pkg] = map[string]struct{}{function: {}}
-		} else {
-			functions[function] = struct{}{}
+		if _, ok := r.errorFunctions[pkg]; !ok {
+			r.errorFunctions[pkg] = make(map[string]struct{})
 		}
+		r.errorFunctions[pkg][function] = struct{}{}
 	}
 	if len(invalidCustomFunctions) != 0 {
 		return fmt.Errorf("found invalid custom function: %s", strings.Join(invalidCustomFunctions, ","))

--- a/rule/error_strings_test.go
+++ b/rule/error_strings_test.go
@@ -1,0 +1,68 @@
+package rule_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
+)
+
+func TestErrorStringsRule_Configure(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments lint.Arguments
+		wantErr   error
+	}{
+		{
+			name:      "Default configuration",
+			arguments: lint.Arguments{},
+		},
+		{
+			name:      "Valid custom functions",
+			arguments: lint.Arguments{"mypkg.MyErrorFunc", "errors.New"},
+		},
+		{
+			name:      "Argument not a string",
+			arguments: lint.Arguments{123},
+		},
+		{
+			name:      "Invalid package",
+			arguments: lint.Arguments{".MyErrorFunc"},
+			wantErr:   errors.New("found invalid custom function: .MyErrorFunc"),
+		},
+		{
+			name:      "Invalid function",
+			arguments: lint.Arguments{"errors."},
+			wantErr:   errors.New("found invalid custom function: errors."),
+		},
+		{
+			name:      "Invalid custom function",
+			arguments: lint.Arguments{"invalidFunction"},
+			wantErr:   errors.New("found invalid custom function: invalidFunction"),
+		},
+		{
+			name:      "Mixed valid and invalid custom functions",
+			arguments: lint.Arguments{"mypkg.MyErrorFunc", "invalidFunction", "invalidFunction2"},
+			wantErr:   errors.New("found invalid custom function: invalidFunction,invalidFunction2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r rule.ErrorStringsRule
+
+			err := r.Configure(tt.arguments)
+
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("Configure() unexpected non-nil error %q", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr.Error() {
+				t.Errorf("Configure() unexpected error: got %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/test/error_strings_custom_functions_test.go
+++ b/test/error_strings_custom_functions_test.go
@@ -15,7 +15,7 @@ func TestErrorStringsWithCustomFunctions(t *testing.T) {
 }
 
 func TestErrorStringsIssue1243(t *testing.T) {
-	args := []any{"errors.New", "errors.Wrap"}
+	args := []any{"errors.Wrap"}
 	testRule(t, "error_strings_issue_1243", &rule.ErrorStringsRule{}, &lint.RuleConfig{
 		Arguments: args,
 	})

--- a/test/error_strings_custom_functions_test.go
+++ b/test/error_strings_custom_functions_test.go
@@ -13,3 +13,10 @@ func TestErrorStringsWithCustomFunctions(t *testing.T) {
 		Arguments: args,
 	})
 }
+
+func TestErrorStringsIssue1243(t *testing.T) {
+	args := []any{"errors.New", "errors.Wrap"}
+	testRule(t, "error_strings_issue_1243", &rule.ErrorStringsRule{}, &lint.RuleConfig{
+		Arguments: args,
+	})
+}

--- a/testdata/error_strings_issue_1243.go
+++ b/testdata/error_strings_issue_1243.go
@@ -1,0 +1,11 @@
+package fixtures
+
+import (
+	"errors"
+	"fmt"
+)
+
+func issue1243() {
+	err := errors.New("An error occurred!") // MATCH /error strings should not be capitalized or end with punctuation or a newline/
+	fmt.Println(err)
+}


### PR DESCRIPTION
The PR fixes a bug in the `error-strings` rule where configuring custom functions overwrites default functions.

When configuring custom functions to `["errors.Wrap"]`, the internal map `r.errorFunctions` would be:

```go
	r.errorFunctions = map[string]map[string]struct{}{
		"fmt": {
			"Errorf": {},
		},
		"errors": {
			"Wrap": {},
		},
	}
```

but it should be:

```go
	r.errorFunctions = map[string]map[string]struct{}{
		"fmt": {
			"Errorf": {},
		},
		"errors": {
			"Errorf":       {},
			"WithMessage":  {},
			"Wrap":         {},
			"New":          {},
			"WithMessagef": {},
			"Wrapf":        {},
		},
	}
```

Fixes #1243