### PR TITLE
refactor: update test package names to fix revive linting

### DIFF
--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,4 +1,4 @@
-package formatter_test
+package formatter
 
 import (
 	"go/token"
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mgechev/revive/formatter"
 	"github.com/mgechev/revive/lint"
 )
 
@@ -33,7 +32,7 @@ func TestFormatter(t *testing.T) {
 		want      string
 	}{
 		{
-			formatter: &formatter.Checkstyle{},
+			formatter: &Checkstyle{},
 			want: `
 <?xml version='1.0' encoding='UTF-8'?>
 <checkstyle version="5.0">
@@ -44,11 +43,11 @@ func TestFormatter(t *testing.T) {
 `,
 		},
 		{
-			formatter: &formatter.Default{},
+			formatter: &Default{},
 			want:      `test.go:2:5: test failure`,
 		},
 		{
-			formatter: &formatter.Friendly{},
+			formatter: &Friendly{},
 			want: `
 ⚠  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
   test.go:2:5
@@ -60,19 +59,21 @@ Warnings:
 `,
 		},
 		{
-			formatter: &formatter.JSON{},
-			want:      `[{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`, //nolint:revive // line-length-limit
+			formatter: &JSON{},
+			//revive:disable-next-line // line-length-limit
+			want: `[{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}]`, //nolint:revive // line-length-limit
 		},
 		{
-			formatter: &formatter.NDJSON{},
-			want:      `{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`, //nolint:revive // line-length-limit
+			formatter: &NDJSON{},
+			//revive:disable-next-line // line-length-limit
+			want: `{"Severity":"warning","Failure":"test failure","RuleName":"rule","Category":"cat","Position":{"Start":{"Filename":"test.go","Offset":0,"Line":2,"Column":5},"End":{"Filename":"test.go","Offset":0,"Line":2,"Column":10}},"Confidence":0,"ReplacementLine":""}`, //nolint:revive // line-length-limit
 		},
 		{
-			formatter: &formatter.Plain{},
+			formatter: &Plain{},
 			want:      `test.go:2:5: test failure https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule`,
 		},
 		{
-			formatter: &formatter.Sarif{},
+			formatter: &Sarif{},
 			want: `
 {
   "runs": [
@@ -111,7 +112,7 @@ Warnings:
 `,
 		},
 		{
-			formatter: &formatter.Stylish{},
+			formatter: &Stylish{},
 			want: `
 test.go
   (2, 5)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
@@ -121,7 +122,7 @@ test.go
 `,
 		},
 		{
-			formatter: &formatter.Unix{},
+			formatter: &Unix{},
 			want:      `test.go:2:5: [rule] test failure`,
 		},
 	} {

--- a/lint/filefilter_test.go
+++ b/lint/filefilter_test.go
@@ -1,14 +1,12 @@
-package lint_test
+package lint
 
 import (
 	"testing"
-
-	"github.com/mgechev/revive/lint"
 )
 
 func TestFileFilter(t *testing.T) {
 	t.Run("whole file name", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("a/b/c.go")
+		ff, err := ParseFileFilter("a/b/c.go")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -21,7 +19,7 @@ func TestFileFilter(t *testing.T) {
 	})
 
 	t.Run("regex", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("~b/[cd].go$")
+		ff, err := ParseFileFilter("~b/[cd].go$")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -37,7 +35,7 @@ func TestFileFilter(t *testing.T) {
 	})
 
 	t.Run("TEST well-known", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("TEST")
+		ff, err := ParseFileFilter("TEST")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -50,7 +48,7 @@ func TestFileFilter(t *testing.T) {
 	})
 
 	t.Run("glob *", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("a/b/*.pb.go")
+		ff, err := ParseFileFilter("a/b/*.pb.go")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,7 +64,7 @@ func TestFileFilter(t *testing.T) {
 	})
 
 	t.Run("glob **", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("a/**/*.pb.go")
+		ff, err := ParseFileFilter("a/**/*.pb.go")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -85,7 +83,7 @@ func TestFileFilter(t *testing.T) {
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("")
+		ff, err := ParseFileFilter("")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -98,7 +96,7 @@ func TestFileFilter(t *testing.T) {
 	})
 
 	t.Run("just *", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("*")
+		ff, err := ParseFileFilter("*")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -111,7 +109,7 @@ func TestFileFilter(t *testing.T) {
 	})
 
 	t.Run("just ~", func(t *testing.T) {
-		ff, err := lint.ParseFileFilter("~")
+		ff, err := ParseFileFilter("~")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/revivelib/core_internal_test.go
+++ b/revivelib/core_internal_test.go
@@ -3,7 +3,6 @@ package revivelib
 import (
 	"testing"
 
-	"github.com/mgechev/revive/config"
 	"github.com/mgechev/revive/lint"
 )
 
@@ -34,36 +33,4 @@ func TestReviveCreateInstance(t *testing.T) {
 	if revive.config.ErrorCode != 1 && revive.config.WarningCode != 1 {
 		t.Fatal("Didn't set the codes in the config instance.")
 	}
-}
-
-type mockRule struct {
-}
-
-func (*mockRule) Name() string {
-	return "mock-rule"
-}
-
-func (*mockRule) Apply(_ *lint.File, _ lint.Arguments) []lint.Failure {
-	return nil
-}
-
-func getMockRevive(t *testing.T) *Revive {
-	t.Helper()
-
-	conf, err := config.GetConfig("../defaults.toml")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	revive, err := New(
-		conf,
-		true,
-		2048,
-		NewExtraRule(&mockRule{}, lint.RuleConfig{}),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return revive
 }

--- a/revivelib/core_test.go
+++ b/revivelib/core_test.go
@@ -1,4 +1,4 @@
-package revivelib_test
+package revivelib
 
 import (
 	"strings"
@@ -7,7 +7,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/mgechev/revive/config"
 	"github.com/mgechev/revive/lint"
-	"github.com/mgechev/revive/revivelib"
 	"github.com/mgechev/revive/rule"
 )
 
@@ -16,7 +15,7 @@ func TestReviveLint(t *testing.T) {
 	revive := getMockRevive(t)
 
 	// ACT
-	failures, err := revive.Lint(revivelib.Include("../testdata/if_return.go"))
+	failures, err := revive.Lint(Include("../testdata/if_return.go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +39,7 @@ func TestReviveFormat(t *testing.T) {
 	// ARRANGE
 	revive := getMockRevive(t)
 
-	failuresChan, err := revive.Lint(revivelib.Include("../testdata/if_return.go"))
+	failuresChan, err := revive.Lint(Include("../testdata/if_return.go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +71,8 @@ func TestReviveFormat(t *testing.T) {
 	}
 }
 
-type mockRule struct{}
+type mockRule struct {
+}
 
 func (*mockRule) Name() string {
 	return "mock-rule"
@@ -82,7 +82,7 @@ func (*mockRule) Apply(_ *lint.File, _ lint.Arguments) []lint.Failure {
 	return nil
 }
 
-func getMockRevive(t *testing.T) *revivelib.Revive {
+func getMockRevive(t *testing.T) *Revive {
 	t.Helper()
 
 	conf, err := config.GetConfig("../defaults.toml")
@@ -90,12 +90,12 @@ func getMockRevive(t *testing.T) *revivelib.Revive {
 		t.Fatal(err)
 	}
 
-	revive, err := revivelib.New(
+	revive, err := New(
 		conf,
 		true,
 		2048,
-		revivelib.NewExtraRule(&rule.IfReturnRule{}, lint.RuleConfig{}),
-		revivelib.NewExtraRule(&mockRule{}, lint.RuleConfig{}),
+		NewExtraRule(&rule.IfReturnRule{}, lint.RuleConfig{}),
+		NewExtraRule(&mockRule{}, lint.RuleConfig{}),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/rule/error_strings_test.go
+++ b/rule/error_strings_test.go
@@ -1,11 +1,10 @@
-package rule_test
+package rule
 
 import (
 	"errors"
 	"testing"
 
 	"github.com/mgechev/revive/lint"
-	"github.com/mgechev/revive/rule"
 )
 
 func TestErrorStringsRule_Configure(t *testing.T) {
@@ -34,7 +33,8 @@ func TestErrorStringsRule_Configure(t *testing.T) {
 		{
 			name:      "Invalid function",
 			arguments: lint.Arguments{"errors."},
-			wantErr:   errors.New("found invalid custom function: errors."), //nolint:revive // error-strings: it's ok for tests
+			//revive:disable-next-line // error-strings: it's ok for tests
+			wantErr: errors.New("found invalid custom function: errors."), //nolint:revive // error-strings: it's ok for tests
 		},
 		{
 			name:      "Invalid custom function",
@@ -50,7 +50,7 @@ func TestErrorStringsRule_Configure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var r rule.ErrorStringsRule
+			var r ErrorStringsRule
 
 			err := r.Configure(tt.arguments)
 

--- a/rule/string_format_test.go
+++ b/rule/string_format_test.go
@@ -1,11 +1,10 @@
-package rule_test
+package rule
 
 import (
 	"errors"
 	"testing"
 
 	"github.com/mgechev/revive/lint"
-	"github.com/mgechev/revive/rule"
 )
 
 func TestStringFormatConfigure(t *testing.T) {
@@ -136,7 +135,7 @@ func TestStringFormatConfigure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var r rule.StringFormatRule
+			var r StringFormatRule
 
 			err := r.Configure(tt.arguments)
 


### PR DESCRIPTION
### Problem

During the PR review for integrating golangci-lint, I noticed that golangci-lint catches the `line-length-limit` issue in `formatter/formatter_test.go` but revive does not, even though they share the same configuration.

Digging deeper, I found that running `revive -config revive.toml ./...` doesn't lint the following files: `formatter/formatter_test.go`, `lint/filefilter_test.go`, `revivelib/core_test.go`, and `rule/string_format_test.go`.

### Reason

The `formatter` tests contain functions from both the `formatter` and `formatter_test` packages. The same applies to the test files in the `lint`, `revivelib`, and `rule` packages.

### Solution

I decided to use `package NAME` instead of `package NAME_test` because we need to test unexported functions.