### PR TITLE
feature: add support for properties tag in struct-tag rule

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -924,7 +924,7 @@ _Configuration_: N/A
 ## struct-tag
 
 _Description_: Struct tags are not checked at compile time.
-This rule spots errors in struct tags of the following types: asn1, bson, datastore, default, json, mapstructure, protobuf, required, toml, url, validate, xml, yaml.
+This rule spots errors in struct tags of the following types: asn1, bson, datastore, default, json, mapstructure, properties, protobuf, required, toml, url, validate, xml, yaml.
 
 _Configuration_: (optional) list of user defined options.
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -532,7 +532,7 @@ func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, name string, options [
 			}
 
 			if !w.typeValueMatch(t, val) {
-				return "field's type and default value's type mismatch", false
+				return "field type and default value type mismatch", false
 			}
 		case "layout":
 			if !found || strings.TrimSpace(val) == "" {

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -207,7 +207,7 @@ func (w lintStructTagRule) checkTaggedField(f *ast.Field) {
 				w.addFailure(f.Tag, msg)
 			}
 		case keyProperties:
-			msg, ok := w.checkPropertiesTag(f.Type, tag.Name, tag.Options)
+			msg, ok := w.checkPropertiesTag(f.Type, tag.Options)
 			if !ok {
 				w.addFailure(f.Tag, msg)
 			}
@@ -512,7 +512,7 @@ func (lintStructTagRule) typeValueMatch(t ast.Expr, val string) bool {
 
 	return typeMatches
 }
-func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, name string, options []string) (string, bool) {
+func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, options []string) (string, bool) {
 	if len(options) == 0 {
 		return "", true
 	}

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -512,7 +512,7 @@ func (lintStructTagRule) typeValueMatch(t ast.Expr, val string) bool {
 
 	return typeMatches
 }
-func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, name string, options []string) (string, bool) {
+func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, options []string) (string, bool) {
 	if len(options) == 0 {
 		return "", true
 	}
@@ -532,15 +532,15 @@ func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, name string, options [
 			}
 
 			if !w.typeValueMatch(t, val) {
-				return "field type and default value type mismatch", false
+				return "field type and default value type mismatch in properties tag", false
 			}
 		case "layout":
 			if !found || strings.TrimSpace(val) == "" {
 				return "malformed layout option for properties tag", false
 			}
 
-			if gofmt(val) != "time.Time" {
-				return "layout option is only applicable to fields of type time.Time", false
+			if gofmt(t) != "time.Time" {
+				return "layout option is only applicable to fields of type time.Time in properties tag", false
 			}
 		default:
 			return fmt.Sprintf("unknown option %q in properties tag", opt), false

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -207,7 +207,7 @@ func (w lintStructTagRule) checkTaggedField(f *ast.Field) {
 				w.addFailure(f.Tag, msg)
 			}
 		case keyProperties:
-			msg, ok := w.checkPropertiesTag(f.Type, tag.Options)
+			msg, ok := w.checkPropertiesTag(f.Type, tag.Name, tag.Options)
 			if !ok {
 				w.addFailure(f.Tag, msg)
 			}
@@ -512,38 +512,42 @@ func (lintStructTagRule) typeValueMatch(t ast.Expr, val string) bool {
 
 	return typeMatches
 }
-
-func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, options []string) (string, bool) {
+func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, name string, options []string) (string, bool) {
 	if len(options) == 0 {
 		return "", true
 	}
 
-	var hasDefault, hasField bool
+	hasDefault := false
 	for _, opt := range options {
-		println(">>>> ", opt)
 		switch {
 		case strings.HasPrefix(opt, "default"):
 			if hasDefault {
-				return "Properties tag accepts only one 'default' option", false
+				return "properties tag accepts only one default option", false
 			}
 			hasDefault = true
 
 			parts := strings.Split(opt, "=")
 			if len(parts) < 2 {
-				return "malformed default for Properties tag", false
+				return "malformed default for properties tag", false
 			}
 
 			if !w.typeValueMatch(t, parts[1]) {
 				return "field's type and default value's type mismatch", false
 			}
+		case strings.HasPrefix(opt, "layout"):
+			parts := strings.Split(opt, "=")
+			if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+				return "malformed layout option for properties tag", false
+			}
+
+			if gofmt(t) != "time.Time" {
+				return "layout option is only applicable to fields of type time.Time", false
+			}
 		default:
-			hasField = true
+			return fmt.Sprintf("unknown option %q in properties tag", opt), false
 		}
 	}
 
-	if !hasDefault && !hasField {
-		return "default is required if field is not set", false
-	}
 	return "", true
 }
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -512,35 +512,34 @@ func (lintStructTagRule) typeValueMatch(t ast.Expr, val string) bool {
 
 	return typeMatches
 }
