### PR TITLE
docs: place `redundant-build-tag` before `redundant-import-alias`

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -63,8 +63,8 @@ List of all available rules.
   - [range-val-in-closure](#range-val-in-closure)
   - [range](#range)
   - [receiver-naming](#receiver-naming)
-  - [redundant-build-tag](#redundant-build-tag)
   - [redefines-builtin-id](#redefines-builtin-id)
+  - [redundant-build-tag](#redundant-build-tag)
   - [redundant-import-alias](#redundant-import-alias)
   - [redundant-test-main-exit](#redundant-test-main-exit)
   - [string-format](#string-format)
@@ -859,17 +859,17 @@ Examples:
     arguments = [{max-length=2}]
 ```
 
-## redundant-build-tag
-
-_Description_: This rule warns about redundant build tag comments `// +build` when `//go:build` is present.
-`gofmt` in Go 1.17+ automatically adds the `//go:build` constraint, making the `// +build` comment unnecessary.
-
-_Configuration_: N/A
-
 ## redefines-builtin-id
 
 _Description_: Constant names like `false`, `true`, `nil`, function names like `append`, `make`, and basic type names like `bool`, and `byte` are not reserved words of the language; therefore the can be redefined.
 Even if possible, redefining these built in names can lead to bugs very difficult to detect.
+
+_Configuration_: N/A
+
+## redundant-build-tag
+
+_Description_: This rule warns about redundant build tag comments `// +build` when `//go:build` is present.
+`gofmt` in Go 1.17+ automatically adds the `//go:build` constraint, making the `// +build` comment unnecessary.
 
 _Configuration_: N/A
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -63,9 +63,9 @@ List of all available rules.
   - [range-val-in-closure](#range-val-in-closure)
   - [range](#range)
   - [receiver-naming](#receiver-naming)
+  - [redundant-build-tag](#redundant-build-tag)
   - [redefines-builtin-id](#redefines-builtin-id)
   - [redundant-import-alias](#redundant-import-alias)
-  - [redundant-build-tag](#redundant-build-tag)
   - [redundant-test-main-exit](#redundant-test-main-exit)
   - [string-format](#string-format)
   - [string-of-int](#string-of-int)
@@ -859,6 +859,13 @@ Examples:
     arguments = [{max-length=2}]
 ```
 
+## redundant-build-tag
+
+_Description_: This rule warns about redundant build tag comments `// +build` when `//go:build` is present.
+`gofmt` in Go 1.17+ automatically adds the `//go:build` constraint, making the `// +build` comment unnecessary.
+
+_Configuration_: N/A
+
 ## redefines-builtin-id
 
 _Description_: Constant names like `false`, `true`, `nil`, function names like `append`, `make`, and basic type names like `bool`, and `byte` are not reserved words of the language; therefore the can be redefined.
@@ -869,13 +876,6 @@ _Configuration_: N/A
 ## redundant-import-alias
 
 _Description_: This rule warns on redundant import aliases. This happens when the alias used on the import statement matches the imported package name.
-
-_Configuration_: N/A
-
-## redundant-build-tag
-
-_Description_: This rule warns about redundant build tag comments `// +build` when `//go:build` is present.
-`gofmt` in Go 1.17+ automatically adds the `//go:build` constraint, making the `// +build` comment unnecessary.
 
 _Configuration_: N/A
 


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the GitHub Action build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

I noticed this while opening https://github.com/golangci/golangci-lint/pull/5692