### PR TITLE
Integrate golangci-lint into CI/CD pipeline

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,9 +45,6 @@ jobs:
       with:
         go-version: stable
 
-    - name: Install revive
-      run: go install
-
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,9 +48,6 @@ jobs:
     - name: Install revive
       run: go install
 
-    - name: Run revive
-      run: revive --config revive.toml ./...
-
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,7 +45,13 @@ jobs:
       with:
         go-version: stable
 
-    - name: golangci-lint
+    - name: Install revive
+      run: go install
+
+    - name: Run revive
+      run: revive --config revive.toml ./...
+
+    - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
         version: v2.1.6

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,4 +48,4 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: latest
+        version: v2.1.6

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -50,3 +50,8 @@ jobs:
 
     - name: Run revive
       run: revive --config revive.toml ./...
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.1.6

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,4 +48,4 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.1.6
+        version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,30 @@
 # Version: v2.0.0
 #
 version: "2"
+
+linters:
+  # some linters are enabled by default
+  # https://golangci-lint.run/usage/linters/
+  #
+  enable:
+    # Vet examines Go source code and reports suspicious constructs.
+    - govet
+
+    # Detects when assignments to existing variables are not used.
+    - ineffassign
+
+    # It's a set of rules from staticcheck. See https://staticcheck.io/
+    - staticcheck
+
+    # Checks Go code for unused constants, variables, functions and types.
+    - unused
+
+  # TODO: Phase in the following
+  disable:
+    # Errcheck is a program for checking for unchecked errors in Go code.
+    - errcheck
+
+  exclusions:
+    rules:
+      - linters: staticcheck
+        text: "SA1019:"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+---
+# golangci-lint configuration file made by @ccoVeille
+# Source: https://github.com/ccoVeille/golangci-lint-config-examples/
+# Author: @ccoVeille
+# License: MIT
+# Variant: 01-defaults
+# Version: v2.0.0
+#
+version: "2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,16 +24,62 @@ linters:
 
     # Checks Go code for unused constants, variables, functions and types.
     - unused
+
+    - revive
  
   disable:
     # TODO: enable errcheck and resolve all errors
     # Errcheck is a program for checking for unchecked errors in Go code.
     - errcheck
 
-    - revive
+  settings:
+    # the following settings should match revive.toml
+    revive:
+      severity: warning
+      confidence: 0.8
 
-  exclusions:
-    rules:
-      - linters: [staticcheck]
-        # SA1019: Using a deprecated function, variable, constant or field
-        text: "SA1019:"
+      rules:
+        - name: bare-return
+        - name: blank-imports
+        - name: comment-spacings
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: deep-exit
+        - name: dot-imports
+        - name: empty-block
+        - name: empty-lines
+        - name: enforce-map-style
+          arguments: ["literal"]
+        - name: enforce-slice-style
+          arguments: ["literal"]
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+        - name: filename-format
+          arguments: ["^[_a-z][_a-z0-9]*\\.go$"]
+        - name: identical-branches
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: line-length-limit
+          arguments: [200]
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: redundant-build-tag
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-naming
+        - name: unexported-return
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: unused-receiver
+        - name: useless-break
+        - name: use-any
+        - name: var-declaration
+        - name: var-naming
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,8 @@ linters:
     - unused
 
     - revive
+
+    - nolintlint
  
   disable:
     # TODO: enable errcheck and resolve all errors

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,33 @@
----
-# golangci-lint configuration file made by @ccoVeille
-# Source: https://github.com/ccoVeille/golangci-lint-config-examples/
-# Author: @ccoVeille
-# License: MIT
-# Variant: 01-defaults
-# Version: v2.0.0
-#
+# This configuration for golangci-lint.
+# See https://golangci-lint.run/usage/configuration/ for details.
+
 version: "2"
 
 linters:
-  # some linters are enabled by default
-  # https://golangci-lint.run/usage/linters/
-  #
+  default: none
   enable:
-    # Vet examines Go source code and reports suspicious constructs.
     - govet
-
-    # Detects when assignments to existing variables are not used.
     - ineffassign
-
-    # It's a set of rules from staticcheck. See https://staticcheck.io/
+    - misspell
+    - nolintlint
+    - revive
     - staticcheck
-
-    # Checks Go code for unused constants, variables, functions and types.
     - unused
 