-func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, options []string) (string, bool) {
+func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, name string, options []string) (string, bool) {
 	if len(options) == 0 {
 		return "", true
 	}
 
 	hasDefault := false
 	for _, opt := range options {
-		switch {
-		case strings.HasPrefix(opt, "default"):
+		key, val, found := strings.Cut(opt, "=")
+		switch key {
+		case "default":
 			if hasDefault {
 				return "properties tag accepts only one default option", false
 			}
 			hasDefault = true
 
-			parts := strings.Split(opt, "=")
-			if len(parts) < 2 {
+			if !found {
 				return "malformed default for properties tag", false
 			}
 
-			if !w.typeValueMatch(t, parts[1]) {
+			if !w.typeValueMatch(t, val) {
 				return "field's type and default value's type mismatch", false
 			}
-		case strings.HasPrefix(opt, "layout"):
-			parts := strings.Split(opt, "=")
-			if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+		case "layout":
+			if !found || strings.TrimSpace(val) == "" {
 				return "malformed layout option for properties tag", false
 			}
 
-			if gofmt(t) != "time.Time" {
+			if gofmt(val) != "time.Time" {
 				return "layout option is only applicable to fields of type time.Time", false
 			}
 		default:

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -165,15 +165,17 @@ type TomlUser struct {
 }
 
 type PropertiesTags struct {
-	Field int        `properties:"-"`
-	Field int        `properties:"myName"`
-	Field int        `properties:"myName,default=15"`
-	Field int        `properties:"myName,default=sString"` // MATCH /field's type and default value's type mismatch/
-	Field int        `properties:",default:15"`            // MATCH /malformed default for Properties tag/
-	Field int        `properties:",default=15,default=2"`  // MATCH /Properties tag accepts only one 'default' option/
-	Field time.Time  `properties:"date,layout=2006-01-02"`
-	Field []string   `properties:",default=a;b;c"`
-	Field SomeStruct `properties:"myName"`
-	Field map[string]string
-	Field map[string]string `properties:"myName"`
+	Field int               `properties:"-"`
+	Field int               `properties:"myName"`
+	Field int               `properties:"myName,default=15"`
+	Field int               `properties:"myName,default=sString"` // MATCH /field's type and default value's type mismatch/
+	Field int               `properties:",default:15"`            // MATCH /malformed default for properties tag/
+	Field int               `properties:",default=15,default=2"`  // MATCH /properties tag accepts only one default option/
+	Field time.Time         `properties:"date,layout=2006-01-02"`
+	Field time.Time         `properties:",layout=2006-01-02"`
+	Field time.Time         `properties:"date,layout"`            // MATCH /malformed layout option for properties tag/
+	Field time.Time         `properties:"date,layout=  "`         // MATCH /malformed layout option for properties tag/
+	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time/
+	Field []string          `properties:",default=a;b;c"`
+	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown option "omitempty" in properties tag/
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -163,3 +163,17 @@ type TomlUser struct {
 	Username string `toml:"username,omitempty"`
 	Location string `toml:"location,unknown"` // MATCH /unknown option 'unknown' in TOML tag/
 }
+
+type PropertiesTags struct {
+	Field int        `properties:"-"`
+	Field int        `properties:"myName"`
+	Field int        `properties:"myName,default=15"`
+	Field int        `properties:"myName,default=sString"` // MATCH /field's type and default value's type mismatch/
+	Field int        `properties:",default:15"`            // MATCH /malformed default for Properties tag/
+	Field int        `properties:",default=15,default=2"`  // MATCH /Properties tag accepts only one 'default' option/
+	Field time.Time  `properties:"date,layout=2006-01-02"`
+	Field []string   `properties:",default=a;b;c"`
+	Field SomeStruct `properties:"myName"`
+	Field map[string]string
+	Field map[string]string `properties:"myName"`
+}

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -168,14 +168,14 @@ type PropertiesTags struct {
 	Field int               `properties:"-"`
 	Field int               `properties:"myName"`
 	Field int               `properties:"myName,default=15"`
-	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch/
+	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch in properties tag/
 	Field int               `properties:",default:15"`            // MATCH /unknown option "default:15" in properties tag/
 	Field int               `properties:",default=15,default=2"`  // MATCH /properties tag accepts only one default option/
 	Field time.Time         `properties:"date,layout=2006-01-02"`
 	Field time.Time         `properties:",layout=2006-01-02"`
 	Field time.Time         `properties:"date,layout"`            // MATCH /malformed layout option for properties tag/
 	Field time.Time         `properties:"date,layout=  "`         // MATCH /malformed layout option for properties tag/
-	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time/
+	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time in properties tag/
 	Field []string          `properties:",default=a;b;c"`
 	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown option "omitempty" in properties tag/
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -168,8 +168,8 @@ type PropertiesTags struct {
 	Field int               `properties:"-"`
 	Field int               `properties:"myName"`
 	Field int               `properties:"myName,default=15"`
-	Field int               `properties:"myName,default=sString"` // MATCH /field's type and default value's type mismatch/
-	Field int               `properties:",default:15"`            // MATCH /malformed default for properties tag/
+	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch/
+	Field int               `properties:",default:15"`            // MATCH /unknown option "default:15" in properties tag/
 	Field int               `properties:",default=15,default=2"`  // MATCH /properties tag accepts only one default option/
 	Field time.Time         `properties:"date,layout=2006-01-02"`
 	Field time.Time         `properties:",layout=2006-01-02"`


### PR DESCRIPTION
Closes #1269 

type checking default values for slices is omitted on purpose (might be added later)

A PR for cleaning up the whole rule's code will follow