### PR TITLE
change: replace log with log/slog for logging

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,6 +19,16 @@ make build
 
 The command will produce the `revive` binary in the root of the project.
 
+## Debug
+
+To enable debug logging, set the `DEBUG` environment variable:
+
+```sh
+DEBUG=1 go run main.go
+```
+
+This will output debug information to `stderr` and to the log file `revive.log` created in the current working directory.
+
 ## Development of rules
 
 If you want to develop a new rule, follow as an example the already existing rules in the [rule package](https://github.com/mgechev/revive/tree/master/rule).

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -3,40 +3,35 @@ package logging
 
 import (
 	"io"
-	"log"
+	"log/slog"
 	"os"
 )
 
-var logger *log.Logger
+const logFile = "revive.log"
+
+var logger *slog.Logger
 
 // GetLogger retrieves an instance of an application logger which outputs
 // to a file if the debug flag is enabled
-func GetLogger() (*log.Logger, error) {
+func GetLogger() (*slog.Logger, error) {
 	if logger != nil {
 		return logger, nil
 	}
 
-	var writer io.Writer
-	var err error
-
-	writer = io.Discard // by default, suppress all logging output
-	debugModeEnabled := os.Getenv("DEBUG") == "1"
-	if debugModeEnabled {
-		writer, err = os.Create("revive.log")
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	logger = log.New(writer, "", log.LstdFlags)
-
+	debugModeEnabled := os.Getenv("DEBUG") != ""
 	if !debugModeEnabled {
-		// Clear all flags to skip log output formatting step to increase
-		// performance somewhat if we're not logging anything
-		logger.SetFlags(0)
+		// by default, suppress all logging output
+		return slog.New(slog.NewTextHandler(io.Discard, nil)), nil
 	}
 
-	logger.Println("Logger initialized")
+	fileWriter, err := os.Create(logFile)
+	if err != nil {
+		return nil, err
+	}
+
+	logger = slog.New(slog.NewTextHandler(io.MultiWriter(os.Stderr, fileWriter), nil))
+
+	logger.Info("Logger initialized", "logFile", logFile)
 
 	return logger, nil
 }

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -1,0 +1,60 @@
+package logging_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mgechev/revive/logging"
+)
+
+func TestGetLogger(t *testing.T) {
+	t.Run("no debug", func(t *testing.T) {
+		t.Setenv("DEBUG", "")
+
+		logger, err := logging.GetLogger()
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if logger == nil {
+			t.Fatal("expected logger to be non-nil")
+		}
+		logger.Info("msg") // no output
+	})
+
+	t.Run("debug", func(t *testing.T) {
+		t.Setenv("DEBUG", "1")
+		t.Cleanup(func() { os.Remove("revive.log") })
+
+		logger, err := logging.GetLogger()
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if logger == nil {
+			t.Fatal("expected logger to be non-nil")
+		}
+		if _, err := os.Stat("revive.log"); os.IsNotExist(err) {
+			t.Error("expected revive.log file to be created")
+		}
+	})
+
+	t.Run("reuse logger", func(t *testing.T) {
+		t.Setenv("DEBUG", "1")
+		t.Cleanup(func() { os.Remove("revive.log") })
+
+		logger1, err := logging.GetLogger()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		logger2, err := logging.GetLogger()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if logger1 != logger2 {
+			t.Errorf("expected the same logger instance to be returned: logger1=%+v, logger2=%+v", logger1, logger2)
+		}
+	})
+}

--- a/revivelib/core.go
+++ b/revivelib/core.go
@@ -3,8 +3,10 @@ package revivelib
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/mgechev/dots"
@@ -18,7 +20,7 @@ import (
 type Revive struct {
 	config       *lint.Config
 	lintingRules []lint.Rule
-	logger       *log.Logger
+	logger       *slog.Logger
 	maxOpenFiles int
 }
 
@@ -56,7 +58,7 @@ func New(
 		return nil, fmt.Errorf("initializing revive - getting lint rules: %w", err)
 	}
 
-	logger.Println("Config loaded")
+	logger.Info("Config loaded", "rules", slices.Collect(maps.Keys(conf.Rules)))
 
 	return &Revive{
 		logger:       logger,


### PR DESCRIPTION
This PR replaces usages of `log` to `log/slog` as discussed in #1278. 

Now, the logger outputs to `stderr` and `revive.log` simultaneously if `DEBUG` environment variable is defined and not empty.

For discarding output, I use `slog.NewTextHandler(io.Discard, nil)` because `slog.DiscardHandler` exist only in Go 1.24.