### PR TITLE
docs: fix displaying rules table on revive.run

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ You can use the following exclude patterns
 ## Available Rules
 
 List of all available rules. The rules ported from `golint` are left unchanged and indicated in the `golint` column.
+
 | Name                  | Config | Description                                                      | `golint` | Typed |
 | --------------------- | :----: | :--------------------------------------------------------------- | :------: | :---: |
 | [`add-constant`](./RULES_DESCRIPTIONS.md#add-constant)        |  map   | Suggests using constant for magic numbers and string literals    |    no    |  no   |


### PR DESCRIPTION
This simple change fixes displaying of the "Available Rules" table on https://revive.run/docs#available-rules

<details><summary>Before</summary>
<p>

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/fa941598-0c0a-4989-8303-d29d87037316" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/87e9cec9-189d-4be6-b3c2-b4d70306c186" />

</p>
</details> 