### PR TITLE
Update rule description URLs to point to revive.run

### DIFF
--- a/formatter/default.go
+++ b/formatter/default.go
@@ -28,5 +28,5 @@ func (*Default) Format(failures <-chan lint.Failure, _ lint.Config) (string, err
 }
 
 func ruleDescriptionURL(ruleName string) string {
-	return "https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#" + ruleName
+	return "https://revive.run/r#" + ruleName
 }

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -50,7 +50,7 @@ func TestFormatter(t *testing.T) {
 		{
 			formatter: &formatter.Friendly{},
 			want: `
-⚠  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
+⚠  https://revive.run/r#rule  test failure  
   test.go:2:5
 
 ⚠ 1 problem (0 errors, 1 warning)
@@ -71,7 +71,7 @@ Warnings:
 		},
 		{
 			formatter: &formatter.Plain{},
-			want:      `test.go:2:5: test failure https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule`,
+			want:      `test.go:2:5: test failure https://revive.run/r#rule`,
 		},
 		{
 			formatter: &formatter.Sarif{},
@@ -102,7 +102,7 @@ Warnings:
       ],
       "tool": {
         "driver": {
-          "informationUri": "https://github.com/mgechev/revive",
+          "informationUri": "https://revive.run",
           "name": "revive"
         }
       }
@@ -116,7 +116,7 @@ Warnings:
 			formatter: &formatter.Stylish{},
 			want: `
 test.go
-  (2, 5)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#rule  test failure  
+  (2, 5)  https://revive.run/r#rule  test failure  
 
 
  ✖ 1 problem (0 errors) (1 warning)

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -20,7 +20,7 @@ func (*Sarif) Name() string {
 	return "sarif"
 }
 
-const reviveSite = "https://github.com/mgechev/revive"
+const reviveSite = "https://revive.run"
 
 // Format formats the failures gotten from the lint.
 func (*Sarif) Format(failures <-chan lint.Failure, cfg lint.Config) (string, error) {

--- a/revivelib/core_test.go
+++ b/revivelib/core_test.go
@@ -54,11 +54,11 @@ func TestReviveFormat(t *testing.T) {
 	}
 
 	errorMsgs := []string{
-		"(91, 3)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code  unreachable code after this statement",
-		"(98, 3)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code  unreachable code after this statement",
-		"(15, 2)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return         redundant if ...; err != nil check, just return error instead.",
-		"(88, 3)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return         redundant if ...; err != nil check, just return error instead.",
-		"(95, 3)  https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return         redundant if ...; err != nil check, just return error instead.",
+		"(91, 3)  https://revive.run/r#unreachable-code  unreachable code after this statement",
+		"(98, 3)  https://revive.run/r#unreachable-code  unreachable code after this statement",
+		"(15, 2)  https://revive.run/r#if-return         redundant if ...; err != nil check, just return error instead.",
+		"(88, 3)  https://revive.run/r#if-return         redundant if ...; err != nil check, just return error instead.",
+		"(95, 3)  https://revive.run/r#if-return         redundant if ...; err != nil check, just return error instead.",
 	}
 	for _, errorMsg := range errorMsgs {
 		if !strings.Contains(failures, errorMsg) {


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the GitHub Action build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

This pull request updates all references to the old Revive documentation and site URLs, replacing them with the new `https://revive.run` domain. The changes ensure consistency across the codebase and tests by using the updated URL format.

Closes #1356 
