### PR TITLE
feature(rule): add rule time-after-leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ List of all available rules. The rules ported from `golint` are left unchanged a
 | [`redundant-build-tag`](./RULES_DESCRIPTIONS.md#redundant-build-tag) | n/a   | Warns about redundant `// +build` comment lines |   no    |  no   |
 | [`use-errors-new`](./RULES_DESCRIPTIONS.md#use-errors-new) | n/a   | Spots calls to `fmt.Errorf` that can be replaced by `errors.New` |   no    |  no   |
 | [`redundant-test-main-exit`](./RULES_DESCRIPTIONS.md#redundant-test-main-exit) |  n/a   | Suggests removing `Exit` call in `TestMain` function for test files |    no    |  no   |
+| [`time-after-leak`](./RULES_DESCRIPTIONS.md#time-after-leak) |  n/a   | Suggests replacing `time.After` with `time.NewTimer` to prevent goroutine leak |    no    |  no   |
 
 ## Configurable rules
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -71,6 +71,7 @@ List of all available rules.
   - [string-of-int](#string-of-int)
   - [struct-tag](#struct-tag)
   - [superfluous-else](#superfluous-else)
+  - [time-after-leak](#time-after-leak)
   - [time-equal](#time-equal)
   - [time-naming](#time-naming)
   - [unchecked-type-assertion](#unchecked-type-assertion)
@@ -892,6 +893,11 @@ Example:
 [rule.superfluous-else]
   arguments = ["preserveScope"]
 ```
+## time-after-leak
+
+_Description_: This rule warns on temporary goroutine leak when using `time.After` in select statements. In Go versions before 1.23, [the garbage collector does not recover the underlying thread until the timer fires](https://pkg.go.dev/time#After).
+
+_Configuration_: N/A
 
 ## time-equal
 

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ var defaultRules = []lint.Rule{
 	&rule.UnusedParamRule{},
 	&rule.UnreachableCodeRule{},
 	&rule.RedefinesBuiltinIDRule{},
+	&rule.TimeAfterLeak{},
 }
 
 var allRules = append([]lint.Rule{

--- a/lint/package.go
+++ b/lint/package.go
@@ -35,10 +35,11 @@ var (
 	trueValue  = 1
 	falseValue = 2
 
-	go115 = goversion.Must(goversion.NewVersion("1.15"))
-	go121 = goversion.Must(goversion.NewVersion("1.21"))
-	go122 = goversion.Must(goversion.NewVersion("1.22"))
-	go124 = goversion.Must(goversion.NewVersion("1.24"))
+	Go115 = goversion.Must(goversion.NewVersion("1.15"))
+	Go121 = goversion.Must(goversion.NewVersion("1.21"))
+	Go122 = goversion.Must(goversion.NewVersion("1.22"))
+	Go123 = goversion.Must(goversion.NewVersion("1.23"))
+	Go124 = goversion.Must(goversion.NewVersion("1.24"))
 )
 
 // Files return package's files.
@@ -196,24 +197,9 @@ func (p *Package) lint(rules []Rule, config Config, failures chan Failure) error
 	return eg.Wait()
 }
 
-// IsAtLeastGo115 returns true if the Go version for this package is 1.15 or higher, false otherwise
-func (p *Package) IsAtLeastGo115() bool {
-	return p.goVersion.GreaterThanOrEqual(go115)
-}
-
-// IsAtLeastGo121 returns true if the Go version for this package is 1.21 or higher, false otherwise
-func (p *Package) IsAtLeastGo121() bool {
-	return p.goVersion.GreaterThanOrEqual(go121)
-}
-
-// IsAtLeastGo122 returns true if the Go version for this package is 1.22 or higher, false otherwise
-func (p *Package) IsAtLeastGo122() bool {
-	return p.goVersion.GreaterThanOrEqual(go122)
-}
-
-// IsAtLeastGo124 returns true if the Go version for this package is 1.24 or higher, false otherwise
-func (p *Package) IsAtLeastGo124() bool {
-	return p.goVersion.GreaterThanOrEqual(go124)
+// IsAtLeastGoVersion returns true if the Go version for this package is v or higher, false otherwise
+func (p *Package) IsAtLeastGoVersion(v *goversion.Version) bool {
+	return p.goVersion.GreaterThanOrEqual(v)
 }
 
 func getSortableMethodFlagForFunction(fn *ast.FuncDecl) sortableMethodsFlags {

--- a/lint/package.go
+++ b/lint/package.go
@@ -35,10 +35,15 @@ var (
 	trueValue  = 1
 	falseValue = 2
 
+	// Constant representing the Go version 1.15
 	Go115 = goversion.Must(goversion.NewVersion("1.15"))
+	// Constant representing the Go version 1.21
 	Go121 = goversion.Must(goversion.NewVersion("1.21"))
+	// Constant representing the Go version 1.22
 	Go122 = goversion.Must(goversion.NewVersion("1.22"))
+	// Constant representing the Go version 1.23
 	Go123 = goversion.Must(goversion.NewVersion("1.23"))
+	// Constant representing the Go version 1.24
 	Go124 = goversion.Must(goversion.NewVersion("1.24"))
 )
 

--- a/lint/package.go
+++ b/lint/package.go
@@ -35,15 +35,15 @@ var (
 	trueValue  = 1
 	falseValue = 2
 
-	// Constant representing the Go version 1.15
+	// Go115 is a constant representing the Go version 1.15
 	Go115 = goversion.Must(goversion.NewVersion("1.15"))
-	// Constant representing the Go version 1.21
+	// Go121 is a constant representing the Go version 1.21
 	Go121 = goversion.Must(goversion.NewVersion("1.21"))
-	// Constant representing the Go version 1.22
+	// Go122 is a constant representing the Go version 1.22
 	Go122 = goversion.Must(goversion.NewVersion("1.22"))
-	// Constant representing the Go version 1.23
+	// Go123 is a constant representing the Go version 1.23
 	Go123 = goversion.Must(goversion.NewVersion("1.23"))
-	// Constant representing the Go version 1.24
+	// Go124 is a constant representing the Go version 1.24
 	Go124 = goversion.Must(goversion.NewVersion("1.24"))
 )
 

--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -12,7 +12,7 @@ type DataRaceRule struct{}
 
 // Apply applies the rule to given file.
 func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
-	isGo122 := file.Pkg.IsAtLeastGo122()
+	isGo122 := file.Pkg.IsAtLeastGoVersion(lint.Go122)
 	var failures []lint.Failure
 	for _, decl := range file.AST.Decls {
 		funcDecl, ok := decl.(*ast.FuncDecl)

--- a/rule/range_val_address.go
+++ b/rule/range_val_address.go
@@ -16,7 +16,7 @@ type RangeValAddress struct{}
 func (*RangeValAddress) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	if file.Pkg.IsAtLeastGo122() {
+	if file.Pkg.IsAtLeastGoVersion(lint.Go122) {
 		return failures
 	}
 

--- a/rule/range_val_in_closure.go
+++ b/rule/range_val_in_closure.go
@@ -14,7 +14,7 @@ type RangeValInClosureRule struct{}
 func (*RangeValInClosureRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	if file.Pkg.IsAtLeastGo122() {
+	if file.Pkg.IsAtLeastGoVersion(lint.Go122) {
 		return failures
 	}
 

--- a/rule/redefines_builtin_id.go
+++ b/rule/redefines_builtin_id.go
@@ -78,7 +78,7 @@ func (*RedefinesBuiltinIDRule) Apply(file *lint.File, _ lint.Arguments) []lint.F
 	astFile := file.AST
 
 	builtFuncs := maps.Clone(builtFunctions)
-	if file.Pkg.IsAtLeastGo121() {
+	if file.Pkg.IsAtLeastGoVersion(lint.Go121) {
 		maps.Copy(builtFuncs, builtFunctionsAfterGo121)
 	}
 	w := &lintRedefinesBuiltinID{

--- a/rule/redundant_test_main_exit.go
+++ b/rule/redundant_test_main_exit.go
@@ -14,7 +14,7 @@ type RedundantTestMainExitRule struct{}
 func (*RedundantTestMainExitRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	if !file.IsTest() || !file.Pkg.IsAtLeastGo115() {
+	if !file.IsTest() || !file.Pkg.IsAtLeastGoVersion(lint.Go115) {
 		// skip analysis for non-test files or for Go versions before 1.15
 		return failures
 	}

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -56,7 +56,7 @@ func (r *StructTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure 
 	w := lintStructTagRule{
 		onFailure:      onFailure,
 		userDefined:    r.userDefined,
-		isAtLeastGo124: file.Pkg.IsAtLeastGo124(),
+		isAtLeastGo124: file.Pkg.IsAtLeastGoVersion(lint.Go124),
 	}
 
 	ast.Walk(w, file.AST)

--- a/rule/time_after_leak.go
+++ b/rule/time_after_leak.go
@@ -1,0 +1,99 @@
+package rule
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// TimeAfterLeak spots potential goroutine leaks caused by Time.After()
+type TimeAfterLeak struct{}
+
+// Apply applies the rule to given file.
+func (r *TimeAfterLeak) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	if file.Pkg.IsAtLeastGoVersion(lint.Go123) {
+		return nil
+	}
+
+	var failures []lint.Failure
+
+	onFailure := func(failure lint.Failure) {
+		failures = append(failures, failure)
+	}
+
+	w := &lintTimeAfterLeak{
+		onFailure: onFailure,
+	}
+
+	ast.Walk(w, file.AST)
+
+	return failures
+}
+
+// Name returns the rule name.
+func (*TimeAfterLeak) Name() string {
+	return "time-after-leak"
+}
+
+type lintTimeAfterLeak struct {
+	onFailure func(lint.Failure)
+}
+
+func (w *lintTimeAfterLeak) Visit(node ast.Node) ast.Visitor {
+	selectStmt, ok := node.(*ast.SelectStmt)
+	if !ok {
+		return w
+	}
+
+	cases := selectStmt.Body.List
+	if len(cases) <= 1 {
+		return w // even if the single case is a read from time.After there is nothing to warn about
+	}
+
+	for _, c := range cases {
+		commClause, ok := c.(*ast.CommClause)
+		if !ok { // we check even if it is not possible to have case that is not a CommClause
+			continue
+		}
+
+		comm := commClause.Comm
+		if comm == nil {
+			continue // is the default select case
+		}
+
+		// case something
+
+		exprStmt, ok := comm.(*ast.ExprStmt)
+		if !ok {
+			continue // is not an expression statement (it's, for example, an assignment)
+		}
+
+		expr, ok := exprStmt.X.(*ast.UnaryExpr)
+		isChannelRead := ok && expr.Op == token.ARROW
+		if !isChannelRead {
+			continue // is not a channel read expression
+		}
+
+		// case <- expr
+
+		call, ok := expr.X.(*ast.CallExpr)
+		if !ok {
+			continue // is not a read from a channel returned by a function call
+		}
+
+		// case <- f()
+
+		if isPkgDot(call.Fun, "time", "After") {
+			// case <- time.After(...)
+			w.onFailure(lint.Failure{
+				Confidence: 0.8,
+				Node:       call.Fun,
+				Category:   lint.FailureCategoryBadPractice,
+				Failure:    "the underlying goroutine of time.After() is not garbage-collected until timer expiration, prefer NewTimer+Timer.Stop",
+			})
+		}
+	}
+
+	return w
+}

--- a/test/time_after_leak_test.go
+++ b/test/time_after_leak_test.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
+)
+
+func TestTimeAfterLeak(t *testing.T) {
+	testRule(t, "time_after_leak", &rule.TimeAfterLeak{}, &lint.RuleConfig{})
+}
+
+func TestTimeAfterLeakAfterGo1_23(t *testing.T) {
+	testRule(t, "go1.23/time_after_leak", &rule.TimeAfterLeak{}, &lint.RuleConfig{})
+}

--- a/testdata/go1.23/go.mod
+++ b/testdata/go1.23/go.mod
@@ -1,0 +1,3 @@
+module github.com/mgechev/revive/testdata
+
+go 1.23

--- a/testdata/go1.23/time_after_leak.go
+++ b/testdata/go1.23/time_after_leak.go
@@ -1,0 +1,17 @@
+package fixtures
+
+import (
+	"fmt"
+	"time"
+)
+
+var c chan int
+
+func timeAfterLeak() {
+	select {
+	case m := <-c:
+		handle(m)
+	case <-time.After(10 * time.Second): // shall not match /the underlying goroutine of time.After() is not garbage-collected until timer expiration, prefer NewTimer+Timer.Stop/
+		fmt.Println("timed out")
+	}
+}

--- a/testdata/time_after_leak.go
+++ b/testdata/time_after_leak.go
@@ -1,0 +1,17 @@
+package fixtures
+
+import (
+	"fmt"
+	"time"
+)
+
+var c chan int
+
+func timeAfterLeak() {
+	select {
+	case m := <-c:
+		handle(m)
+	case <-time.After(10 * time.Second): // MATCH /the underlying goroutine of time.After() is not garbage-collected until timer expiration, prefer NewTimer+Timer.Stop/
+		fmt.Println("timed out")
+	}
+}


### PR DESCRIPTION
This PR adds a new rule: `time-after-leak`
The rule spots the [known problem](https://arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/) of temporary leak of goroutines underlying `time.After()`

As described by the [documentation of `time.After()`](https://pkg.go.dev/time#After), version 1.23 of Go fixed the problem thus the rule skips files of packages with a Go version equal or higher than 1.23. 

The PR also introduces `lint.IsAtLeastGoVersion` to factor-out the common code of `lint.IsAtLeastGo1*`
