### PR TITLE
struct-tag: change reported messages and refactor implementation

### DIFF
--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -207,7 +207,7 @@ func (w lintStructTagRule) checkTaggedField(f *ast.Field) {
 				w.addFailure(f.Tag, msg)
 			}
 		case keyProperties:
-			msg, ok := w.checkPropertiesTag(f.Type, tag.Name, tag.Options)
+			msg, ok := w.checkPropertiesTag(f.Type, tag.Options)
 			if !ok {
 				w.addFailure(f.Tag, msg)
 			}

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -172,83 +172,90 @@ func (w lintStructTagRule) checkTaggedField(f *ast.Field) {
 	}
 
 	for _, tag := range tags.Tags() {
-		if msg, ok := w.checkTagNameIfNeed(tag); !ok {
+		failure := checkTag()
+		if failure != nil {
+			w.onFailure(failure)
+		}
+	}
+}
+
+func (w lintStructTagRule) checkTag() lint.Failure {
+	if msg, ok := w.checkTagNameIfNeed(tag); !ok {
+		return w.addFailure(f.Tag, msg)
+	}
+
+	switch key := tag.Key; key {
+	case keyASN1:
+		msg, ok := w.checkASN1Tag(f.Type, tag)
+		if !ok {
 			w.addFailure(f.Tag, msg)
 		}
-
-		switch key := tag.Key; key {
-		case keyASN1:
-			msg, ok := w.checkASN1Tag(f.Type, tag)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyBSON:
-			msg, ok := w.checkBSONTag(tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyDatastore:
-			msg, ok := w.checkDatastoreTag(tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyDefault:
-			if !w.typeValueMatch(f.Type, tag.Name) {
-				w.addFailure(f.Tag, "field's type and default value's type mismatch")
-			}
-		case keyJSON:
-			msg, ok := w.checkJSONTag(tag.Name, tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyMapstructure:
-			msg, ok := w.checkMapstructureTag(tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyProperties:
-			msg, ok := w.checkPropertiesTag(f.Type, tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyProtobuf:
-			msg, ok := w.checkProtobufTag(tag)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyRequired:
-			if tag.Name != "true" && tag.Name != "false" {
-				w.addFailure(f.Tag, "required should be 'true' or 'false'")
-			}
-		case keyTOML:
-			msg, ok := w.checkTOMLTag(tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyURL:
-			msg, ok := w.checkURLTag(tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyValidate:
-			opts := append([]string{tag.Name}, tag.Options...)
-			msg, ok := w.checkValidateTag(opts)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyXML:
-			msg, ok := w.checkXMLTag(tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		case keyYAML:
-			msg, ok := w.checkYAMLTag(tag.Options)
-			if !ok {
-				w.addFailure(f.Tag, msg)
-			}
-		default:
-			// unknown key
+	case keyBSON:
+		msg, ok := w.checkBSONTag(tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
 		}
+	case keyDatastore:
+		msg, ok := w.checkDatastoreTag(tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyDefault:
+		if !w.typeValueMatch(f.Type, tag.Name) {
+			w.addFailure(f.Tag, "field's type and default value's type mismatch")
+		}
+	case keyJSON:
+		msg, ok := w.checkJSONTag(tag.Name, tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyMapstructure:
+		msg, ok := w.checkMapstructureTag(tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyProperties:
+		msg, ok := w.checkPropertiesTag(f.Type, tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyProtobuf:
+		msg, ok := w.checkProtobufTag(tag)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyRequired:
+		if tag.Name != "true" && tag.Name != "false" {
+			w.addFailure(f.Tag, "required should be 'true' or 'false'")
+		}
+	case keyTOML:
+		msg, ok := w.checkTOMLTag(tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyURL:
+		msg, ok := w.checkURLTag(tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyValidate:
+		opts := append([]string{tag.Name}, tag.Options...)
+		msg, ok := w.checkValidateTag(opts)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyXML:
+		msg, ok := w.checkXMLTag(tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	case keyYAML:
+		msg, ok := w.checkYAMLTag(tag.Options)
+		if !ok {
+			w.addFailure(f.Tag, msg)
+		}
+	default:
+		// unknown key
 	}
 }
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -35,7 +35,7 @@ const (
 	keyYAML         tagKey = "yaml"
 )
 
-type tagChecker func(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool)
+type tagChecker func(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeeded bool)
 
 // populate tag checkers map
 var tagCheckers = map[tagKey]tagChecker{
@@ -190,7 +190,7 @@ func (w lintStructTagRule) checkTaggedField(checkCtx *checkContext, f *ast.Field
 	}
 }
 
-func (w lintStructTagRule) checkTagNameIfNeed(checkCtx *checkContext, tag *structtag.Tag) (message string, succeded bool) {
+func (w lintStructTagRule) checkTagNameIfNeed(checkCtx *checkContext, tag *structtag.Tag) (message string, succeeded bool) {
 	isUnnamedTag := tag.Name == "" || tag.Name == "-"
 	if isUnnamedTag {
 		return "", true
@@ -235,7 +235,7 @@ func (lintStructTagRule) getTagName(tag *structtag.Tag) string {
 	}
 }
 
-func checkASN1Tag(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool) {
+func checkASN1Tag(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeeded bool) {
 	checkList := append(tag.Options, tag.Name)
 	for _, opt := range checkList {
 		switch opt {
@@ -252,7 +252,7 @@ func checkASN1Tag(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr
 	return "", true
 }
 
-func checkCompoundANS1Option(checkCtx *checkContext, opt string, fieldType ast.Expr) (message string, succeded bool) {
+func checkCompoundANS1Option(checkCtx *checkContext, opt string, fieldType ast.Expr) (message string, succeeded bool) {
 	parts := strings.Split(opt, ":")
 	switch parts[0] {
 	case "tag":
@@ -280,7 +280,7 @@ func checkCompoundANS1Option(checkCtx *checkContext, opt string, fieldType ast.E
 	return "", true
 }
 
-func checkDatastoreTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkDatastoreTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "flatten", "noindex", "omitempty":
@@ -295,7 +295,7 @@ func checkDatastoreTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (
 	return "", true
 }
 
-func checkDefaultTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool) {
+func checkDefaultTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeeded bool) {
 	if !typeValueMatch(fieldType, tag.Name) {
 		return msgTypeMismatch, false
 	}
@@ -303,7 +303,7 @@ func checkDefaultTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (m
 	return "", true
 }
 
-func checkBSONTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkBSONTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "inline", "minsize", "omitempty":
@@ -318,7 +318,7 @@ func checkBSONTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messa
 	return "", true
 }
 
-func checkJSONTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkJSONTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "omitempty", "string":
@@ -343,7 +343,7 @@ func checkJSONTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messa
 	return "", true
 }
 
-func checkMapstructureTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkMapstructureTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "omitempty", "reminder", "squash":
@@ -358,7 +358,7 @@ func checkMapstructureTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr
 	return "", true
 }
 
-func checkPropertiesTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool) {
+func checkPropertiesTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeeded bool) {
 	options := tag.Options
 	if len(options) == 0 {
 		return "", true
@@ -379,7 +379,7 @@ func checkPropertiesTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr)
 	return "", true
 }
 
-func checkCompoundPropertiesOption(key, value string, fieldType ast.Expr, seenOptions map[string]bool) (message string, succeded bool) {
+func checkCompoundPropertiesOption(key, value string, fieldType ast.Expr, seenOptions map[string]bool) (message string, succeeded bool) {
 	if _, ok := seenOptions[key]; ok {
 		return fmt.Sprintf(msgDuplicatedOption, key), false
 	}
@@ -403,7 +403,7 @@ func checkCompoundPropertiesOption(key, value string, fieldType ast.Expr, seenOp
 	return "", true
 }
 
-func checkProtobufTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkProtobufTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	// check name
 	switch tag.Name {
 	case "bytes", "fixed32", "fixed64", "group", "varint", "zigzag32", "zigzag64":
@@ -415,7 +415,7 @@ func checkProtobufTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (m
 	return checkProtobufOptions(checkCtx, tag.Options)
 }
 
-func checkProtobufOptions(checkCtx *checkContext, options []string) (message string, succeded bool) {
+func checkProtobufOptions(checkCtx *checkContext, options []string) (message string, succeeded bool) {
 	seenOptions := map[string]bool{}
 	hasName := false
 	for _, opt := range options {
@@ -456,7 +456,7 @@ func checkProtobufOptions(checkCtx *checkContext, options []string) (message str
 	return "", true
 }
 
-func checkRequiredTag(_ *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkRequiredTag(_ *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	if tag.Name != "true" && tag.Name != "false" {
 		return `required should be "true" or "false"`, false
 	}
@@ -464,7 +464,7 @@ func checkRequiredTag(_ *checkContext, tag *structtag.Tag, _ ast.Expr) (message 
 	return "", true
 }
 
-func checkTOMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkTOMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "omitempty":
@@ -479,7 +479,7 @@ func checkTOMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messa
 	return "", true
 }
 
-func checkURLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkURLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	var delimiter = ""
 	for _, opt := range tag.Options {
 		switch opt {
@@ -502,7 +502,7 @@ func checkURLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messag
 	return "", true
 }
 
-func checkValidateTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkValidateTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	previousOption := ""
 	seenKeysOption := false
 	options := append([]string{tag.Name}, tag.Options...)
@@ -531,7 +531,7 @@ func checkValidateTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (m
 	return "", true
 }
 
-func checkXMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkXMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "any", "attr", "cdata", "chardata", "comment", "innerxml", "omitempty", "typeattr":
@@ -546,7 +546,7 @@ func checkXMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messag
 	return "", true
 }
 
-func checkYAMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
+func checkYAMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "flow", "inline", "omitempty":
@@ -561,7 +561,7 @@ func checkYAMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messa
 	return "", true
 }
 
-func checkValidateOptionsAlternatives(checkCtx *checkContext, alternatives []string) (message string, succeded bool) {
+func checkValidateOptionsAlternatives(checkCtx *checkContext, alternatives []string) (message string, succeeded bool) {
 	for _, alternative := range alternatives {
 		alternative := strings.TrimSpace(alternative)
 		parts := strings.Split(alternative, "=")

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -35,7 +35,7 @@ const (
 	keyYAML         tagKey = "yaml"
 )
 
-type tagChecker func(ctx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (failureMessage string, checkSuccedded bool)
+type tagChecker func(ctx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool)
 
 // populate tag checkers map
 var tagCheckers = map[tagKey]tagChecker{
@@ -47,7 +47,7 @@ var tagCheckers = map[tagKey]tagChecker{
 	keyMapstructure: checkMapstructureTag,
 	keyProperties:   checkPropertiesTag,
 	keyProtobuf:     checkProtobufTag,
-	keyRequired:     checkrequiredTag,
+	keyRequired:     checkRequiredTag,
 	keyTOML:         checkTOMLTag,
 	keyURL:          checkURLTag,
 	keyValidate:     checkValidateTag,
@@ -190,7 +190,7 @@ func (w lintStructTagRule) checkTaggedField(ctx *checkContext, f *ast.Field) {
 	}
 }
 
-func (w lintStructTagRule) checkTagNameIfNeed(ctx *checkContext, tag *structtag.Tag) (string, bool) {
+func (w lintStructTagRule) checkTagNameIfNeed(ctx *checkContext, tag *structtag.Tag) (message string, succeded bool) {
 	isUnnamedTag := tag.Name == "" || tag.Name == "-"
 	if isUnnamedTag {
 		return "", true
@@ -235,7 +235,7 @@ func (lintStructTagRule) getTagName(tag *structtag.Tag) string {
 	}
 }
 
-func checkASN1Tag(ctx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (string, bool) {
+func checkASN1Tag(ctx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool) {
 	checkList := append(tag.Options, tag.Name)
 	for _, opt := range checkList {
 		switch opt {
@@ -252,7 +252,7 @@ func checkASN1Tag(ctx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (st
 	return "", true
 }
 
-func checkCompoundANS1Option(ctx *checkContext, opt string, fieldType ast.Expr) (string, bool) {
+func checkCompoundANS1Option(ctx *checkContext, opt string, fieldType ast.Expr) (message string, succeded bool) {
 	parts := strings.Split(opt, ":")
 	switch parts[0] {
 	case "tag":
@@ -280,7 +280,7 @@ func checkCompoundANS1Option(ctx *checkContext, opt string, fieldType ast.Expr) 
 	return "", true
 }
 
-func checkDatastoreTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkDatastoreTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "flatten", "noindex", "omitempty":
@@ -295,7 +295,7 @@ func checkDatastoreTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (strin
 	return "", true
 }
 
-func checkDefaultTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (string, bool) {
+func checkDefaultTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool) {
 	if !typeValueMatch(fieldType, tag.Name) {
 		return "field type and default value type mismatch", false
 	}
@@ -303,7 +303,7 @@ func checkDefaultTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (s
 	return "", true
 }
 
-func checkBSONTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkBSONTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "inline", "minsize", "omitempty":
@@ -318,7 +318,7 @@ func checkBSONTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bo
 	return "", true
 }
 
-func checkJSONTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkJSONTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "omitempty", "string":
@@ -343,7 +343,7 @@ func checkJSONTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bo
 	return "", true
 }
 
-func checkMapstructureTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkMapstructureTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "omitempty", "reminder", "squash":
@@ -358,7 +358,7 @@ func checkMapstructureTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (st
 	return "", true
 }
 
-func checkPropertiesTag(ctx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (string, bool) {
+func checkPropertiesTag(ctx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool) {
 	options := tag.Options
 	if len(options) == 0 {
 		return "", true
@@ -383,7 +383,7 @@ func checkPropertiesTag(ctx *checkContext, tag *structtag.Tag, fieldType ast.Exp
 	return "", true
 }
 
-func checkCompoundPropertiesOption(key, value string, fieldType ast.Expr, seenOptions map[string]bool) (string, bool) {
+func checkCompoundPropertiesOption(key, value string, fieldType ast.Expr, seenOptions map[string]bool) (message string, succeded bool) {
 	if _, ok := seenOptions[key]; ok {
 		return fmt.Sprintf("duplicated option %q in properties tag", key), false
 	}
@@ -407,7 +407,7 @@ func checkCompoundPropertiesOption(key, value string, fieldType ast.Expr, seenOp
 	return "", true
 }
 
-func checkProtobufTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkProtobufTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	// check name
 	switch tag.Name {
 	case "bytes", "fixed32", "fixed64", "group", "varint", "zigzag32", "zigzag64":
@@ -461,7 +461,7 @@ func checkProtobufTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string
 	return "", true
 }
 
-func checkrequiredTag(_ *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkRequiredTag(_ *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	if tag.Name != "true" && tag.Name != "false" {
 		return `required should be "true" or "false"`, false
 	}
@@ -469,7 +469,7 @@ func checkrequiredTag(_ *checkContext, tag *structtag.Tag, _ ast.Expr) (string, 
 	return "", true
 }
 
-func checkTOMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkTOMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "omitempty":
@@ -484,7 +484,7 @@ func checkTOMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bo
 	return "", true
 }
 
-func checkURLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkURLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	var delimiter = ""
 	for _, opt := range tag.Options {
 		switch opt {
@@ -507,7 +507,7 @@ func checkURLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, boo
 	return "", true
 }
 
-func checkValidateTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkValidateTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	previousOption := ""
 	seenKeysOption := false
 	options := append([]string{tag.Name}, tag.Options...)
@@ -536,7 +536,7 @@ func checkValidateTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string
 	return "", true
 }
 
-func checkXMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkXMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "any", "attr", "cdata", "chardata", "comment", "innerxml", "omitempty", "typeattr":
@@ -551,7 +551,7 @@ func checkXMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, boo
 	return "", true
 }
 
-func checkYAMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bool) {
+func checkYAMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeded bool) {
 	for _, opt := range tag.Options {
 		switch opt {
 		case "flow", "inline", "omitempty":
@@ -566,7 +566,7 @@ func checkYAMLTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (string, bo
 	return "", true
 }
 
-func checkValidateOptionsAlternatives(ctx *checkContext, alternatives []string) (string, bool) {
+func checkValidateOptionsAlternatives(ctx *checkContext, alternatives []string) (message string, succeded bool) {
 	for _, alternative := range alternatives {
 		alternative := strings.TrimSpace(alternative)
 		parts := strings.Split(alternative, "=")
@@ -615,147 +615,13 @@ func typeValueMatch(t ast.Expr, val string) bool {
 
 	return typeMatches
 }
-func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, options []string) (string, bool) {
-	if len(options) == 0 {
-		return "", true
-	}
-
-	hasDefault := false
-	for _, opt := range options {
-		key, val, found := strings.Cut(opt, "=")
-		switch key {
-		case "default":
-			if hasDefault {
-				return "properties tag accepts only one default option", false
-			}
-			hasDefault = true
-
-			if !found {
-				return "malformed default for properties tag", false
-			}
-
-			if !w.typeValueMatch(t, val) {
-				return "field type and default value type mismatch in properties tag", false
-			}
-		case "layout":
-			if !found || strings.TrimSpace(val) == "" {
-				return "malformed layout option for properties tag", false
-			}
-
-			if gofmt(t) != "time.Time" {
-				return "layout option is only applicable to fields of type time.Time in properties tag", false
-			}
-		default:
-			return fmt.Sprintf("unknown option %q in properties tag", opt), false
-		}
-	}
-
-	return "", true
-}
-
-func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, options []string) (string, bool) {
-	if len(options) == 0 {
-		return "", true
-	}
-
-	hasDefault := false
-	for _, opt := range options {
-		switch {
-		case strings.HasPrefix(opt, "default"):
-			if hasDefault {
-				return "properties tag accepts only one default option", false
-			}
-			hasDefault = true
-
-			parts := strings.Split(opt, "=")
-			if len(parts) < 2 {
-				return "malformed default for properties tag", false
-			}
-
-			if !w.typeValueMatch(t, parts[1]) {
-				return "field's type and default value's type mismatch", false
-			}
-		case strings.HasPrefix(opt, "layout"):
-			parts := strings.Split(opt, "=")
-			if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
-				return "malformed layout option for properties tag", false
-			}
-
-			if gofmt(t) != "time.Time" {
-				return "layout option is only applicable to fields of type time.Time", false
-			}
-		default:
-			return fmt.Sprintf("unknown option %q in properties tag", opt), false
-		}
-	}
-
-	return "", true
-}
-
-func (w lintStructTagRule) checkProtobufTag(tag *structtag.Tag) (string, bool) {
-	// check name
-	switch tag.Name {
-	case "bytes", "fixed32", "fixed64", "group", "varint", "zigzag32", "zigzag64":
-		// do nothing
-	default:
-		return fmt.Sprintf("invalid protobuf tag name '%s'", tag.Name), false
-	}
-
-	// check options
-	seenOptions := map[string]bool{}
-	for _, opt := range tag.Options {
-		if number, err := strconv.Atoi(opt); err == nil {
-			_, alreadySeen := w.usedTagNbr[number]
-			if alreadySeen {
-				return fmt.Sprintf("duplicated tag number %v", number), false
-			}
-			w.usedTagNbr[number] = true
-			continue // option is an integer
-		}
-
-		switch {
-		case opt == "opt" || opt == "proto3" || opt == "rep" || opt == "req":
-			// do nothing
-		case strings.Contains(opt, "="):
-			o := strings.Split(opt, "=")[0]
-			_, alreadySeen := seenOptions[o]
-			if alreadySeen {
-				return fmt.Sprintf("protobuf tag has duplicated option '%s'", o), false
-			}
-			seenOptions[o] = true
-			continue
-		}
-	}
-	_, hasName := seenOptions["name"]
-	if !hasName {
-		return "protobuf tag lacks mandatory option 'name'", false
-	}
-
-	for k := range seenOptions {
-		switch k {
-		case "name", "json":
-			// do nothing
-		default:
-			if w.isUserDefined(keyProtobuf, k) {
-				continue
-			}
-			return fmt.Sprintf("unknown option '%s' in protobuf tag", k), false
-		}
-	}
-
-	return "", true
-}
 
 func (w lintStructTagRule) addFailure(n ast.Node, msg string) {
 	w.onFailure(lint.Failure{
 		Node:       n,
 		Failure:    msg,
 		Confidence: 1,
-	}
-}
-
-func (w lintStructTagRule) addFailure(n ast.Node, msg string) {
-	w.onFailure(w.newFailure(n, msg))
+	})
 }
 
 func areValidateOpts(opts string) (string, bool) {

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -331,7 +331,7 @@ func checkJSONTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messa
 			if checkCtx.isAtLeastGo124 {
 				continue
 			}
-			fallthrough
+			return `prior Go 1.24, option "omitzero" is unsupported`, false
 		default:
 			if checkCtx.isUserDefined(keyJSON, opt) {
 				continue

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -561,25 +561,23 @@ func checkYAMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messa
 func checkValidateOptionsAlternatives(checkCtx *checkContext, alternatives []string) (message string, succeeded bool) {
 	for _, alternative := range alternatives {
 		alternative := strings.TrimSpace(alternative)
-		parts := strings.Split(alternative, "=")
-		switch len(parts) {
-		case 1:
-			badOpt, ok := areValidateOpts(parts[0])
-			if ok || checkCtx.isUserDefined(keyValidate, badOpt) {
-				continue
-			}
-			return fmt.Sprintf(msgUnknownOption, badOpt), false
-		case 2:
-			lhs := parts[0]
+		lhs, _, found := strings.Cut(alternative, "=")
+		if found {
 			_, ok := validateLHS[lhs]
 			if ok || checkCtx.isUserDefined(keyValidate, lhs) {
 				continue
 			}
 			return fmt.Sprintf(msgUnknownOption, lhs), false
-		default:
-			return fmt.Sprintf("malformed options %q, not expected more than one '='", alternative), false
 		}
+
+		badOpt, ok := areValidateOpts(alternative)
+		if ok || checkCtx.isUserDefined(keyValidate, badOpt) {
+			continue
+		}
+
+		return fmt.Sprintf(msgUnknownOption, badOpt), false
 	}
+
 	return "", true
 }
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -366,15 +366,11 @@ func checkPropertiesTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr)
 
 	seenOptions := map[string]bool{}
 	for _, opt := range options {
-		var msg string
-		var ok bool
-		parts := strings.Split(opt, "=")
-		switch len(parts) {
-		case 2:
-			msg, ok = checkCompoundPropertiesOption(parts[0], parts[1], fieldType, seenOptions)
-		default:
-			msg, ok = fmt.Sprintf("unknown or malformed option %q", opt), false
+		msg, ok := fmt.Sprintf("unknown or malformed option %q", opt), false
+		if key, value, found := strings.Cut(opt, "="); found {
+			msg, ok = checkCompoundPropertiesOption(key, value, fieldType, seenOptions)
 		}
+
 		if !ok {
 			return msg, false
 		}

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -212,7 +212,7 @@ func (w lintStructTagRule) checkTagNameIfNeed(ctx *checkContext, tag *structtag.
 	// to allow the same tag name in different tag type.
 	mapKey := tag.Key + ":" + tagName
 	if _, ok := ctx.usedTagName[mapKey]; ok {
-		return fmt.Sprintf(msgDuplicatedTagName, tagName), false
+		return fmt.Sprintf("duplicated tag name %q", tagName), false
 	}
 
 	ctx.usedTagName[mapKey] = true
@@ -641,7 +641,6 @@ func areValidateOpts(opts string) (string, bool) {
 
 const (
 	msgDuplicatedOption    = "duplicated option %q"
-	msgDuplicatedTagName   = "duplicated tag name %q"
 	msgDuplicatedTagNumber = "duplicated tag number %v"
 	msgUnknownOption       = "unknown option %q"
 	msgTypeMismatch        = "type mismatch between field type and default value type"

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -453,11 +453,12 @@ func checkProtobufOptions(checkCtx *checkContext, options []string) (message str
 }
 
 func checkRequiredTag(_ *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
-	if tag.Name != "true" && tag.Name != "false" {
+	switch tag.Name {
+	case "true", "false":
+		return "", true
+	default:
 		return `required should be "true" or "false"`, false
 	}
-
-	return "", true
 }
 
 func checkTOMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -550,6 +550,40 @@ func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, options []string) (str
 	return "", true
 }
 
+func (w lintStructTagRule) checkPropertiesTag(t ast.Expr, options []string) (string, bool) {
+	if len(options) == 0 {
+		return "", true
+	}
+
+	var hasDefault, hasField bool
+	for _, opt := range options {
+		println(">>>> ", opt)
+		switch {
+		case strings.HasPrefix(opt, "default"):
+			if hasDefault {
+				return "Properties tag accepts only one 'default' option", false
+			}
+			hasDefault = true
+
+			parts := strings.Split(opt, "=")
+			if len(parts) < 2 {
+				return "malformed default for Properties tag", false
+			}
+
+			if !w.typeValueMatch(t, parts[1]) {
+				return "field's type and default value's type mismatch", false
+			}
+		default:
+			hasField = true
+		}
+	}
+
+	if !hasDefault && !hasField {
+		return "default is required if field is not set", false
+	}
+	return "", true
+}
+
 func (w lintStructTagRule) checkProtobufTag(tag *structtag.Tag) (string, bool) {
 	// check name
 	switch tag.Name {

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -13,7 +13,7 @@ import (
 
 // StructTagRule lints struct tags.
 type StructTagRule struct {
-	userDefined map[string][]string // map: key -> []option
+	userDefined map[tagKey][]string // map: key -> []option
 }
 
 type tagKey string
@@ -56,7 +56,7 @@ var tagCheckers = map[tagKey]tagChecker{
 }
 
 type checkContext struct {
-	userDefined    map[string][]string // map: key -> []option
+	userDefined    map[tagKey][]string // map: key -> []option
 	usedTagNbr     map[int]bool        // list of used tag numbers
 	usedTagName    map[string]bool     // list of used tag keys
 	isAtLeastGo124 bool
@@ -67,7 +67,7 @@ func (checkCtx checkContext) isUserDefined(key tagKey, opt string) bool {
 		return false
 	}
 
-	options := checkCtx.userDefined[string(key)]
+	options := checkCtx.userDefined[key]
 	return slices.Contains(options, opt)
 }
 
@@ -84,7 +84,7 @@ func (r *StructTagRule) Configure(arguments lint.Arguments) error {
 		return err
 	}
 
-	r.userDefined = make(map[string][]string, len(arguments))
+	r.userDefined = make(map[tagKey][]string, len(arguments))
 	for _, arg := range arguments {
 		item, ok := arg.(string)
 		if !ok {
@@ -94,7 +94,7 @@ func (r *StructTagRule) Configure(arguments lint.Arguments) error {
 		if len(parts) < 2 {
 			return fmt.Errorf("invalid argument to the %s rule. Expecting a string of the form key[,option]+, got %s", r.Name(), item)
 		}
-		key := strings.TrimSpace(parts[0])
+		key := tagKey(strings.TrimSpace(parts[0]))
 		for i := 1; i < len(parts); i++ {
 			option := strings.TrimSpace(parts[i])
 			r.userDefined[key] = append(r.userDefined[key], option)
@@ -130,7 +130,7 @@ func (*StructTagRule) Name() string {
 
 type lintStructTagRule struct {
 	onFailure      func(lint.Failure)
-	userDefined    map[string][]string // map: key -> []option
+	userDefined    map[tagKey][]string // map: key -> []option
 	isAtLeastGo124 bool
 	tagCheckers    map[tagKey]tagChecker
 }

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -358,7 +358,7 @@ func checkMapstructureTag(ctx *checkContext, tag *structtag.Tag, _ ast.Expr) (me
 	return "", true
 }
 
-func checkPropertiesTag(ctx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool) {
+func checkPropertiesTag(_ *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeded bool) {
 	options := tag.Options
 	if len(options) == 0 {
 		return "", true

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -175,7 +175,7 @@ func (w lintStructTagRule) checkTaggedField(checkCtx *checkContext, f *ast.Field
 
 	for _, tag := range tags.Tags() {
 		if msg, ok := w.checkTagNameIfNeed(checkCtx, tag); !ok {
-			w.addFailureWithTagKeyf(f.Tag, msg, tag.Key)
+			w.addFailureWithTagKey(f.Tag, msg, tag.Key)
 		}
 
 		checker, ok := w.tagCheckers[tagKey(tag.Key)]
@@ -185,7 +185,7 @@ func (w lintStructTagRule) checkTaggedField(checkCtx *checkContext, f *ast.Field
 
 		msg, ok := checker(checkCtx, tag, f.Type)
 		if !ok {
-			w.addFailureWithTagKeyf(f.Tag, msg, tag.Key)
+			w.addFailureWithTagKey(f.Tag, msg, tag.Key)
 		}
 	}
 }
@@ -606,7 +606,7 @@ func typeValueMatch(t ast.Expr, val string) bool {
 	return typeMatches
 }
 
-func (w lintStructTagRule) addFailureWithTagKeyf(n ast.Node, msg string, tagKey string) {
+func (w lintStructTagRule) addFailureWithTagKey(n ast.Node, msg string, tagKey string) {
 	w.addFailuref(n, "%s in %s tag", msg, tagKey)
 }
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -253,23 +253,19 @@ func checkASN1Tag(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr
 }
 
 func checkCompoundANS1Option(checkCtx *checkContext, opt string, fieldType ast.Expr) (message string, succeeded bool) {
-	parts := strings.Split(opt, ":")
-	switch parts[0] {
+	key, value, _ := strings.Cut(opt, ":")
+	switch key {
 	case "tag":
-		tagNumber := strings.TrimLeft(opt, "tag:")
-		number, err := strconv.Atoi(tagNumber)
+		number, err := strconv.Atoi(value)
 		if err != nil {
-			return fmt.Sprintf("tag must be a number but is %q", tagNumber), false
+			return fmt.Sprintf("tag must be a number but is %q", value), false
 		}
 		if checkCtx.usedTagNbr[number] {
 			return fmt.Sprintf(msgDuplicatedTagNumber, number), false
 		}
 		checkCtx.usedTagNbr[number] = true
 	case "default":
-		if len(parts) < 2 {
-			return "malformed default", false
-		}
-		if !typeValueMatch(fieldType, parts[1]) {
+		if !typeValueMatch(fieldType, value) {
 			return msgTypeMismatch, false
 		}
 	default:

--- a/testdata/go1.24/struct_tag.go
+++ b/testdata/go1.24/struct_tag.go
@@ -25,7 +25,7 @@ type decodeAndValidateRequest struct {
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
 	Tiret       string `json:"-,"`
 	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in JSON tag/
-	ForOmitzero string `json:"forOmitZero,omitzero"` // 'omitzero' is valid in go 1.24
+	ForOmitzero string `json:"forOmitZero,omitzero"` // Go 1.24 introduces omitzero
 }
 
 type RangeAllocation struct {
@@ -169,13 +169,13 @@ type PropertiesTags struct {
 	Field int               `properties:"myName"`
 	Field int               `properties:"myName,default=15"`
 	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch/
-	Field int               `properties:",default:15"`            // MATCH /malformed default for properties tag/
-	Field int               `properties:",default=15,default=2"`  // MATCH /properties tag accepts only one default option/
+	Field int               `properties:",default:15"`            // MATCH /unknown or malformed option "default:15" in properties tag/
+	Field int               `properties:",default=15,default=2"`  // MATCH /duplicated option "default" in properties tag/
 	Field time.Time         `properties:"date,layout=2006-01-02"`
 	Field time.Time         `properties:",layout=2006-01-02"`
-	Field time.Time         `properties:"date,layout"`            // MATCH /malformed layout option for properties tag/
-	Field time.Time         `properties:"date,layout=  "`         // MATCH /malformed layout option for properties tag/
+	Field time.Time         `properties:"date,layout"`            // MATCH /unknown or malformed option "layout" in properties tag/
+	Field time.Time         `properties:"date,layout=  "`         // MATCH /expected option "layout" to be of the form layout=value in properties tag/
 	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time/
 	Field []string          `properties:",default=a;b;c"`
-	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown option "omitempty" in properties tag/
+	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown or malformed option "omitempty" in properties tag/
 }

--- a/testdata/go1.24/struct_tag.go
+++ b/testdata/go1.24/struct_tag.go
@@ -1,22 +1,20 @@
 package fixtures
 
-import "time"
-
 type decodeAndValidateRequest struct {
 	// BEAWRE : the flag of URLParam should match the const string URLParam
 	URLParam    string `json:"-" path:"url_param" validate:"numeric"`
 	Text        string `json:"text" validate:"max=10"`
-	DefaultInt  int    `json:"defaultInt" default:"10.0"` // MATCH /field type and default value type mismatch/
+	DefaultInt  int    `json:"defaultInt" default:"10.0"` // MATCH /type mismatch between field type and default value type in default tag/
 	DefaultInt2 int    `json:"defaultInt2" default:"10"`
-	// MATCH:12 /unknown option "inline" in JSON tag/
-	DefaultInt3      int             `json:"defaultInt2,inline" default:"11"` // MATCH /duplicate tag name: "defaultInt2"/
+	// MATCH:10 /unknown option "inline" in json tag/
+	DefaultInt3      int             `json:"defaultInt2,inline" default:"11"` // MATCH /duplicated tag name "defaultInt2" in json tag/
 	DefaultString    string          `json:"defaultString" default:"foo"`
-	DefaultBool      bool            `json:"defaultBool" default:"trues"` // MATCH /field type and default value type mismatch/
+	DefaultBool      bool            `json:"defaultBool" default:"trues"` // MATCH /type mismatch between field type and default value type in default tag/
 	DefaultBool2     bool            `json:"defaultBool2" default:"true"`
 	DefaultBool3     bool            `json:"defaultBool3" default:"false"`
-	DefaultFloat     float64         `json:"defaultFloat" default:"f10.0"` // MATCH /field type and default value type mismatch/
+	DefaultFloat     float64         `json:"defaultFloat" default:"f10.0"` // MATCH /type mismatch between field type and default value type in default tag/
 	DefaultFloat2    float64         `json:"defaultFloat2" default:"10.0"`
-	MandatoryStruct  mandatoryStruct `json:"mandatoryStruct" required:"trues"` // MATCH /required should be "true" or "false"/
+	MandatoryStruct  mandatoryStruct `json:"mandatoryStruct" required:"trues"` // MATCH /required should be "true" or "false" in required tag/
 	MandatoryStruct2 mandatoryStruct `json:"mandatoryStruct2" required:"true"`
 	MandatoryStruct4 mandatoryStruct `json:"mandatoryStruct4" required:"false"`
 	OptionalStruct   *optionalStruct `json:"optionalStruct,omitempty"`
@@ -24,158 +22,13 @@ type decodeAndValidateRequest struct {
 	optionalQuery    string          `json:"-" querystring:"queryfoo"` // MATCH /tag on not-exported field optionalQuery/
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
 	Tiret       string `json:"-,"`
-	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in JSON tag/
+	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in json tag/
 	ForOmitzero string `json:"forOmitZero,omitzero"` // Go 1.24 introduces omitzero
 }
 
 type RangeAllocation struct {
-	metav1.TypeMeta   `json:",inline"` // MATCH /unknown option "inline" in JSON tag/
+	metav1.TypeMeta   `json:",inline"` // MATCH /unknown option "inline" in json tag/
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Range             string `json:"range,flow"`  // MATCH /unknown option "flow" in JSON tag/
-	Data              []byte `json:"data,inline"` // MATCH /unknown option "inline" in JSON tag/
-}
-
-type RangeAllocation struct {
-	metav1.TypeMeta   `bson:",minsize"`
-	metav1.ObjectMeta `bson:"metadata,omitempty"`
-	Range             string `bson:"range,flow"` // MATCH /unknown option "flow" in BSON tag/
-	Data              []byte `bson:"data,inline"`
-}
-
-type TestContextSpecificTags2 struct {
-	A       int       `asn1:"explicit,tag:1"`
-	B       int       `asn1:"tag:2"`
-	S       string    `asn1:"tag:0,utf8"`
-	Ints    []int     `asn1:"set"`
-	Version int       `asn1:"optional,explicit,default:0,tag:000"` // MATCH /duplicated tag number 0/
-	Time    time.Time `asn1:"explicit,tag:4,other"`                // MATCH /unknown option "other" in ASN1 tag/
-	X       int       `asn1:"explicit,tag:invalid"`                // MATCH /ASN1 tag must be a number, got "invalid"/
-}
-
-type VirtualMachineRelocateSpecDiskLocator struct {
-	DynamicData
-
-	DiskId          int32                           `xml:"diskId,attr,cdata"`
-	Datastore       ManagedObjectReference          `xml:"datastore,chardata,innerxml"`
-	DiskMoveType    string                          `xml:"diskMoveType,omitempty,comment"`
-	DiskBackingInfo BaseVirtualDeviceBackingInfo    `xml:"diskBackingInfo,omitempty,any"`
-	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,other"` // MATCH /unknown option "other" in XML tag/
-}
-
-type TestDuplicatedXMLTags struct {
-	A int `xml:"a"`
-	B int `xml:"a"` // MATCH /duplicate tag name: "a"/
-	C int `xml:"c"`
-}
-
-type TestDuplicatedBSONTags struct {
-	A int `bson:"b"`
-	B int `bson:"b"` // MATCH /duplicate tag name: "b"/
-	C int `bson:"c"`
-}
-
-type TestDuplicatedYAMLTags struct {
-	A int `yaml:"b"`
-	B int `yaml:"c"`
-	C int `yaml:"c"` // MATCH /duplicate tag name: "c"/
-}
-
-type TestDuplicatedProtobufTags struct {
-	A int `protobuf:"varint,name=b"`
-	B int `protobuf:"varint,name=c"`
-	C int `protobuf:"varint,name=c"` // MATCH /duplicate tag name: "c"/
-}
-
-// test case from
-// sigs.k8s.io/kustomize/api/types/helmchartargs.go
-
-type HelmChartArgs struct {
-	ChartName        string                 `json:"chartName,omitempty" yaml:"chartName,omitempty"`
-	ChartVersion     string                 `json:"chartVersion,omitempty" yaml:"chartVersion,omitempty"`
-	ChartRepoURL     string                 `json:"chartRepoUrl,omitempty" yaml:"chartRepoUrl,omitempty"`
-	ChartHome        string                 `json:"chartHome,omitempty" yaml:"chartHome,omitempty"`
-	ChartRepoName    string                 `json:"chartRepoName,omitempty" yaml:"chartRepoName,omitempty"`
-	HelmBin          string                 `json:"helmBin,omitempty" yaml:"helmBin,omitempty"`
-	HelmHome         string                 `json:"helmHome,omitempty" yaml:"helmHome,omitempty"`
-	Values           string                 `json:"values,omitempty" yaml:"values,omitempty"`
-	ValuesLocal      map[string]interface{} `json:"valuesLocal,omitempty" yaml:"valuesLocal,omitempty"`
-	ValuesMerge      string                 `json:"valuesMerge,omitempty" yaml:"valuesMerge,omitempty"`
-	ReleaseName      string                 `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
-	ReleaseNamespace string                 `json:"releaseNamespace,omitempty" yaml:"releaseNamespace,omitempty"`
-	ExtraArgs        []string               `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
-}
-
-// Test message for holding primitive types.
-type Simple struct {
-	OBool                *bool    `protobuf:"varint,1,req,json=oBool"`                           // MATCH /protobuf tag lacks mandatory option "name"/
-	OInt32               *int32   `protobuf:"varint,2,opt,name=o_int32,jsonx=oInt32"`            // MATCH /unknown option "jsonx" in protobuf tag/
-	OInt32Str            *int32   `protobuf:"varint,3,rep,name=o_int32_str,name=oInt32Str"`      // MATCH /protobuf tag has duplicated option "name"/
-	OInt64               *int64   `protobuf:"varint,4,opt,json=oInt64,name=o_int64,json=oInt64"` // MATCH /protobuf tag has duplicated option "json"/
-	OSint32Str           *int32   `protobuf:"zigzag32,11,opt,name=o_sint32_str,json=oSint32Str"`
-	OSint64Str           *int64   `protobuf:"zigzag64,13,opt,name=o_sint32_str,json=oSint64Str"` // MATCH /duplicate tag name: "o_sint32_str"/
-	OFloat               *float32 `protobuf:"fixed32,14,opt,name=o_float,json=oFloat"`
-	ODouble              *float64 `protobuf:"fixed64,014,opt,name=o_double,json=oDouble"`      // MATCH /duplicated tag number 14/
-	ODoubleStr           *float64 `protobuf:"fixed6,17,opt,name=o_double_str,json=oDoubleStr"` // MATCH /invalid protobuf tag name "fixed6"/
-	OString              *string  `protobuf:"bytes,18,opt,name=o_string,json=oString"`
-	OString2             *string  `protobuf:"bytes,name=ameno"`
-	OString3             *string  `protobuf:"bytes,name=ameno"` // MATCH /duplicate tag name: "ameno"/
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-type RequestQueryOption struct {
-	Properties           []string `url:"properties,comma,omitempty"`
-	CustomProperties     []string `url:"-"`
-	Associations         []string `url:"associations,brackets,omitempty"`
-	Associations2        []string `url:"associations2,semicolon,omitempty"`
-	Associations3        []string `url:"associations3,space,brackets,omitempty"`
-	Associations4        []string `url:"associations4,numbered,omitempty"`
-	Associations5        []string `url:"associations5,space,semicolon,omitempty"` // MATCH /can not set both "semicolon" and "space" as delimiters in URL tag/
-	PaginateAssociations bool     `url:"paginateAssociations,int,omitempty"`
-	Archived             bool     `url:"archived,myURLOption"` // MATCH /unknown option "myURLOption" in URL tag/
-	IDProperty           string   `url:"idProperty,omitempty"`
-}
-
-type Fields struct {
-	Field      string `datastore:",noindex,flatten,omitempty"`
-	OtherField string `datastore:",unknownOption"` // MATCH /unknown option "unknownOption" in Datastore tag/
-}
-
-type MapStruct struct {
-	Field1     string `mapstructure:",squash,reminder,omitempty"`
-	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option "unknownOption" in Mapstructure tag/
-}
-
-type ValidateUser struct {
-	Username    string `validate:"required,min=3,max=32"`
-	Email       string `validate:"required,email"`
-	Password    string `validate:"required,min=8,max=32"`
-	Biography   string `validate:"min=0,max=1000"`
-	DisplayName string `validate:"displayName,min=3,max=32"` // MATCH /unknown option "displayName" in validate tag/
-	Complex     string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,required"`
-	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option "keys" must follow a "dive" option in validate tag/
-	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option "endkeys" without a previous "keys" option in validate tag/
-	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option "endkeys" without a previous "keys" option in validate tag/
-}
-
-type TomlUser struct {
-	Username string `toml:"username,omitempty"`
-	Location string `toml:"location,unknown"` // MATCH /unknown option "unknown" in TOML tag/
-}
-
-type PropertiesTags struct {
-	Field int               `properties:"-"`
-	Field int               `properties:"myName"`
-	Field int               `properties:"myName,default=15"`
-	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch/
-	Field int               `properties:",default:15"`            // MATCH /unknown or malformed option "default:15" in properties tag/
-	Field int               `properties:",default=15,default=2"`  // MATCH /duplicated option "default" in properties tag/
-	Field time.Time         `properties:"date,layout=2006-01-02"`
-	Field time.Time         `properties:",layout=2006-01-02"`
-	Field time.Time         `properties:"date,layout"`            // MATCH /unknown or malformed option "layout" in properties tag/
-	Field time.Time         `properties:"date,layout=  "`         // MATCH /expected option "layout" to be of the form layout=value in properties tag/
-	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time/
-	Field []string          `properties:",default=a;b;c"`
-	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown or malformed option "omitempty" in properties tag/
+	Range             string `json:"range,flow"`  // MATCH /unknown option "flow" in json tag/
+	Data              []byte `json:"data,inline"` // MATCH /unknown option "inline" in json tag/
 }

--- a/testdata/go1.24/struct_tag.go
+++ b/testdata/go1.24/struct_tag.go
@@ -6,17 +6,17 @@ type decodeAndValidateRequest struct {
 	// BEAWRE : the flag of URLParam should match the const string URLParam
 	URLParam    string `json:"-" path:"url_param" validate:"numeric"`
 	Text        string `json:"text" validate:"max=10"`
-	DefaultInt  int    `json:"defaultInt" default:"10.0"` // MATCH /field's type and default value's type mismatch/
+	DefaultInt  int    `json:"defaultInt" default:"10.0"` // MATCH /field type and default value type mismatch/
 	DefaultInt2 int    `json:"defaultInt2" default:"10"`
-	// MATCH:12 /unknown option 'inline' in JSON tag/
-	DefaultInt3      int             `json:"defaultInt2,inline" default:"11"` // MATCH /duplicate tag name: 'defaultInt2'/
+	// MATCH:12 /unknown option "inline" in JSON tag/
+	DefaultInt3      int             `json:"defaultInt2,inline" default:"11"` // MATCH /duplicate tag name: "defaultInt2"/
 	DefaultString    string          `json:"defaultString" default:"foo"`
-	DefaultBool      bool            `json:"defaultBool" default:"trues"` // MATCH /field's type and default value's type mismatch/
+	DefaultBool      bool            `json:"defaultBool" default:"trues"` // MATCH /field type and default value type mismatch/
 	DefaultBool2     bool            `json:"defaultBool2" default:"true"`
 	DefaultBool3     bool            `json:"defaultBool3" default:"false"`
-	DefaultFloat     float64         `json:"defaultFloat" default:"f10.0"` // MATCH /field's type and default value's type mismatch/
+	DefaultFloat     float64         `json:"defaultFloat" default:"f10.0"` // MATCH /field type and default value type mismatch/
 	DefaultFloat2    float64         `json:"defaultFloat2" default:"10.0"`
-	MandatoryStruct  mandatoryStruct `json:"mandatoryStruct" required:"trues"` // MATCH /required should be 'true' or 'false'/
+	MandatoryStruct  mandatoryStruct `json:"mandatoryStruct" required:"trues"` // MATCH /required should be "true" or "false"/
 	MandatoryStruct2 mandatoryStruct `json:"mandatoryStruct2" required:"true"`
 	MandatoryStruct4 mandatoryStruct `json:"mandatoryStruct4" required:"false"`
 	OptionalStruct   *optionalStruct `json:"optionalStruct,omitempty"`
@@ -29,16 +29,16 @@ type decodeAndValidateRequest struct {
 }
 
 type RangeAllocation struct {
-	metav1.TypeMeta   `json:",inline"` // MATCH /unknown option 'inline' in JSON tag/
+	metav1.TypeMeta   `json:",inline"` // MATCH /unknown option "inline" in JSON tag/
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Range             string `json:"range,flow"`  // MATCH /unknown option 'flow' in JSON tag/
-	Data              []byte `json:"data,inline"` // MATCH /unknown option 'inline' in JSON tag/
+	Range             string `json:"range,flow"`  // MATCH /unknown option "flow" in JSON tag/
+	Data              []byte `json:"data,inline"` // MATCH /unknown option "inline" in JSON tag/
 }
 
 type RangeAllocation struct {
 	metav1.TypeMeta   `bson:",minsize"`
 	metav1.ObjectMeta `bson:"metadata,omitempty"`
-	Range             string `bson:"range,flow"` // MATCH /unknown option 'flow' in BSON tag/
+	Range             string `bson:"range,flow"` // MATCH /unknown option "flow" in BSON tag/
 	Data              []byte `bson:"data,inline"`
 }
 
@@ -48,8 +48,8 @@ type TestContextSpecificTags2 struct {
 	S       string    `asn1:"tag:0,utf8"`
 	Ints    []int     `asn1:"set"`
 	Version int       `asn1:"optional,explicit,default:0,tag:000"` // MATCH /duplicated tag number 0/
-	Time    time.Time `asn1:"explicit,tag:4,other"`                // MATCH /unknown option 'other' in ASN1 tag/
-	X       int       `asn1:"explicit,tag:invalid"`                // MATCH /ASN1 tag must be a number, got 'invalid'/
+	Time    time.Time `asn1:"explicit,tag:4,other"`                // MATCH /unknown option "other" in ASN1 tag/
+	X       int       `asn1:"explicit,tag:invalid"`                // MATCH /ASN1 tag must be a number, got "invalid"/
 }
 
 type VirtualMachineRelocateSpecDiskLocator struct {
@@ -59,31 +59,31 @@ type VirtualMachineRelocateSpecDiskLocator struct {
 	Datastore       ManagedObjectReference          `xml:"datastore,chardata,innerxml"`
 	DiskMoveType    string                          `xml:"diskMoveType,omitempty,comment"`
 	DiskBackingInfo BaseVirtualDeviceBackingInfo    `xml:"diskBackingInfo,omitempty,any"`
-	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,other"` // MATCH /unknown option 'other' in XML tag/
+	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,other"` // MATCH /unknown option "other" in XML tag/
 }
 
 type TestDuplicatedXMLTags struct {
 	A int `xml:"a"`
-	B int `xml:"a"` // MATCH /duplicate tag name: 'a'/
+	B int `xml:"a"` // MATCH /duplicate tag name: "a"/
 	C int `xml:"c"`
 }
 
 type TestDuplicatedBSONTags struct {
 	A int `bson:"b"`
-	B int `bson:"b"` // MATCH /duplicate tag name: 'b'/
+	B int `bson:"b"` // MATCH /duplicate tag name: "b"/
 	C int `bson:"c"`
 }
 
 type TestDuplicatedYAMLTags struct {
 	A int `yaml:"b"`
 	B int `yaml:"c"`
-	C int `yaml:"c"` // MATCH /duplicate tag name: 'c'/
+	C int `yaml:"c"` // MATCH /duplicate tag name: "c"/
 }
 
 type TestDuplicatedProtobufTags struct {
 	A int `protobuf:"varint,name=b"`
 	B int `protobuf:"varint,name=c"`
-	C int `protobuf:"varint,name=c"` // MATCH /duplicate tag name: 'c'/
+	C int `protobuf:"varint,name=c"` // MATCH /duplicate tag name: "c"/
 }
 
 // test case from
@@ -107,19 +107,75 @@ type HelmChartArgs struct {
 
 // Test message for holding primitive types.
 type Simple struct {
-	OBool                *bool    `protobuf:"varint,1,req,json=oBool"`                           // MATCH /protobuf tag lacks mandatory option 'name'/
-	OInt32               *int32   `protobuf:"varint,2,opt,name=o_int32,jsonx=oInt32"`            // MATCH /unknown option 'jsonx' in protobuf tag/
-	OInt32Str            *int32   `protobuf:"varint,3,rep,name=o_int32_str,name=oInt32Str"`      // MATCH /protobuf tag has duplicated option 'name'/
-	OInt64               *int64   `protobuf:"varint,4,opt,json=oInt64,name=o_int64,json=oInt64"` // MATCH /protobuf tag has duplicated option 'json'/
+	OBool                *bool    `protobuf:"varint,1,req,json=oBool"`                           // MATCH /protobuf tag lacks mandatory option "name"/
+	OInt32               *int32   `protobuf:"varint,2,opt,name=o_int32,jsonx=oInt32"`            // MATCH /unknown option "jsonx" in protobuf tag/
+	OInt32Str            *int32   `protobuf:"varint,3,rep,name=o_int32_str,name=oInt32Str"`      // MATCH /protobuf tag has duplicated option "name"/
+	OInt64               *int64   `protobuf:"varint,4,opt,json=oInt64,name=o_int64,json=oInt64"` // MATCH /protobuf tag has duplicated option "json"/
 	OSint32Str           *int32   `protobuf:"zigzag32,11,opt,name=o_sint32_str,json=oSint32Str"`
-	OSint64Str           *int64   `protobuf:"zigzag64,13,opt,name=o_sint32_str,json=oSint64Str"` // MATCH /duplicate tag name: 'o_sint32_str'/
+	OSint64Str           *int64   `protobuf:"zigzag64,13,opt,name=o_sint32_str,json=oSint64Str"` // MATCH /duplicate tag name: "o_sint32_str"/
 	OFloat               *float32 `protobuf:"fixed32,14,opt,name=o_float,json=oFloat"`
 	ODouble              *float64 `protobuf:"fixed64,014,opt,name=o_double,json=oDouble"`      // MATCH /duplicated tag number 14/
-	ODoubleStr           *float64 `protobuf:"fixed6,17,opt,name=o_double_str,json=oDoubleStr"` // MATCH /invalid protobuf tag name 'fixed6'/
+	ODoubleStr           *float64 `protobuf:"fixed6,17,opt,name=o_double_str,json=oDoubleStr"` // MATCH /invalid protobuf tag name "fixed6"/
 	OString              *string  `protobuf:"bytes,18,opt,name=o_string,json=oString"`
 	OString2             *string  `protobuf:"bytes,name=ameno"`
-	OString3             *string  `protobuf:"bytes,name=ameno"` // MATCH /duplicate tag name: 'ameno'/
+	OString3             *string  `protobuf:"bytes,name=ameno"` // MATCH /duplicate tag name: "ameno"/
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
+}
+
+type RequestQueryOption struct {
+	Properties           []string `url:"properties,comma,omitempty"`
+	CustomProperties     []string `url:"-"`
+	Associations         []string `url:"associations,brackets,omitempty"`
+	Associations2        []string `url:"associations2,semicolon,omitempty"`
+	Associations3        []string `url:"associations3,space,brackets,omitempty"`
+	Associations4        []string `url:"associations4,numbered,omitempty"`
+	Associations5        []string `url:"associations5,space,semicolon,omitempty"` // MATCH /can not set both "semicolon" and "space" as delimiters in URL tag/
+	PaginateAssociations bool     `url:"paginateAssociations,int,omitempty"`
+	Archived             bool     `url:"archived,myURLOption"` // MATCH /unknown option "myURLOption" in URL tag/
+	IDProperty           string   `url:"idProperty,omitempty"`
+}
+
+type Fields struct {
+	Field      string `datastore:",noindex,flatten,omitempty"`
+	OtherField string `datastore:",unknownOption"` // MATCH /unknown option "unknownOption" in Datastore tag/
+}
+
+type MapStruct struct {
+	Field1     string `mapstructure:",squash,reminder,omitempty"`
+	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option "unknownOption" in Mapstructure tag/
+}
+
+type ValidateUser struct {
+	Username    string `validate:"required,min=3,max=32"`
+	Email       string `validate:"required,email"`
+	Password    string `validate:"required,min=8,max=32"`
+	Biography   string `validate:"min=0,max=1000"`
+	DisplayName string `validate:"displayName,min=3,max=32"` // MATCH /unknown option "displayName" in validate tag/
+	Complex     string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,required"`
+	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option "keys" must follow a "dive" option in validate tag/
+	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option "endkeys" without a previous "keys" option in validate tag/
+	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option "endkeys" without a previous "keys" option in validate tag/
+}
+
+type TomlUser struct {
+	Username string `toml:"username,omitempty"`
+	Location string `toml:"location,unknown"` // MATCH /unknown option "unknown" in TOML tag/
+}
+
+type PropertiesTags struct {
+	Field int               `properties:"-"`
+	Field int               `properties:"myName"`
+	Field int               `properties:"myName,default=15"`
+	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch/
+	Field int               `properties:",default:15"`            // MATCH /malformed default for properties tag/
+	Field int               `properties:",default=15,default=2"`  // MATCH /properties tag accepts only one default option/
+	Field time.Time         `properties:"date,layout=2006-01-02"`
+	Field time.Time         `properties:",layout=2006-01-02"`
+	Field time.Time         `properties:"date,layout"`            // MATCH /malformed layout option for properties tag/
+	Field time.Time         `properties:"date,layout=  "`         // MATCH /malformed layout option for properties tag/
+	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time/
+	Field []string          `properties:",default=a;b;c"`
+	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown option "omitempty" in properties tag/
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -6,17 +6,17 @@ type decodeAndValidateRequest struct {
 	// BEAWRE : the flag of URLParam should match the const string URLParam
 	URLParam    string `json:"-" path:"url_param" validate:"numeric"`
 	Text        string `json:"text" validate:"max=10"`
-	DefaultInt  int    `json:"defaultInt" default:"10.0"` // MATCH /field's type and default value's type mismatch/
+	DefaultInt  int    `json:"defaultInt" default:"10.0"` // MATCH /field type and default value type mismatch/
 	DefaultInt2 int    `json:"defaultInt2" default:"10"`
-	// MATCH:12 /unknown option 'inline' in JSON tag/
-	DefaultInt3      int             `json:"defaultInt2,inline" default:"11"` // MATCH /duplicate tag name: 'defaultInt2'/
+	// MATCH:12 /unknown option "inline" in JSON tag/
+	DefaultInt3      int             `json:"defaultInt2,inline" default:"11"` // MATCH /duplicate tag name: "defaultInt2"/
 	DefaultString    string          `json:"defaultString" default:"foo"`
-	DefaultBool      bool            `json:"defaultBool" default:"trues"` // MATCH /field's type and default value's type mismatch/
+	DefaultBool      bool            `json:"defaultBool" default:"trues"` // MATCH /field type and default value type mismatch/
 	DefaultBool2     bool            `json:"defaultBool2" default:"true"`
 	DefaultBool3     bool            `json:"defaultBool3" default:"false"`
-	DefaultFloat     float64         `json:"defaultFloat" default:"f10.0"` // MATCH /field's type and default value's type mismatch/
+	DefaultFloat     float64         `json:"defaultFloat" default:"f10.0"` // MATCH /field type and default value type mismatch/
 	DefaultFloat2    float64         `json:"defaultFloat2" default:"10.0"`
-	MandatoryStruct  mandatoryStruct `json:"mandatoryStruct" required:"trues"` // MATCH /required should be 'true' or 'false'/
+	MandatoryStruct  mandatoryStruct `json:"mandatoryStruct" required:"trues"` // MATCH /required should be "true" or "false"/
 	MandatoryStruct2 mandatoryStruct `json:"mandatoryStruct2" required:"true"`
 	MandatoryStruct4 mandatoryStruct `json:"mandatoryStruct4" required:"false"`
 	OptionalStruct   *optionalStruct `json:"optionalStruct,omitempty"`
@@ -25,20 +25,20 @@ type decodeAndValidateRequest struct {
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
 	Tiret       string `json:"-,"`
 	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in JSON tag/
-	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /unknown option 'omitzero' in JSON tag/
+	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /unknown option "omitzero" in JSON tag/
 }
 
 type RangeAllocation struct {
-	metav1.TypeMeta   `json:",inline"` // MATCH /unknown option 'inline' in JSON tag/
+	metav1.TypeMeta   `json:",inline"` // MATCH /unknown option "inline" in JSON tag/
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Range             string `json:"range,flow"`  // MATCH /unknown option 'flow' in JSON tag/
-	Data              []byte `json:"data,inline"` // MATCH /unknown option 'inline' in JSON tag/
+	Range             string `json:"range,flow"`  // MATCH /unknown option "flow" in JSON tag/
+	Data              []byte `json:"data,inline"` // MATCH /unknown option "inline" in JSON tag/
 }
 
 type RangeAllocation struct {
 	metav1.TypeMeta   `bson:",minsize"`
 	metav1.ObjectMeta `bson:"metadata,omitempty"`
-	Range             string `bson:"range,flow"` // MATCH /unknown option 'flow' in BSON tag/
+	Range             string `bson:"range,flow"` // MATCH /unknown option "flow" in BSON tag/
 	Data              []byte `bson:"data,inline"`
 }
 
@@ -48,8 +48,8 @@ type TestContextSpecificTags2 struct {
 	S       string    `asn1:"tag:0,utf8"`
 	Ints    []int     `asn1:"set"`
 	Version int       `asn1:"optional,explicit,default:0,tag:000"` // MATCH /duplicated tag number 0/
-	Time    time.Time `asn1:"explicit,tag:4,other"`                // MATCH /unknown option 'other' in ASN1 tag/
-	X       int       `asn1:"explicit,tag:invalid"`                // MATCH /ASN1 tag must be a number, got 'invalid'/
+	Time    time.Time `asn1:"explicit,tag:4,other"`                // MATCH /unknown option "other" in ASN1 tag/
+	X       int       `asn1:"explicit,tag:invalid"`                // MATCH /ASN1 tag must be a number, got "invalid"/
 }
 
 type VirtualMachineRelocateSpecDiskLocator struct {
@@ -59,31 +59,31 @@ type VirtualMachineRelocateSpecDiskLocator struct {
 	Datastore       ManagedObjectReference          `xml:"datastore,chardata,innerxml"`
 	DiskMoveType    string                          `xml:"diskMoveType,omitempty,comment"`
 	DiskBackingInfo BaseVirtualDeviceBackingInfo    `xml:"diskBackingInfo,omitempty,any"`
-	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,other"` // MATCH /unknown option 'other' in XML tag/
+	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,other"` // MATCH /unknown option "other" in XML tag/
 }
 
 type TestDuplicatedXMLTags struct {
 	A int `xml:"a"`
-	B int `xml:"a"` // MATCH /duplicate tag name: 'a'/
+	B int `xml:"a"` // MATCH /duplicate tag name: "a"/
 	C int `xml:"c"`
 }
 
 type TestDuplicatedBSONTags struct {
 	A int `bson:"b"`
-	B int `bson:"b"` // MATCH /duplicate tag name: 'b'/
+	B int `bson:"b"` // MATCH /duplicate tag name: "b"/
 	C int `bson:"c"`
 }
 
 type TestDuplicatedYAMLTags struct {
 	A int `yaml:"b"`
 	B int `yaml:"c"`
-	C int `yaml:"c"` // MATCH /duplicate tag name: 'c'/
+	C int `yaml:"c"` // MATCH /duplicate tag name: "c"/
 }
 
 type TestDuplicatedProtobufTags struct {
 	A int `protobuf:"varint,name=b"`
 	B int `protobuf:"varint,name=c"`
-	C int `protobuf:"varint,name=c"` // MATCH /duplicate tag name: 'c'/
+	C int `protobuf:"varint,name=c"` // MATCH /duplicate tag name: "c"/
 }
 
 // test case from
@@ -107,18 +107,18 @@ type HelmChartArgs struct {
 
 // Test message for holding primitive types.
 type Simple struct {
-	OBool                *bool    `protobuf:"varint,1,req,json=oBool"`                           // MATCH /protobuf tag lacks mandatory option 'name'/
-	OInt32               *int32   `protobuf:"varint,2,opt,name=o_int32,jsonx=oInt32"`            // MATCH /unknown option 'jsonx' in protobuf tag/
-	OInt32Str            *int32   `protobuf:"varint,3,rep,name=o_int32_str,name=oInt32Str"`      // MATCH /protobuf tag has duplicated option 'name'/
-	OInt64               *int64   `protobuf:"varint,4,opt,json=oInt64,name=o_int64,json=oInt64"` // MATCH /protobuf tag has duplicated option 'json'/
+	OBool                *bool    `protobuf:"varint,1,req,json=oBool"`                           // MATCH /protobuf tag lacks mandatory option "name"/
+	OInt32               *int32   `protobuf:"varint,2,opt,name=o_int32,jsonx=oInt32"`            // MATCH /unknown option "jsonx" in protobuf tag/
+	OInt32Str            *int32   `protobuf:"varint,3,rep,name=o_int32_str,name=oInt32Str"`      // MATCH /protobuf tag has duplicated option "name"/
+	OInt64               *int64   `protobuf:"varint,4,opt,json=oInt64,name=o_int64,json=oInt64"` // MATCH /protobuf tag has duplicated option "json"/
 	OSint32Str           *int32   `protobuf:"zigzag32,11,opt,name=o_sint32_str,json=oSint32Str"`
-	OSint64Str           *int64   `protobuf:"zigzag64,13,opt,name=o_sint32_str,json=oSint64Str"` // MATCH /duplicate tag name: 'o_sint32_str'/
+	OSint64Str           *int64   `protobuf:"zigzag64,13,opt,name=o_sint32_str,json=oSint64Str"` // MATCH /duplicate tag name: "o_sint32_str"/
 	OFloat               *float32 `protobuf:"fixed32,14,opt,name=o_float,json=oFloat"`
 	ODouble              *float64 `protobuf:"fixed64,014,opt,name=o_double,json=oDouble"`      // MATCH /duplicated tag number 14/
-	ODoubleStr           *float64 `protobuf:"fixed6,17,opt,name=o_double_str,json=oDoubleStr"` // MATCH /invalid protobuf tag name 'fixed6'/
+	ODoubleStr           *float64 `protobuf:"fixed6,17,opt,name=o_double_str,json=oDoubleStr"` // MATCH /invalid protobuf tag name "fixed6"/
 	OString              *string  `protobuf:"bytes,18,opt,name=o_string,json=oString"`
 	OString2             *string  `protobuf:"bytes,name=ameno"`
-	OString3             *string  `protobuf:"bytes,name=ameno"` // MATCH /duplicate tag name: 'ameno'/
+	OString3             *string  `protobuf:"bytes,name=ameno"` // MATCH /duplicate tag name: "ameno"/
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -131,20 +131,20 @@ type RequestQueryOption struct {
 	Associations2        []string `url:"associations2,semicolon,omitempty"`
 	Associations3        []string `url:"associations3,space,brackets,omitempty"`
 	Associations4        []string `url:"associations4,numbered,omitempty"`
-	Associations5        []string `url:"associations5,space,semicolon,omitempty"` // MATCH /can not set both 'semicolon' and 'space' as delimiters in URL tag/
+	Associations5        []string `url:"associations5,space,semicolon,omitempty"` // MATCH /can not set both "semicolon" and "space" as delimiters in URL tag/
 	PaginateAssociations bool     `url:"paginateAssociations,int,omitempty"`
-	Archived             bool     `url:"archived,myURLOption"` // MATCH /unknown option 'myURLOption' in URL tag/
+	Archived             bool     `url:"archived,myURLOption"` // MATCH /unknown option "myURLOption" in URL tag/
 	IDProperty           string   `url:"idProperty,omitempty"`
 }
 
 type Fields struct {
 	Field      string `datastore:",noindex,flatten,omitempty"`
-	OtherField string `datastore:",unknownOption"` // MATCH /unknown option 'unknownOption' in Datastore tag/
+	OtherField string `datastore:",unknownOption"` // MATCH /unknown option "unknownOption" in Datastore tag/
 }
 
 type MapStruct struct {
 	Field1     string `mapstructure:",squash,reminder,omitempty"`
-	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option 'unknownOption' in Mapstructure tag/
+	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option "unknownOption" in Mapstructure tag/
 }
 
 type ValidateUser struct {
@@ -152,16 +152,16 @@ type ValidateUser struct {
 	Email       string `validate:"required,email"`
 	Password    string `validate:"required,min=8,max=32"`
 	Biography   string `validate:"min=0,max=1000"`
-	DisplayName string `validate:"displayName,min=3,max=32"` // MATCH /unknown option 'displayName' in validate tag/
+	DisplayName string `validate:"displayName,min=3,max=32"` // MATCH /unknown option "displayName" in validate tag/
 	Complex     string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,required"`
-	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option 'keys' must follow a 'dive' option in validate tag/
-	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option 'endkeys' without a previous 'keys' option in validate tag/
-	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option 'endkeys' without a previous 'keys' option in validate tag/
+	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option "keys" must follow a "dive" option in validate tag/
+	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option "endkeys" without a previous "keys" option in validate tag/
+	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option "endkeys" without a previous "keys" option in validate tag/
 }
 
 type TomlUser struct {
 	Username string `toml:"username,omitempty"`
-	Location string `toml:"location,unknown"` // MATCH /unknown option 'unknown' in TOML tag/
+	Location string `toml:"location,unknown"` // MATCH /unknown option "unknown" in TOML tag/
 }
 
 type PropertiesTags struct {

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -6,17 +6,17 @@ type decodeAndValidateRequest struct {
 	// BEAWRE : the flag of URLParam should match the const string URLParam
 	URLParam    string `json:"-" path:"url_param" validate:"numeric"`
 	Text        string `json:"text" validate:"max=10"`
-	DefaultInt  int    `json:"defaultInt" default:"10.0"` // MATCH /field type and default value type mismatch/
+	DefaultInt  int    `json:"defaultInt" default:"10.0"` // MATCH /type mismatch between field type and default value type in default tag/
 	DefaultInt2 int    `json:"defaultInt2" default:"10"`
-	// MATCH:12 /unknown option "inline" in JSON tag/
-	DefaultInt3      int             `json:"defaultInt2,inline" default:"11"` // MATCH /duplicate tag name: "defaultInt2"/
+	// MATCH:12 /unknown option "inline" in json tag/
+	DefaultInt3      int             `json:"defaultInt2,inline" default:"11"` // MATCH /duplicated tag name "defaultInt2" in json tag/
 	DefaultString    string          `json:"defaultString" default:"foo"`
-	DefaultBool      bool            `json:"defaultBool" default:"trues"` // MATCH /field type and default value type mismatch/
+	DefaultBool      bool            `json:"defaultBool" default:"trues"` // MATCH /type mismatch between field type and default value type in default tag/
 	DefaultBool2     bool            `json:"defaultBool2" default:"true"`
 	DefaultBool3     bool            `json:"defaultBool3" default:"false"`
-	DefaultFloat     float64         `json:"defaultFloat" default:"f10.0"` // MATCH /field type and default value type mismatch/
+	DefaultFloat     float64         `json:"defaultFloat" default:"f10.0"` // MATCH /type mismatch between field type and default value type in default tag/
 	DefaultFloat2    float64         `json:"defaultFloat2" default:"10.0"`
-	MandatoryStruct  mandatoryStruct `json:"mandatoryStruct" required:"trues"` // MATCH /required should be "true" or "false"/
+	MandatoryStruct  mandatoryStruct `json:"mandatoryStruct" required:"trues"` // MATCH /required should be "true" or "false" in required tag/
 	MandatoryStruct2 mandatoryStruct `json:"mandatoryStruct2" required:"true"`
 	MandatoryStruct4 mandatoryStruct `json:"mandatoryStruct4" required:"false"`
 	OptionalStruct   *optionalStruct `json:"optionalStruct,omitempty"`
@@ -24,21 +24,23 @@ type decodeAndValidateRequest struct {
 	optionalQuery    string          `json:"-" querystring:"queryfoo"` // MATCH /tag on not-exported field optionalQuery/
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
 	Tiret       string `json:"-,"`
-	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in JSON tag/
-	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /unknown option "omitzero" in JSON tag/
+	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in json tag/
+	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /unknown option "omitzero" in json tag/
+	// MATCH:30 /option can not be empty in json tag/
+	BadTiret string `json:"other,"` // MATCH /duplicated tag name "other" in json tag/
 }
 
 type RangeAllocation struct {
-	metav1.TypeMeta   `json:",inline"` // MATCH /unknown option "inline" in JSON tag/
+	metav1.TypeMeta   `json:",inline"` // MATCH /unknown option "inline" in json tag/
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Range             string `json:"range,flow"`  // MATCH /unknown option "flow" in JSON tag/
-	Data              []byte `json:"data,inline"` // MATCH /unknown option "inline" in JSON tag/
+	Range             string `json:"range,flow"`  // MATCH /unknown option "flow" in json tag/
+	Data              []byte `json:"data,inline"` // MATCH /unknown option "inline" in json tag/
 }
 
 type RangeAllocation struct {
 	metav1.TypeMeta   `bson:",minsize"`
 	metav1.ObjectMeta `bson:"metadata,omitempty"`
-	Range             string `bson:"range,flow"` // MATCH /unknown option "flow" in BSON tag/
+	Range             string `bson:"range,flow"` // MATCH /unknown option "flow" in bson tag/
 	Data              []byte `bson:"data,inline"`
 }
 
@@ -47,9 +49,9 @@ type TestContextSpecificTags2 struct {
 	B       int       `asn1:"tag:2"`
 	S       string    `asn1:"tag:0,utf8"`
 	Ints    []int     `asn1:"set"`
-	Version int       `asn1:"optional,explicit,default:0,tag:000"` // MATCH /duplicated tag number 0/
-	Time    time.Time `asn1:"explicit,tag:4,other"`                // MATCH /unknown option "other" in ASN1 tag/
-	X       int       `asn1:"explicit,tag:invalid"`                // MATCH /ASN1 tag must be a number, got "invalid"/
+	Version int       `asn1:"optional,explicit,default:0,tag:000"` // MATCH /duplicated tag number 0 in asn1 tag/
+	Time    time.Time `asn1:"explicit,tag:4,other"`                // MATCH /unknown option "other" in asn1 tag/
+	X       int       `asn1:"explicit,tag:invalid"`                // MATCH /tag must be a number but is "invalid" in asn1 tag/
 }
 
 type VirtualMachineRelocateSpecDiskLocator struct {
@@ -59,31 +61,31 @@ type VirtualMachineRelocateSpecDiskLocator struct {
 	Datastore       ManagedObjectReference          `xml:"datastore,chardata,innerxml"`
 	DiskMoveType    string                          `xml:"diskMoveType,omitempty,comment"`
 	DiskBackingInfo BaseVirtualDeviceBackingInfo    `xml:"diskBackingInfo,omitempty,any"`
-	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,other"` // MATCH /unknown option "other" in XML tag/
+	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,other"` // MATCH /unknown option "other" in xml tag/
 }
 
-type TestDuplicatedXMLTags struct {
+type TestDuplicatedxmlTags struct {
 	A int `xml:"a"`
-	B int `xml:"a"` // MATCH /duplicate tag name: "a"/
+	B int `xml:"a"` // MATCH /duplicated tag name "a" in xml tag/
 	C int `xml:"c"`
 }
 
-type TestDuplicatedBSONTags struct {
+type TestDuplicatedbsonTags struct {
 	A int `bson:"b"`
-	B int `bson:"b"` // MATCH /duplicate tag name: "b"/
+	B int `bson:"b"` // MATCH /duplicated tag name "b" in bson tag/
 	C int `bson:"c"`
 }
 
 type TestDuplicatedYAMLTags struct {
 	A int `yaml:"b"`
 	B int `yaml:"c"`
-	C int `yaml:"c"` // MATCH /duplicate tag name: "c"/
+	C int `yaml:"c"` // MATCH /duplicated tag name "c" in yaml tag/
 }
 
 type TestDuplicatedProtobufTags struct {
 	A int `protobuf:"varint,name=b"`
 	B int `protobuf:"varint,name=c"`
-	C int `protobuf:"varint,name=c"` // MATCH /duplicate tag name: "c"/
+	C int `protobuf:"varint,name=c"` // MATCH /duplicated tag name "c" in protobuf tag/
 }
 
 // test case from
@@ -107,18 +109,18 @@ type HelmChartArgs struct {
 
 // Test message for holding primitive types.
 type Simple struct {
-	OBool                *bool    `protobuf:"varint,1,req,json=oBool"`                           // MATCH /protobuf tag lacks mandatory option "name"/
+	OBool                *bool    `protobuf:"varint,1,req,json=oBool"`                           // MATCH /mandatory option "name" not found in protobuf tag/
 	OInt32               *int32   `protobuf:"varint,2,opt,name=o_int32,jsonx=oInt32"`            // MATCH /unknown option "jsonx" in protobuf tag/
-	OInt32Str            *int32   `protobuf:"varint,3,rep,name=o_int32_str,name=oInt32Str"`      // MATCH /protobuf tag has duplicated option "name"/
-	OInt64               *int64   `protobuf:"varint,4,opt,json=oInt64,name=o_int64,json=oInt64"` // MATCH /protobuf tag has duplicated option "json"/
+	OInt32Str            *int32   `protobuf:"varint,3,rep,name=o_int32_str,name=oInt32Str"`      // MATCH /duplicated option "name" in protobuf tag/
+	OInt64               *int64   `protobuf:"varint,4,opt,json=oInt64,name=o_int64,json=oInt64"` // MATCH /duplicated option "json" in protobuf tag/
 	OSint32Str           *int32   `protobuf:"zigzag32,11,opt,name=o_sint32_str,json=oSint32Str"`
-	OSint64Str           *int64   `protobuf:"zigzag64,13,opt,name=o_sint32_str,json=oSint64Str"` // MATCH /duplicate tag name: "o_sint32_str"/
+	OSint64Str           *int64   `protobuf:"zigzag64,13,opt,name=o_sint32_str,json=oSint64Str"` // MATCH /duplicated tag name "o_sint32_str" in protobuf tag/
 	OFloat               *float32 `protobuf:"fixed32,14,opt,name=o_float,json=oFloat"`
-	ODouble              *float64 `protobuf:"fixed64,014,opt,name=o_double,json=oDouble"`      // MATCH /duplicated tag number 14/
-	ODoubleStr           *float64 `protobuf:"fixed6,17,opt,name=o_double_str,json=oDoubleStr"` // MATCH /invalid protobuf tag name "fixed6"/
+	ODouble              *float64 `protobuf:"fixed64,014,opt,name=o_double,json=oDouble"`      // MATCH /duplicated tag number 14 in protobuf tag/
+	ODoubleStr           *float64 `protobuf:"fixed6,17,opt,name=o_double_str,json=oDoubleStr"` // MATCH /invalid tag name "fixed6" in protobuf tag/
 	OString              *string  `protobuf:"bytes,18,opt,name=o_string,json=oString"`
 	OString2             *string  `protobuf:"bytes,name=ameno"`
-	OString3             *string  `protobuf:"bytes,name=ameno"` // MATCH /duplicate tag name: "ameno"/
+	OString3             *string  `protobuf:"bytes,name=ameno"` // MATCH /duplicated tag name "ameno" in protobuf tag/
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -131,20 +133,20 @@ type RequestQueryOption struct {
 	Associations2        []string `url:"associations2,semicolon,omitempty"`
 	Associations3        []string `url:"associations3,space,brackets,omitempty"`
 	Associations4        []string `url:"associations4,numbered,omitempty"`
-	Associations5        []string `url:"associations5,space,semicolon,omitempty"` // MATCH /can not set both "semicolon" and "space" as delimiters in URL tag/
+	Associations5        []string `url:"associations5,space,semicolon,omitempty"` // MATCH /can not set both "semicolon" and "space" as delimiters in url tag/
 	PaginateAssociations bool     `url:"paginateAssociations,int,omitempty"`
-	Archived             bool     `url:"archived,myURLOption"` // MATCH /unknown option "myURLOption" in URL tag/
+	Archived             bool     `url:"archived,myURLOption"` // MATCH /unknown option "myURLOption" in url tag/
 	IDProperty           string   `url:"idProperty,omitempty"`
 }
 
 type Fields struct {
 	Field      string `datastore:",noindex,flatten,omitempty"`
-	OtherField string `datastore:",unknownOption"` // MATCH /unknown option "unknownOption" in Datastore tag/
+	OtherField string `datastore:",unknownOption"` // MATCH /unknown option "unknownOption" in datastore tag/
 }
 
 type MapStruct struct {
 	Field1     string `mapstructure:",squash,reminder,omitempty"`
-	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option "unknownOption" in Mapstructure tag/
+	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option "unknownOption" in mapstructure tag/
 }
 
 type ValidateUser struct {
@@ -161,21 +163,21 @@ type ValidateUser struct {
 
 type TomlUser struct {
 	Username string `toml:"username,omitempty"`
-	Location string `toml:"location,unknown"` // MATCH /unknown option "unknown" in TOML tag/
+	Location string `toml:"location,unknown"` // MATCH /unknown option "unknown" in toml tag/
 }
 
 type PropertiesTags struct {
 	Field int               `properties:"-"`
 	Field int               `properties:"myName"`
 	Field int               `properties:"myName,default=15"`
-	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch/
+	Field int               `properties:"myName,default=sString"` // MATCH /type mismatch between field type and default value type in properties tag/
 	Field int               `properties:",default:15"`            // MATCH /unknown or malformed option "default:15" in properties tag/
 	Field int               `properties:",default=15,default=2"`  // MATCH /duplicated option "default" in properties tag/
 	Field time.Time         `properties:"date,layout=2006-01-02"`
 	Field time.Time         `properties:",layout=2006-01-02"`
 	Field time.Time         `properties:"date,layout"`            // MATCH /unknown or malformed option "layout" in properties tag/
-	Field time.Time         `properties:"date,layout=  "`         // MATCH /expected option "layout" to be of the form layout=value in properties tag/
-	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time/
+	Field time.Time         `properties:"date,layout=  "`         // MATCH /option "layout" not of the form layout=value in properties tag/
+	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time in properties tag/
 	Field []string          `properties:",default=a;b;c"`
 	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown or malformed option "omitempty" in properties tag/
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -25,7 +25,7 @@ type decodeAndValidateRequest struct {
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
 	Tiret       string `json:"-,"`
 	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in json tag/
-	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /unknown option "omitzero" in json tag/
+	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /prior Go 1.24, option "omitzero" is unsupported in json tag/
 	// MATCH:30 /option can not be empty in json tag/
 	BadTiret string `json:"other,"` // MATCH /duplicated tag name "other" in json tag/
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -168,14 +168,14 @@ type PropertiesTags struct {
 	Field int               `properties:"-"`
 	Field int               `properties:"myName"`
 	Field int               `properties:"myName,default=15"`
-	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch in properties tag/
-	Field int               `properties:",default:15"`            // MATCH /unknown option "default:15" in properties tag/
-	Field int               `properties:",default=15,default=2"`  // MATCH /properties tag accepts only one default option/
+	Field int               `properties:"myName,default=sString"` // MATCH /field type and default value type mismatch/
+	Field int               `properties:",default:15"`            // MATCH /unknown or malformed option "default:15" in properties tag/
+	Field int               `properties:",default=15,default=2"`  // MATCH /duplicated option "default" in properties tag/
 	Field time.Time         `properties:"date,layout=2006-01-02"`
 	Field time.Time         `properties:",layout=2006-01-02"`
-	Field time.Time         `properties:"date,layout"`            // MATCH /malformed layout option for properties tag/
-	Field time.Time         `properties:"date,layout=  "`         // MATCH /malformed layout option for properties tag/
-	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time in properties tag/
+	Field time.Time         `properties:"date,layout"`            // MATCH /unknown or malformed option "layout" in properties tag/
+	Field time.Time         `properties:"date,layout=  "`         // MATCH /expected option "layout" to be of the form layout=value in properties tag/
+	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time/
 	Field []string          `properties:",default=a;b;c"`
-	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown option "omitempty" in properties tag/
+	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown or malformed option "omitempty" in properties tag/
 }

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -4,30 +4,30 @@ type RangeAllocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Range             string `json:"range,outline"`
-	Data              []byte `json:"data,flow"` // MATCH /unknown option "flow" in JSON tag/
+	Data              []byte `json:"data,flow"` // MATCH /unknown option "flow" in json tag/
 }
 
 type RangeAllocation struct {
 	metav1.TypeMeta   `bson:",minsize,gnu"`
 	metav1.ObjectMeta `bson:"metadata,omitempty"`
-	Range             string `bson:"range,flow"` // MATCH /unknown option "flow" in BSON tag/
+	Range             string `bson:"range,flow"` // MATCH /unknown option "flow" in bson tag/
 	Data              []byte `bson:"data,inline"`
 }
 
 type RequestQueryOptions struct {
-	Properties       []string `url:"properties,commmma,omitempty"` // MATCH /unknown option "commmma" in URL tag/
+	Properties       []string `url:"properties,commmma,omitempty"` // MATCH /unknown option "commmma" in url tag/
 	CustomProperties []string `url:"-"`
 	Archived         bool     `url:"archived,myURLOption"`
 }
 
 type Fields struct {
 	Field      string `datastore:",noindex,flatten,omitempty,myDatastoreOption"`
-	OtherField string `datastore:",unknownOption"` // MATCH /unknown option "unknownOption" in Datastore tag/
+	OtherField string `datastore:",unknownOption"` // MATCH /unknown option "unknownOption" in datastore tag/
 }
 
 type MapStruct struct {
 	Field1     string `mapstructure:",squash,reminder,omitempty,myMapstructureOption"`
-	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option "unknownOption" in Mapstructure tag/
+	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option "unknownOption" in mapstructure tag/
 }
 
 type ValidateUser struct {

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -4,30 +4,30 @@ type RangeAllocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Range             string `json:"range,outline"`
-	Data              []byte `json:"data,flow"` // MATCH /unknown option 'flow' in JSON tag/
+	Data              []byte `json:"data,flow"` // MATCH /unknown option "flow" in JSON tag/
 }
 
 type RangeAllocation struct {
 	metav1.TypeMeta   `bson:",minsize,gnu"`
 	metav1.ObjectMeta `bson:"metadata,omitempty"`
-	Range             string `bson:"range,flow"` // MATCH /unknown option 'flow' in BSON tag/
+	Range             string `bson:"range,flow"` // MATCH /unknown option "flow" in BSON tag/
 	Data              []byte `bson:"data,inline"`
 }
 
 type RequestQueryOptions struct {
-	Properties       []string `url:"properties,commmma,omitempty"` // MATCH /unknown option 'commmma' in URL tag/
+	Properties       []string `url:"properties,commmma,omitempty"` // MATCH /unknown option "commmma" in URL tag/
 	CustomProperties []string `url:"-"`
 	Archived         bool     `url:"archived,myURLOption"`
 }
 
 type Fields struct {
 	Field      string `datastore:",noindex,flatten,omitempty,myDatastoreOption"`
-	OtherField string `datastore:",unknownOption"` // MATCH /unknown option 'unknownOption' in Datastore tag/
+	OtherField string `datastore:",unknownOption"` // MATCH /unknown option "unknownOption" in Datastore tag/
 }
 
 type MapStruct struct {
 	Field1     string `mapstructure:",squash,reminder,omitempty,myMapstructureOption"`
-	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option 'unknownOption' in Mapstructure tag/
+	OtherField string `mapstructure:",unknownOption"` // MATCH /unknown option "unknownOption" in Mapstructure tag/
 }
 
 type ValidateUser struct {
@@ -37,9 +37,9 @@ type ValidateUser struct {
 	Biography   string `validate:"min=0,max=1000"`
 	DisplayName string `validate:"displayName,min=3,max=32"`
 	Complex     string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,required"`
-	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option 'keys' must follow a 'dive' option in validate tag/
-	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option 'endkeys' without a previous 'keys' option in validate tag/
-	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option 'endkeys' without a previous 'keys' option in validate tag/
+	BadComplex  string `validate:"gt=0,keys,eq=1|eq=2,endkeys,required"`              // MATCH /option "keys" must follow a "dive" option in validate tag/
+	BadComplex2 string `validate:"gt=0,dive,eq=1|eq=2,endkeys,required"`              // MATCH /option "endkeys" without a previous "keys" option in validate tag/
+	BadComplex3 string `validate:"gt=0,dive,keys,eq=1|eq=2,endkeys,endkeys,required"` // MATCH /option "endkeys" without a previous "keys" option in validate tag/
 }
 
 type TomlUser struct {


### PR DESCRIPTION
This PR proposes  a ~full rewriting of the rule `struct-tag` in an attempt to clean-up the implementation.

This PR introduces the following changes:

1. Defines a common signature for tag-checker functions
2. Normalizes failure messages
3. Reduces the implementation complexity of some checks (protobuf, properties, ...)
