### PR TITLE
tiny refactoring on friendly, sarif and stylish formatters

### DIFF
--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -117,7 +117,7 @@ test.go
   (2, 5)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
 
 
- ✖ 1 problem (0 errors) (1 warnings)
+ ✖ 1 problem (0 errors) (1 warning)
 `,
 		},
 		{

--- a/formatter/friendly.go
+++ b/formatter/friendly.go
@@ -13,14 +13,6 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-func getErrorEmoji() string {
-	return color.RedString("✘")
-}
-
-func getWarningEmoji() string {
-	return color.YellowString("⚠")
-}
-
 // Friendly is an implementation of the Formatter interface
 // which formats the errors to JSON.
 type Friendly struct {
@@ -64,10 +56,13 @@ func (f *Friendly) printFriendlyFailure(sb *strings.Builder, failure lint.Failur
 	sb.WriteString("\n\n")
 }
 
+var errorEmoji = color.RedString("✘")
+var warningEmoji = color.YellowString("⚠")
+
 func (*Friendly) printHeaderRow(sb *strings.Builder, failure lint.Failure, severity lint.Severity) {
-	emoji := getWarningEmoji()
+	emoji := warningEmoji
 	if severity == lint.SeverityError {
-		emoji = getErrorEmoji()
+		emoji = errorEmoji
 	}
 	sb.WriteString(table([][]string{{emoji, ruleDescriptionURL(failure.RuleName), color.GreenString(failure.Failure)}}))
 }
@@ -82,9 +77,9 @@ type statEntry struct {
 }
 
 func (*Friendly) printSummary(w io.Writer, errors, warnings int) {
-	emoji := getWarningEmoji()
+	emoji := warningEmoji
 	if errors > 0 {
-		emoji = getErrorEmoji()
+		emoji = errorEmoji
 	}
 	problemsLabel := "problems"
 	if errors+warnings == 1 {

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -27,7 +27,7 @@ func (*Sarif) Format(failures <-chan lint.Failure, cfg lint.Config) (string, err
 	sarifLog := newReviveRunLog(cfg)
 
 	for failure := range failures {
-		sarifLog.AddResult(failure)
+		sarifLog.addResult(failure)
 	}
 
 	buf := new(bytes.Buffer)
@@ -72,7 +72,7 @@ func (l *reviveRunLog) addRules(cfg map[string]lint.RuleConfig) {
 	}
 }
 
-func (l *reviveRunLog) AddResult(failure lint.Failure) {
+func (l *reviveRunLog) addResult(failure lint.Failure) {
 	positiveOrZero := func(x int) int {
 		if x > 0 {
 			return x

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -20,10 +20,10 @@ func (*Stylish) Name() string {
 
 func formatFailure(failure lint.Failure, severity lint.Severity) []string {
 	fString := color.CyanString(failure.Failure)
-	fURL := ruleDescriptionURL(failure.RuleName)
-	fName := color.RedString(fURL)
 	lineColumn := failure.Position
 	pos := fmt.Sprintf("(%d, %d)", lineColumn.Start.Line, lineColumn.Start.Column)
+	fURL := ruleDescriptionURL(failure.RuleName)
+	fName := color.RedString(fURL)
 	if severity == lint.SeverityWarning {
 		fName = color.YellowString(fURL)
 	}
@@ -44,10 +44,6 @@ func (*Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string
 		}
 		result = append(result, formatFailure(f, lint.Severity(currentType)))
 	}
-	ps := "problems"
-	if total == 1 {
-		ps = "problem"
-	}
 
 	fileReport := map[string][][]string{}
 
@@ -66,6 +62,10 @@ func (*Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string
 		output += table(val) + "\n"
 	}
 
+	ps := "problems"
+	if total == 1 {
+		ps = "problem"
+	}
 	suffix := fmt.Sprintf(" %d %s (%d errors) (%d warnings)", total, ps, totalErrors, total-totalErrors)
 
 	switch {

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -62,11 +62,20 @@ func (*Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string
 		output += table(val) + "\n"
 	}
 
-	ps := "problems"
+	problemsLabel := "problems"
 	if total == 1 {
-		ps = "problem"
+		problemsLabel = "problem"
 	}
-	suffix := fmt.Sprintf(" %d %s (%d errors) (%d warnings)", total, ps, totalErrors, total-totalErrors)
+	totalWarnings := total - totalErrors
+	warningsLabel := "warnings"
+	if totalWarnings == 1 {
+		warningsLabel = "warning"
+	}
+	errorsLabel := "errors"
+	if totalErrors == 1 {
+		errorsLabel = "error"
+	}
+	suffix := fmt.Sprintf(" %d %s (%d %s) (%d %s)", total, problemsLabel, totalErrors, errorsLabel, totalWarnings, warningsLabel)
 
 	switch {
 	case total > 0 && totalErrors > 0:


### PR DESCRIPTION
Replace function call by var ref and move def near utilization in friendly and stylish formatters