### PR TITLE
chore: remove redundant //revive:disable-line

### DIFF
--- a/lint/linter_test.go
+++ b/lint/linter_test.go
@@ -41,7 +41,7 @@ func TestRetrieveModFile(t *testing.T) {
 }
 
 // TestIsGenerated tests isGenerated function.
-func TestIsGenerated(t *testing.T) { //revive:disable-line:exported
+func TestIsGenerated(t *testing.T) {
 	tests := []struct {
 		source    string
 		generated bool

--- a/lint/name_test.go
+++ b/lint/name_test.go
@@ -3,7 +3,7 @@ package lint
 import "testing"
 
 // TestName tests Name function
-func TestName(t *testing.T) { //revive:disable-line:exported
+func TestName(t *testing.T) {
 	tests := []struct {
 		name, want string
 	}{

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -283,7 +283,7 @@ func srcLine(src []byte, p token.Position) string {
 }
 
 // TestLine tests srcLine function
-func TestLine(t *testing.T) { //revive:disable-line:exported
+func TestLine(t *testing.T) {
 	tests := []struct {
 		src    string
 		offset int
@@ -325,7 +325,7 @@ func exportedType(typ types.Type) bool {
 }
 
 // TestExportedType tests exportedType function
-func TestExportedType(t *testing.T) { //revive:disable-line:exported
+func TestExportedType(t *testing.T) {
 	tests := []struct {
 		typString string
 		exp       bool


### PR DESCRIPTION
These directives are not needed and can be removed.