### PR TITLE
feature: Improve error-strings rule to detect acronyms and proper nouns

### DIFF
--- a/rule/error_strings.go
+++ b/rule/error_strings.go
@@ -179,24 +179,28 @@ func lintErrorString(s string) (isClean bool, conf float64) {
 	const basicConfidence = 0.8
 	const capConfidence = basicConfidence - 0.2
 
-	first, firstN := utf8.DecodeRuneInString(s)
 	last, _ := utf8.DecodeLastRuneInString(s)
 	if last == '.' || last == ':' || last == '!' || last == '\n' {
 		return false, basicConfidence
 	}
 
-	if unicode.IsUpper(first) {
-		// People use proper nouns and exported Go identifiers in error strings,
-		// so decrease the confidence of warnings for capitalization.
+	first, firstN := utf8.DecodeRuneInString(s)
+	if !unicode.IsUpper(first) {
+		return true, 0
+	}
 
-		for _, r := range s[firstN:] {
-			if unicode.IsUpper(r) {
-				return true, 0 // accept words with more than 2 capital letters (e.g. GitHub, URLs, )
-			}
+	// People use proper nouns and exported Go identifiers in error strings,
+	// so decrease the confidence of warnings for capitalization.
+	for _, r := range s[firstN:] {
+		if unicode.IsSpace(r) {
+			break
 		}
 
-		// Flag strings starting with something that doesn't look like an initialism.
-		return false, capConfidence
+		if unicode.IsUpper(r) || unicode.IsDigit(r) {
+			return true, 0 // accept words with more than 2 capital letters or digits (e.g. GitHub, URLs, I2000)
+		}
 	}
-	return true, 0
+
+	// Flag strings starting with something that doesn't look like an initialism.
+	return false, capConfidence
 }

--- a/rule/error_strings.go
+++ b/rule/error_strings.go
@@ -178,11 +178,11 @@ func (lintErrorStrings) checkArg(expr *ast.CallExpr, arg int) (s *ast.BasicLit, 
 func lintErrorString(s string) (isClean bool, conf float64) {
 	const basicConfidence = 0.8
 	const capConfidence = basicConfidence - 0.2
-	confidence := basicConfidence
+
 	first, firstN := utf8.DecodeRuneInString(s)
 	last, _ := utf8.DecodeLastRuneInString(s)
 	if last == '.' || last == ':' || last == '!' || last == '\n' {
-		return false, confidence
+		return false, basicConfidence
 	}
 
 	if unicode.IsUpper(first) {

--- a/testdata/golint/error_strings.go
+++ b/testdata/golint/error_strings.go
@@ -18,6 +18,11 @@ func g(x int) error {
 	err = errors.New("This %d is too low", x)     // MATCH /error strings should not be capitalized or end with punctuation or a newline/
 	err = errors.New("GitHub should be ok", x)
 	err = errors.New("OTP should be ok", x)
+	err = errors.New("A JSON should be not ok", x) // MATCH /error strings should not be capitalized or end with punctuation or a newline/
+	err = errors.New("H264 should be ok", x)
+	err = errors.New("I/O should be ok", x)
+	err = errors.New("U.S. should be ok", x)
+	err = errors.New("Wi-Fi should be ok", x)
 
 	// Non-regression test for issue #610
 	d.stack.Push(from)

--- a/testdata/golint/error_strings.go
+++ b/testdata/golint/error_strings.go
@@ -16,6 +16,8 @@ func g(x int) error {
 	err = fmt.Errorf("Newlines are really fun\n") // MATCH /error strings should not be capitalized or end with punctuation or a newline/
 	err = errors.New(`too much stuff.`)           // MATCH /error strings should not be capitalized or end with punctuation or a newline/
 	err = errors.New("This %d is too low", x)     // MATCH /error strings should not be capitalized or end with punctuation or a newline/
+	err = errors.New("GitHub should be ok", x)
+	err = errors.New("OTP should be ok", x)
 
 	// Non-regression test for issue #610
 	d.stack.Push(from)


### PR DESCRIPTION
Closes #1264 by accepting words with more than two capital letters at the beginning of error messages
