### PR TITLE
exported: correctly report deprecation-only comments

### DIFF
--- a/test/exported_test.go
+++ b/test/exported_test.go
@@ -40,3 +40,7 @@ func TestCheckDisablingOnDeclarationTypes(t *testing.T) {
 func TestCheckDirectiveComment(t *testing.T) {
 	testRule(t, "exported_issue_1202", &rule.ExportedRule{}, &lint.RuleConfig{})
 }
+
+func TestCheckDeprecationComment(t *testing.T) {
+	testRule(t, "exported_issue_1231", &rule.ExportedRule{}, &lint.RuleConfig{})
+}

--- a/testdata/exported_issue_1231.go
+++ b/testdata/exported_issue_1231.go
@@ -1,0 +1,46 @@
+package golint
+
+// Deprecated: this is deprecated, use math.PI instead
+const PI = 3.14 // MATCH /exported const PI should have comment or be unexported/
+
+// Deprecated: this is deprecated
+var Buffer []byte // MATCH /exported var Buffer should have comment or be unexported/
+
+// Deprecated: this is deprecated, use min instead
+func Min(a, b int) int { // MATCH /exported function Min should have comment or be unexported/
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Max returns the maximum one of two integers.
+// Deprecated: this is deprecated, use max instead
+func Max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Deprecated: this is deprecated
+type Number float64 // MATCH /exported type Number should have comment or be unexported/
+
+// Name is a type that represents a name.
+type Name string
+
+// Greet returns a greeting for the name.
+func (n Name) Greet() string {
+	return "Hello, " + string(n)
+}
+
+// Deprecated: this is deprecated, use Name.ToString instead
+func (n Name) ToString() string { // MATCH /exported method Name.ToString should have comment or be unexported/
+	return string(n)
+}
+
+// String returns the string representation of the name.
+// Deprecated: this is deprecated, use Name.Greet instead
+func (n Name) String() string {
+	return string(n)
+}


### PR DESCRIPTION
Closes #1231

Fixed the exported rule to correctly handle and exclude deprecation-only comments.

Previously, when only a deprecation comment was present, it incorrectly reported:
`comment on exported type ... should be of the form`; 
now it reports: 
`exported type ... should have comment or be unexported.`