-    - revive
-
-    - nolintlint
- 
-  disable:
-    # TODO: enable errcheck and resolve all errors
-    # Errcheck is a program for checking for unchecked errors in Go code.
-    - errcheck
-
   settings:
-    # the following settings should match revive.toml
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow
+    nolintlint:
+      allow-unused: true
+      require-explanation: true
+      require-specific: true
+    # The following settings should match revive.toml
     revive:
       severity: warning
       confidence: 0.8
-
       rules:
         - name: bare-return
         - name: blank-imports
@@ -61,6 +49,7 @@ linters:
         - name: errorf
         - name: exported
         - name: filename-format
+          # Override the default pattern to forbid .go files with uppercase letters and dashes.
           arguments: ["^[_a-z][_a-z0-9]*\\.go$"]
         - name: identical-branches
         - name: increment-decrement
@@ -84,4 +73,3 @@ linters:
         - name: use-any
         - name: var-declaration
         - name: var-naming
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,13 +24,16 @@ linters:
 
     # Checks Go code for unused constants, variables, functions and types.
     - unused
-
-  # TODO: Phase in the following
+ 
   disable:
+    # TODO: enable errcheck and resolve all errors
     # Errcheck is a program for checking for unchecked errors in Go code.
     - errcheck
+
+    - revive
 
   exclusions:
     rules:
       - linters: staticcheck
+        # SA1019: Using a deprecated function, variable, constant or field
         text: "SA1019:"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,6 @@ linters:
 
   exclusions:
     rules:
