### PR TITLE
var-name checks each package name only once

### DIFF
--- a/rule/var_naming.go
+++ b/rule/var_naming.go
@@ -44,7 +44,7 @@ type VarNamingRule struct {
 	allowUpperCaseConst   bool                // if true - allows to use UPPER_SOME_NAMES for constants
 	skipPackageNameChecks bool                // check for meaningless and user-defined bad package names
 	extraBadPackageNames  map[string]struct{} // inactive if skipPackageNameChecks is false
-	pkgNameAlreadyChecked set                 // set of packages with reported failure on its name
+	pkgNameAlreadyChecked set                 // set of packages names already checked
 }
 
 // Configure validates the rule configuration, and configures the rule accordingly.

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -90,9 +90,6 @@ func assertFailures(t *testing.T, baseDir string, fi os.FileInfo, src []byte, ru
 	l := lint.New(os.ReadFile, 0)
 
 	ins := parseInstructions(t, filepath.Join(baseDir, fi.Name()), src)
-	if ins == nil {
-		return fmt.Errorf("Test file %v does not have instructions", fi.Name())
-	}
 
 	ps, err := l.Lint([][]string{{filepath.Join(baseDir, fi.Name())}}, rules, lint.Config{
 		Rules: config,

--- a/testdata/golint/a_pkg_with_caps.go
+++ b/testdata/golint/a_pkg_with_caps.go
@@ -1,0 +1,5 @@
+// MixedCaps package name
+// This file must be the first (by lexicographical order) file in the directory
+
+// Package PkgName ...
+package PkgName // MATCH /don't use MixedCaps in package names; PkgName should be pkgname/

--- a/testdata/golint/another_pkg_with_caps.go
+++ b/testdata/golint/another_pkg_with_caps.go
@@ -1,0 +1,6 @@
+// MixedCaps package name
+
+// Package PkgName ...
+package PkgName // var-naming doesn't match because the package name was already checked in a_pkg_with_caps.go
+
+func pkgName() {}

--- a/testdata/golint/pkg_caps.go
+++ b/testdata/golint/pkg_caps.go
@@ -1,4 +1,4 @@
 // MixedCaps package name
 
 // Package PkgName ...
-package PkgName // MATCH /don't use MixedCaps in package name; PkgName should be pkgname/
+package PkgName // MATCH /don't use MixedCaps in package names; PkgName should be pkgname/

--- a/testdata/golint/pkg_caps.go
+++ b/testdata/golint/pkg_caps.go
@@ -1,4 +1,0 @@
-// MixedCaps package name
-
-// Package PkgName ...
-package PkgName // MATCH /don't use MixedCaps in package names; PkgName should be pkgname/

--- a/testdata/golint/var_naming.go
+++ b/testdata/golint/var_naming.go
@@ -1,7 +1,7 @@
 // Test for name linting.
 
-// Package pkg_with_underscores ...
-package pkg_with_underscores // MATCH /don't use an underscore in package name/
+// Package pkg ...
+package pkg // package names checks are tested elesewhere
 
 import (
 	"io"

--- a/testdata/var_naming_skip_package_name_checks_false.go
+++ b/testdata/var_naming_skip_package_name_checks_false.go
@@ -1,3 +1,3 @@
 // should fail if skipPackageNameChecks = false (by default)
 
-package pkg_with_underscores // MATCH /don't use an underscore in package name/
+package pkg_with_underscores // MATCH /don't use underscores in package names/

--- a/testdata/var_naming_skip_package_name_checks_false.go
+++ b/testdata/var_naming_skip_package_name_checks_false.go
@@ -1,3 +1,3 @@
 // should fail if skipPackageNameChecks = false (by default)
 
-package pkg_with_underscores // MATCH /don't use underscores in package names/
+package pkg_with_underscores // MATCH /don't use an underscore in package name/


### PR DESCRIPTION
This PR is related to #1317, more specifically to 
[Generate a single failure per package (instead of one for each file in a package)]( https://github.com/mgechev/revive/pull/1312#pullrequestreview-2770906632)

Here, "check" must be understood as "check package name"

Remarks:
1. The proposed implementation checks only once each package name. This is accomplished by checking source file and keeping a reference to the directory it belongs to; after, no other file in the same directory will be checked.
2. Testing required a trick. Standard test method allows checking only one file at the time thus it is inappropriate to test package-wide checks. On the other side, `var-naming` rule is tested with other `golint`-related rules. These rules are tested differently, by executing all of them in a package-wide environment (defined under `testdata\golint`). This allows to test `var-naming` only fails once per package name. Testsdata files `a_pkg_with_caps.go`  and `another_pkg_with_caps.go` are named in such a way that they are the first and the second files to be analysed: `var-naming` will raise a failure for the first but not for the second even if both have the same package name. The testing machinery required a modification to do not raise an error when a testdata file has no _testing instructions_ (i.e. annotations of the form `// MATCH /.../`) Testing the functionality implemented by this PR requires a test file (`another_pkg_with_caps.go`) without testing instructions.

BTW: the testing machinery might deserve a refactoring to remove unused code (JSON test code for example) and to make it more Go idiomatic.
