### PR TITLE
Skip test files in 'unexported-return' rule

### DIFF
--- a/rule/unexported_return.go
+++ b/rule/unexported_return.go
@@ -16,6 +16,7 @@ type UnexportedReturnRule struct{}
 func (*UnexportedReturnRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
+	// Skip test files, as their functions are not exported anyway.
 	if file.IsTest() {
 		return nil
 	}

--- a/rule/unexported_return.go
+++ b/rule/unexported_return.go
@@ -16,6 +16,10 @@ type UnexportedReturnRule struct{}
 func (*UnexportedReturnRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
+	if file.IsTest() {
+		return nil
+	}
+
 	file.Pkg.TypeCheck()
 
 	for _, decl := range file.AST.Decls {

--- a/test/unexported_return_test.go
+++ b/test/unexported_return_test.go
@@ -1,0 +1,12 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestUnexportedReturn(t *testing.T) {
+	testRule(t, "unexported_return", &rule.UnexportedReturnRule{})
+	testRule(t, "unexported_return_test", &rule.UnexportedReturnRule{})
+}

--- a/testdata/unexported_return.go
+++ b/testdata/unexported_return.go
@@ -1,0 +1,27 @@
+package fixtures
+
+import "strconv"
+
+type options struct{}
+
+func NewOptions() *options { // MATCH /exported func NewOptions returns unexported type *fixtures.options, which can be annoying to use/
+	return &options{}
+}
+
+type port uint16
+
+func ToPort(s string) (port, bool) { // MATCH /exported func ToPort returns unexported type fixtures.port, which can be annoying to use/
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return port(i), true
+}
+
+type Config struct {
+	p port
+}
+
+func (c *Config) Port() port { // MATCH /exported method Port returns unexported type fixtures.port, which can be annoying to use/
+	return c.p
+}

--- a/testdata/unexported_return_test.go
+++ b/testdata/unexported_return_test.go
@@ -1,0 +1,27 @@
+package fixtures
+
+import "strconv"
+
+type options struct{}
+
+func NewOptions() *options {
+	return &options{}
+}
+
+type port uint16
+
+func ToPort(s string) (port, bool) {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return port(i), true
+}
+
+type Config struct {
+	p port
+}
+
+func (c *Config) Port() port {
+	return c.p
+}


### PR DESCRIPTION
- Adding missing unit tests for `unexported-return`
- Exclude test files in `unexported-return`

Fixes #1343