### PR TITLE
refactor: return an error instead of panicking

### DIFF
--- a/rule/unused_param.go
+++ b/rule/unused_param.go
@@ -38,7 +38,7 @@ func (r *UnusedParamRule) Configure(args lint.Arguments) error {
 	// Arguments = [{allowRegex="^_"}]
 	allowRegexStr, ok := allowRegexParam.(string)
 	if !ok {
-		panic(fmt.Errorf("error configuring %s rule: allowRegex is not string but [%T]", r.Name(), allowRegexParam))
+		return fmt.Errorf("error configuring %s rule: allowRegex is not string but [%T]", r.Name(), allowRegexParam)
 	}
 	var err error
 	r.allowRegex, err = regexp.Compile(allowRegexStr)

--- a/rule/unused_receiver.go
+++ b/rule/unused_receiver.go
@@ -36,7 +36,7 @@ func (r *UnusedReceiverRule) Configure(args lint.Arguments) error {
 	// Arguments = [{allowRegex="^_"}]
 	allowRegexStr, ok := allowRegexParam.(string)
 	if !ok {
-		panic(fmt.Errorf("error configuring [unused-receiver] rule: allowRegex is not string but [%T]", allowRegexParam))
+		return fmt.Errorf("error configuring [unused-receiver] rule: allowRegex is not string but [%T]", allowRegexParam)
 	}
 	var err error
 	r.allowRegex, err = regexp.Compile(allowRegexStr)


### PR DESCRIPTION
The PR changes the `Configure` function for both `UnusedReceiverRule` and `UnusedParamRule` to return an error instead of panicking. This is a leftover from #1185.
