### PR TITLE
test: add missing unit tests for 'unexported-return' rule

### DIFF
--- a/test/unexported_return_test.go
+++ b/test/unexported_return_test.go
@@ -1,0 +1,11 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestUnexportedReturn(t *testing.T) {
+	testRule(t, "unexported_return", &rule.UnexportedReturnRule{})
+}

--- a/testdata/unexported_return.go
+++ b/testdata/unexported_return.go
@@ -1,0 +1,27 @@
+package fixtures
+
+import "strconv"
+
+type options struct{}
+
+func NewOptions() *options { // MATCH /exported func NewOptions returns unexported type *fixtures.options, which can be annoying to use/
+	return &options{}
+}
+
+type port uint16
+
+func ToPort(s string) (port, bool) { // MATCH /exported func ToPort returns unexported type fixtures.port, which can be annoying to use/
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return port(i), true
+}
+
+type Config struct {
+	p port
+}
+
+func (c *Config) Port() port { // MATCH /exported method Port returns unexported type fixtures.port, which can be annoying to use/
+	return c.p
+}


### PR DESCRIPTION
Add missing unit tests for `unexported-return` rule

I noticed that there were no unit tests for the `unexported-return` rule. I had previously added them in PR #1344, but since that PR was closed, I'm submitting this separate PR specifically for the unit tests.

