### PR TITLE
refactor: replace IsAtLeastGo1* functions by IsAtLeastGoVersion

### DIFF
--- a/lint/package.go
+++ b/lint/package.go
@@ -35,10 +35,14 @@ var (
 	trueValue  = 1
 	falseValue = 2
 
-	go115 = goversion.Must(goversion.NewVersion("1.15"))
-	go121 = goversion.Must(goversion.NewVersion("1.21"))
-	go122 = goversion.Must(goversion.NewVersion("1.22"))
-	go124 = goversion.Must(goversion.NewVersion("1.24"))
+	// Go115 is a constant representing the Go version 1.15
+	Go115 = goversion.Must(goversion.NewVersion("1.15"))
+	// Go121 is a constant representing the Go version 1.21
+	Go121 = goversion.Must(goversion.NewVersion("1.21"))
+	// Go122 is a constant representing the Go version 1.22
+	Go122 = goversion.Must(goversion.NewVersion("1.22"))
+	// Go124 is a constant representing the Go version 1.24
+	Go124 = goversion.Must(goversion.NewVersion("1.24"))
 )
 
 // Files return package's files.
@@ -196,24 +200,9 @@ func (p *Package) lint(rules []Rule, config Config, failures chan Failure) error
 	return eg.Wait()
 }
 
-// IsAtLeastGo115 returns true if the Go version for this package is 1.15 or higher, false otherwise
-func (p *Package) IsAtLeastGo115() bool {
-	return p.goVersion.GreaterThanOrEqual(go115)
-}
-
-// IsAtLeastGo121 returns true if the Go version for this package is 1.21 or higher, false otherwise
-func (p *Package) IsAtLeastGo121() bool {
-	return p.goVersion.GreaterThanOrEqual(go121)
-}
-
-// IsAtLeastGo122 returns true if the Go version for this package is 1.22 or higher, false otherwise
-func (p *Package) IsAtLeastGo122() bool {
-	return p.goVersion.GreaterThanOrEqual(go122)
-}
-
-// IsAtLeastGo124 returns true if the Go version for this package is 1.24 or higher, false otherwise
-func (p *Package) IsAtLeastGo124() bool {
-	return p.goVersion.GreaterThanOrEqual(go124)
+// IsAtLeastGoVersion returns true if the Go version for this package is v or higher, false otherwise
+func (p *Package) IsAtLeastGoVersion(v *goversion.Version) bool {
+	return p.goVersion.GreaterThanOrEqual(v)
 }
 
 func getSortableMethodFlagForFunction(fn *ast.FuncDecl) sortableMethodsFlags {

--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -12,7 +12,7 @@ type DataRaceRule struct{}
 
 // Apply applies the rule to given file.
 func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
-	isGo122 := file.Pkg.IsAtLeastGo122()
+	isGo122 := file.Pkg.IsAtLeastGoVersion(lint.Go122)
 	var failures []lint.Failure
 	for _, decl := range file.AST.Decls {
 		funcDecl, ok := decl.(*ast.FuncDecl)

--- a/rule/range_val_address.go
+++ b/rule/range_val_address.go
@@ -16,7 +16,7 @@ type RangeValAddress struct{}
 func (*RangeValAddress) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	if file.Pkg.IsAtLeastGo122() {
+	if file.Pkg.IsAtLeastGoVersion(lint.Go122) {
 		return failures
 	}
 

--- a/rule/range_val_in_closure.go
+++ b/rule/range_val_in_closure.go
@@ -14,7 +14,7 @@ type RangeValInClosureRule struct{}
 func (*RangeValInClosureRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	if file.Pkg.IsAtLeastGo122() {
+	if file.Pkg.IsAtLeastGoVersion(lint.Go122) {
 		return failures
 	}
 

--- a/rule/redefines_builtin_id.go
+++ b/rule/redefines_builtin_id.go
@@ -78,7 +78,7 @@ func (*RedefinesBuiltinIDRule) Apply(file *lint.File, _ lint.Arguments) []lint.F
 	astFile := file.AST
 
 	builtFuncs := maps.Clone(builtFunctions)
-	if file.Pkg.IsAtLeastGo121() {
+	if file.Pkg.IsAtLeastGoVersion(lint.Go121) {
 		maps.Copy(builtFuncs, builtFunctionsAfterGo121)
 	}
 	w := &lintRedefinesBuiltinID{

--- a/rule/redundant_test_main_exit.go
+++ b/rule/redundant_test_main_exit.go
@@ -14,7 +14,7 @@ type RedundantTestMainExitRule struct{}
 func (*RedundantTestMainExitRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
-	if !file.IsTest() || !file.Pkg.IsAtLeastGo115() {
+	if !file.IsTest() || !file.Pkg.IsAtLeastGoVersion(lint.Go115) {
 		// skip analysis for non-test files or for Go versions before 1.15
 		return failures
 	}

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -56,7 +56,7 @@ func (r *StructTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure 
 	w := lintStructTagRule{
 		onFailure:      onFailure,
 		userDefined:    r.userDefined,
-		isAtLeastGo124: file.Pkg.IsAtLeastGo124(),
+		isAtLeastGo124: file.Pkg.IsAtLeastGoVersion(lint.Go124),
 	}
 
 	ast.Walk(w, file.AST)


### PR DESCRIPTION
The PR introduces `lint.IsAtLeastGoVersion` to factor-out the common code of lint.IsAtLeastGo1*