-      - linters: staticcheck
+      - linters: [staticcheck]
         # SA1019: Using a deprecated function, variable, constant or field
         text: "SA1019:"

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -50,7 +50,7 @@ func TestFormatter(t *testing.T) {
 		{
 			formatter: &formatter.Friendly{},
 			want: `
-⚠  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
+⚠  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure
   test.go:2:5
 
 ⚠ 1 problem (0 errors, 1 warning)
@@ -61,15 +61,11 @@ Warnings:
 		},
 		{
 			formatter: &formatter.JSON{},
-			want: `[{"Severity":"warning","Failure":"test failure","RuleName":"rule",` +
-				`"Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},` +
-				`"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`,
+			want:      `[{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`, //nolint:revive // line-length-limit
 		},
 		{
 			formatter: &formatter.NDJSON{},
-			want: `{"Severity":"warning","Failure":"test failure","RuleName":"rule",` +
-				`"Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},` +
-				`"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`,
+			want:      `{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`, //nolint:revive // line-length-limit
 		},
 		{
 			formatter: &formatter.Plain{},
@@ -118,7 +114,7 @@ Warnings:
 			formatter: &formatter.Stylish{},
 			want: `
 test.go
-  (2, 5)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
+  (2, 5)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure
 
 
  ✖ 1 problem (0 errors) (1 warnings)

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -61,11 +61,15 @@ Warnings:
 		},
 		{
 			formatter: &formatter.JSON{},
-			want:      `[{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`,
+			want: `[{"Severity":"warning","Failure":"test failure","RuleName":"rule",` +
+				`"Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},` +
+				`"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`,
 		},
 		{
 			formatter: &formatter.NDJSON{},
-			want:      `{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`,
+			want: `{"Severity":"warning","Failure":"test failure","RuleName":"rule",` +
+				`"Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},` +
+				`"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`,
 		},
 		{
 			formatter: &formatter.Plain{},

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -61,11 +61,11 @@ Warnings:
 		},
 		{
 			formatter: &formatter.JSON{},
-			want:      `[{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`,
+			want:      `[{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`, //nolint:revive // line-length-limit
 		},
 		{
 			formatter: &formatter.NDJSON{},
-			want:      `{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`,
+			want:      `{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`, //nolint:revive // line-length-limit
 		},
 		{
 			formatter: &formatter.Plain{},

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -50,7 +50,7 @@ func TestFormatter(t *testing.T) {
 		{
 			formatter: &formatter.Friendly{},
 			want: `
-⚠  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure
+⚠  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
   test.go:2:5
 
 ⚠ 1 problem (0 errors, 1 warning)
@@ -61,11 +61,11 @@ Warnings:
 		},
 		{
 			formatter: &formatter.JSON{},
-			want:      `[{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`, //nolint:revive // line-length-limit
+			want:      `[{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`,
 		},
 		{
 			formatter: &formatter.NDJSON{},
-			want:      `{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`, //nolint:revive // line-length-limit
+			want:      `{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`,
 		},
 		{
 			formatter: &formatter.Plain{},
@@ -114,7 +114,7 @@ Warnings:
 			formatter: &formatter.Stylish{},
 			want: `
 test.go
-  (2, 5)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure
+  (2, 5)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
 
 
  ✖ 1 problem (0 errors) (1 warnings)

--- a/formatter/friendly.go
+++ b/formatter/friendly.go
@@ -73,7 +73,7 @@ func (f *Friendly) printHeaderRow(sb *strings.Builder, failure lint.Failure, sev
 }
 
 func (*Friendly) printFilePosition(sb *strings.Builder, failure lint.Failure) {
-	sb.WriteString(fmt.Sprintf("  %s:%d:%d", failure.GetFilename(), failure.Position.Start.Line, failure.Position.Start.Column))
+	fmt.Fprintf(sb, "  %s:%d:%d", failure.GetFilename(), failure.Position.Start.Line, failure.Position.Start.Column)
 }
 
 type statEntry struct {

--- a/lint/package.go
+++ b/lint/package.go
@@ -58,9 +58,10 @@ func (p *Package) IsMain() bool {
 	p.Lock()
 	defer p.Unlock()
 
-	if p.main == trueValue {
+	switch p.main {
+	case trueValue:
 		return true
-	} else if p.main == falseValue {
+	case falseValue:
 		return false
 	}
 	for _, f := range p.files {

--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -23,6 +23,7 @@ func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 		funcResults := funcDecl.Type.Results
 
 		// TODO: ast.Object is deprecated
+		//nolint:staticcheck
 		returnIDs := map[*ast.Object]struct{}{}
 		if funcResults != nil {
 			returnIDs = r.extractReturnIDs(funcResults.List)
@@ -35,8 +36,9 @@ func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 		fl := &lintFunctionForDataRaces{
 			onFailure: onFailure,
 			returnIDs: returnIDs,
-			rangeIDs:  map[*ast.Object]struct{}{}, // TODO: ast.Object is deprecated
-			go122for:  isGo122,
+			//nolint:staticcheck
+			rangeIDs: map[*ast.Object]struct{}{}, // TODO: ast.Object is deprecated
+			go122for: isGo122,
 		}
 
 		ast.Walk(fl, funcDecl.Body)
@@ -51,6 +53,8 @@ func (*DataRaceRule) Name() string {
 }
 
 // TODO: ast.Object is deprecated
+//
+//nolint:staticcheck
 func (*DataRaceRule) extractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
 	r := map[*ast.Object]struct{}{}
 	for _, f := range fields {
@@ -65,8 +69,10 @@ func (*DataRaceRule) extractReturnIDs(fields []*ast.Field) map[*ast.Object]struc
 type lintFunctionForDataRaces struct {
 	_         struct{}
 	onFailure func(failure lint.Failure)
+	//nolint:staticcheck
 	returnIDs map[*ast.Object]struct{} // TODO: ast.Object is deprecated
-	rangeIDs  map[*ast.Object]struct{} // TODO: ast.Object is deprecated
+	//nolint:staticcheck
+	rangeIDs map[*ast.Object]struct{} // TODO: ast.Object is deprecated
 
 	go122for bool
 }

--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -35,9 +35,8 @@ func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 		fl := &lintFunctionForDataRaces{
 			onFailure: onFailure,
 			returnIDs: returnIDs,
-			//nolint:staticcheck // TODO: ast.Object is deprecated
-			rangeIDs: map[*ast.Object]struct{}{},
-			go122for: isGo122,
+			rangeIDs:  map[*ast.Object]struct{}{}, //nolint:staticcheck // TODO: ast.Object is deprecated
+			go122for:  isGo122,
 		}
 
 		ast.Walk(fl, funcDecl.Body)
@@ -63,12 +62,11 @@ func (*DataRaceRule) extractReturnIDs(fields []*ast.Field) map[*ast.Object]struc
 	return r
 }
 
-//nolint:staticcheck // TODO: ast.Object is deprecated
 type lintFunctionForDataRaces struct {
 	_         struct{}
 	onFailure func(failure lint.Failure)
-	returnIDs map[*ast.Object]struct{}
-	rangeIDs  map[*ast.Object]struct{}
+	returnIDs map[*ast.Object]struct{} //nolint:staticcheck // TODO: ast.Object is deprecated
+	rangeIDs  map[*ast.Object]struct{} //nolint:staticcheck // TODO: ast.Object is deprecated
 
 	go122for bool
 }

--- a/rule/datarace.go
+++ b/rule/datarace.go
@@ -22,8 +22,7 @@ func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 
 		funcResults := funcDecl.Type.Results
 
-		// TODO: ast.Object is deprecated
-		//nolint:staticcheck
+		//nolint:staticcheck // TODO: ast.Object is deprecated
 		returnIDs := map[*ast.Object]struct{}{}
 		if funcResults != nil {
 			returnIDs = r.extractReturnIDs(funcResults.List)
@@ -36,8 +35,8 @@ func (r *DataRaceRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 		fl := &lintFunctionForDataRaces{
 			onFailure: onFailure,
 			returnIDs: returnIDs,
-			//nolint:staticcheck
-			rangeIDs: map[*ast.Object]struct{}{}, // TODO: ast.Object is deprecated
+			//nolint:staticcheck // TODO: ast.Object is deprecated
+			rangeIDs: map[*ast.Object]struct{}{},
 			go122for: isGo122,
 		}
 
@@ -52,9 +51,7 @@ func (*DataRaceRule) Name() string {
 	return "datarace"
 }
 
-// TODO: ast.Object is deprecated
-//
-//nolint:staticcheck
+//nolint:staticcheck // TODO: ast.Object is deprecated
 func (*DataRaceRule) extractReturnIDs(fields []*ast.Field) map[*ast.Object]struct{} {
 	r := map[*ast.Object]struct{}{}
 	for _, f := range fields {
@@ -66,13 +63,12 @@ func (*DataRaceRule) extractReturnIDs(fields []*ast.Field) map[*ast.Object]struc
 	return r
 }
 
+//nolint:staticcheck // TODO: ast.Object is deprecated
 type lintFunctionForDataRaces struct {
 	_         struct{}
 	onFailure func(failure lint.Failure)
-	//nolint:staticcheck
-	returnIDs map[*ast.Object]struct{} // TODO: ast.Object is deprecated
-	//nolint:staticcheck
-	rangeIDs map[*ast.Object]struct{} // TODO: ast.Object is deprecated
+	returnIDs map[*ast.Object]struct{}
+	rangeIDs  map[*ast.Object]struct{}
 
 	go122for bool
 }

--- a/rule/early_return.go
+++ b/rule/early_return.go
@@ -52,7 +52,7 @@ func (*EarlyReturnRule) Name() string {
 
 func (e *EarlyReturnRule) checkIfElse(chain ifelse.Chain) (string, bool) {
 	if chain.HasElse {
-		if !chain.Else.BranchKind.Deviates() {
+		if !chain.Else.Deviates() {
 			// this rule only applies if the else-block deviates control flow
 			return "", false
 		}

--- a/rule/error_strings_test.go
+++ b/rule/error_strings_test.go
@@ -34,8 +34,7 @@ func TestErrorStringsRule_Configure(t *testing.T) {
 		{
 			name:      "Invalid function",
 			arguments: lint.Arguments{"errors."},
-			//nolint:revive
-			wantErr: errors.New("found invalid custom function: errors."),
+			wantErr:   errors.New("found invalid custom function: errors."), //nolint:revive // error-strings: it's ok for tests
 		},
 		{
 			name:      "Invalid custom function",

--- a/rule/error_strings_test.go
+++ b/rule/error_strings_test.go
@@ -34,7 +34,8 @@ func TestErrorStringsRule_Configure(t *testing.T) {
 		{
 			name:      "Invalid function",
 			arguments: lint.Arguments{"errors."},
-			wantErr:   errors.New("found invalid custom function: errors."),
+			//nolint: revive
+			wantErr: errors.New("found invalid custom function: errors."),
 		},
 		{
 			name:      "Invalid custom function",

--- a/rule/error_strings_test.go
+++ b/rule/error_strings_test.go
@@ -34,7 +34,7 @@ func TestErrorStringsRule_Configure(t *testing.T) {
 		{
 			name:      "Invalid function",
 			arguments: lint.Arguments{"errors."},
-			//nolint: revive
+			//nolint:revive
 			wantErr: errors.New("found invalid custom function: errors."),
 		},
 		{

--- a/rule/if_return.go
+++ b/rule/if_return.go
@@ -44,7 +44,7 @@ func (w *lintElseError) Visit(node ast.Node) ast.Visitor {
 				continue
 			}
 			assign, ok := s.Init.(*ast.AssignStmt)
-			if !ok || len(assign.Lhs) != 1 || !(assign.Tok == token.DEFINE || assign.Tok == token.ASSIGN) {
+			if !ok || len(assign.Lhs) != 1 || assign.Tok != token.DEFINE && assign.Tok != token.ASSIGN {
 				continue
 			}
 			id, ok := assign.Lhs[0].(*ast.Ident)

--- a/rule/if_return.go
+++ b/rule/if_return.go
@@ -44,7 +44,8 @@ func (w *lintElseError) Visit(node ast.Node) ast.Visitor {
 				continue
 			}
 			assign, ok := s.Init.(*ast.AssignStmt)
-			if !ok || len(assign.Lhs) != 1 || assign.Tok != token.DEFINE && assign.Tok != token.ASSIGN {
+			//nolint:staticcheck // QF1001: it's readable enough
+			if !ok || len(assign.Lhs) != 1 || !(assign.Tok == token.DEFINE || assign.Tok == token.ASSIGN) {
 				continue
 			}
 			id, ok := assign.Lhs[0].(*ast.Ident)

--- a/rule/import_alias_naming_test.go
+++ b/rule/import_alias_naming_test.go
@@ -39,7 +39,7 @@ func TestImportAliasNamingRule_Configure(t *testing.T) {
 			}},
 			wantErr:        nil,
 			wantAllowRegex: regexp.MustCompile("^[a-z][a-z0-9]*$"),
-			wantDenyRegex:  regexp.MustCompile("^v\\d+$"),
+			wantDenyRegex:  regexp.MustCompile(`^v\d+$`),
 		},
 		{
 			name: "valid map lowercased arguments",
@@ -49,7 +49,7 @@ func TestImportAliasNamingRule_Configure(t *testing.T) {
 			}},
 			wantErr:        nil,
 			wantAllowRegex: regexp.MustCompile("^[a-z][a-z0-9]*$"),
-			wantDenyRegex:  regexp.MustCompile("^v\\d+$"),
+			wantDenyRegex:  regexp.MustCompile(`^v\d+$`),
 		},
 		{
 			name: "valid map kebab-cased arguments",
@@ -59,7 +59,7 @@ func TestImportAliasNamingRule_Configure(t *testing.T) {
 			}},
 			wantErr:        nil,
 			wantAllowRegex: regexp.MustCompile("^[a-z][a-z0-9]*$"),
-			wantDenyRegex:  regexp.MustCompile("^v\\d+$"),
+			wantDenyRegex:  regexp.MustCompile(`^v\d+$`),
 		},
 		{
 			name:      "invalid argument type",

--- a/rule/import_shadowing.go
+++ b/rule/import_shadowing.go
@@ -28,6 +28,7 @@ func (*ImportShadowingRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fail
 		onFailure: func(failure lint.Failure) {
 			failures = append(failures, failure)
 		},
+		//nolint:staticcheck
 		alreadySeen: map[*ast.Object]struct{}{}, // TODO: ast.Object is deprecated
 		skipIdents:  map[*ast.Ident]struct{}{},
 	}
@@ -62,8 +63,9 @@ type importShadowing struct {
 	packageNameIdent *ast.Ident
 	importNames      map[string]struct{}
 	onFailure        func(lint.Failure)
-	alreadySeen      map[*ast.Object]struct{} // TODO: ast.Object is deprecated
-	skipIdents       map[*ast.Ident]struct{}
+	//nolint:staticcheck
+	alreadySeen map[*ast.Object]struct{} // TODO: ast.Object is deprecated
+	skipIdents  map[*ast.Ident]struct{}
 }
 
 // Visit visits AST nodes and checks if id nodes (ast.Ident) shadow an import name

--- a/rule/import_shadowing.go
+++ b/rule/import_shadowing.go
@@ -28,8 +28,7 @@ func (*ImportShadowingRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fail
 		onFailure: func(failure lint.Failure) {
 			failures = append(failures, failure)
 		},
-		//nolint:staticcheck
-		alreadySeen: map[*ast.Object]struct{}{}, // TODO: ast.Object is deprecated
+		alreadySeen: map[*ast.Object]struct{}{}, //nolint:staticcheck // TODO: ast.Object is deprecated
 		skipIdents:  map[*ast.Ident]struct{}{},
 	}
 
@@ -63,9 +62,8 @@ type importShadowing struct {
 	packageNameIdent *ast.Ident
 	importNames      map[string]struct{}
 	onFailure        func(lint.Failure)
-	//nolint:staticcheck
-	alreadySeen map[*ast.Object]struct{} // TODO: ast.Object is deprecated
-	skipIdents  map[*ast.Ident]struct{}
+	alreadySeen      map[*ast.Object]struct{} //nolint:staticcheck // TODO: ast.Object is deprecated
+	skipIdents       map[*ast.Ident]struct{}
 }
 
 // Visit visits AST nodes and checks if id nodes (ast.Ident) shadow an import name

--- a/rule/range_val_address.go
+++ b/rule/range_val_address.go
@@ -70,9 +70,8 @@ func (w rangeValAddress) Visit(node ast.Node) ast.Visitor {
 
 type rangeBodyVisitor struct {
 	valueIsStarExpr bool
-	//nolint:staticcheck
-	valueID   *ast.Object // TODO: ast.Object is deprecated
-	onFailure func(lint.Failure)
+	valueID         *ast.Object //nolint:staticcheck // TODO: ast.Object is deprecated
+	onFailure       func(lint.Failure)
 }
 
 func (bw rangeBodyVisitor) Visit(node ast.Node) ast.Visitor {

--- a/rule/range_val_address.go
+++ b/rule/range_val_address.go
@@ -70,8 +70,9 @@ func (w rangeValAddress) Visit(node ast.Node) ast.Visitor {
 
 type rangeBodyVisitor struct {
 	valueIsStarExpr bool
-	valueID         *ast.Object // TODO: ast.Object is deprecated
-	onFailure       func(lint.Failure)
+	//nolint:staticcheck
+	valueID   *ast.Object // TODO: ast.Object is deprecated
+	onFailure func(lint.Failure)
 }
 
 func (bw rangeBodyVisitor) Visit(node ast.Node) ast.Visitor {

--- a/rule/unused_param.go
+++ b/rule/unused_param.go
@@ -144,6 +144,8 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 }
 
 // TODO: ast.Object is deprecated
+//
+//nolint:staticcheck
 func retrieveNamedParams(params *ast.FieldList) map[*ast.Object]bool {
 	result := map[*ast.Object]bool{}
 	if params.List == nil {

--- a/rule/unused_param.go
+++ b/rule/unused_param.go
@@ -143,9 +143,7 @@ func (w lintUnusedParamRule) Visit(node ast.Node) ast.Visitor {
 	return w // full method body was inspected
 }
 
-// TODO: ast.Object is deprecated
-//
-//nolint:staticcheck
+//nolint:staticcheck // TODO: ast.Object is deprecated
 func retrieveNamedParams(params *ast.FieldList) map[*ast.Object]bool {
 	result := map[*ast.Object]bool{}
 	if params.List == nil {


### PR DESCRIPTION
## Motivation/Why
Integrate [golangci-lint](https://golangci-lint.run/) into the CI/CD pipeline to ensure code quality and consistency across the project.

## Steps followed
1. Add golangci-lint config with minimal configuration. The config could be based on https://github.com/ccoVeille/golangci-lint-config-examples
2. Extend GitHub Actions Workflow .github/workflows/lint.yaml with golangci-lint job. It should use [golangci-lint-action](https://github.com/marketplace/actions/golangci-lint).
3. Run golangci-lint locally, identify, and fix existing linting issues.
4. Disabled Revive in the golangci-lint config

**Important Notes**
- I initially attempted to follow the [basic golangci-lint config](https://github.com/ccoVeille/golangci-lint-config-examples/tree/main/02-basic), but quickly ran into 34 linting issues (errcheck: 24, staticcheck: 10). To keep this PR focused and manageable, I decided to enable only staticcheck and address all related issues.

- I’ve disabled rule SA1019 (usage of deprecated identifiers) for now, as the only trigger was ast.Object, which is a known case of a deprecated field. Handling this seems better suited for a dedicated follow-up PR.

# Footer
Closes #1250 
