### PR TITLE
fix(unexported-return): add missing TypeCheck call

### DIFF
--- a/rule/unexported_return.go
+++ b/rule/unexported_return.go
@@ -16,6 +16,8 @@ type UnexportedReturnRule struct{}
 func (*UnexportedReturnRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
+	file.Pkg.TypeCheck()
+
 	for _, decl := range file.AST.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok {
@@ -70,7 +72,7 @@ func (*UnexportedReturnRule) Name() string {
 // It is imprecise, and will err on the side of returning true,
 // such as for composite types.
 func exportedType(typ types.Type) bool {
-	switch t := typ.(type) {
+	switch t := types.Unalias(typ).(type) {
 	case *types.Named:
 		obj := t.Obj()
 		switch {


### PR DESCRIPTION
**This PR needs PR #1307.**

The problem of consistency was related to a missing call to `Package.TypeCheck()`.

The `UnexportedReturnRule` calls `Package.TypeOf()`, but this requires the data from `Package.TypeCheck()`: depending on the order of the rule, the data may exist or may not.

I checked the calls to `Package.TypeOf()`, and it is only missing for `unexported-return`.

The bad news is that `unexported-return` is now a part of the [other issue](https://github.com/mgechev/revive/issues/1277) about `Package.TypeCheck()`.
Concretely, it was already a part of this issue as it relies on `Package.TypeOf()`.

The regression comes from [#1170](https://github.com/mgechev/revive/pull/1170/files) (v1.6.0); this explains why the number of issues has increased since the beginning of the year.

Note: I also fixed a problem with a missing call to `types.Unalias()`.

Fixes #1306

Note: numbers have changed (723 -> 722) because I replaced `wc` with `jq` (so no extra empty line).

```console
$ ./revive-bench.sh
722
722
722
722
...
722
722
722
```

<details>
<summary>revive-bench.sh</summary>

```bash
#!/bin/bash -e

for a in {1..1000}; do
    revive -formatter json ./... | jq '. |length'
done

```

</details> 