### PR TITLE
feature: detect time/date out of bounds in time-date rule

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1073,7 +1073,7 @@ _Examples_:
   - out of bounds argument for the month (12), day (31), hour (23), minute (59), or seconds (59)
   - an invalid date: 31st of June, 29th of February in 2023, ...
 
-- Non-decimal integers used are used as arguments
+- Non-decimal integers are used as arguments
 
   This includes:
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1065,9 +1065,25 @@ _Description_: Reports bad usage of `time.Date`.
 
 _Configuration_: N/A
 
-_Example_:
+_Examples_:
 
-Here the leading zeros are defining integers with octal notation
+- Invalid dates reporting:
+
+  - 0 for the month or day argument
+  - out of bounds argument for the month (12), day (31), hour (23), minute (59), or seconds (59)
+  - an invalid date: 31st of June, 29th of February in 2023, ...
+
+- Non-decimal integers used are used as arguments
+
+  This includes:
+
+  - leading zero notation like using 00 for hours, minutes, and seconds.
+  - octal notation 0o1, 0o0 that are often caused by using gofumpt on leading zero notation.
+  - padding zeros such as 00123456 that are source of bugs.
+  - ... and some other use cases.
+
+<details>
+<summary>More information about what is detected and reported</summary>
 
 ```go
 import "time"
@@ -1113,6 +1129,8 @@ import "time"
 
 var _ = time.Date(2023, 01, 02, 03, 04, 00, 0, time.UTC)
 ```
+
+</details>
 
 ## time-equal
 

--- a/rule/time_date.go
+++ b/rule/time_date.go
@@ -141,10 +141,8 @@ func (w lintTimeDate) Visit(n ast.Node) ast.Visitor {
 				parsedDate.month = parsedValue
 
 				if parsedValue == 0 {
-					// this is a special case, where the month is 0
-					// Go will ignore it and use January,
-					// but we can still report it as a failure
-
+					// Special case: month is 0.
+					// Go treats it as January, but we still report it as a failure.
 					w.onFailure(lint.Failure{
 						Category:   "time",
 						Node:       arg,
@@ -158,10 +156,8 @@ func (w lintTimeDate) Visit(n ast.Node) ast.Visitor {
 
 				switch {
 				case parsedValue == 0:
-					// this is a special case, where the day is 0
-					// Go will ignore it and use the first day of the month,
-					// but we can still report it as a failure
-
+					// Special case: day is 0.
+					// Go treats it as the first day of the month, but we still report it as a failure.
 					w.onFailure(lint.Failure{
 						Category:   "time",
 						Node:       arg,
@@ -170,7 +166,7 @@ func (w lintTimeDate) Visit(n ast.Node) ast.Visitor {
 					})
 					continue
 
-				// the month is valid, we can check the day
+				// the month is valid, check the day
 				case parsedDate.month >= 1 && parsedDate.month <= 12:
 					month := time.Month(parsedDate.month)
 
@@ -303,8 +299,8 @@ func (w *lintTimeDate) checkArgSign(arg ast.Node, fieldName timeDateArgument) (*
 	// We can have an unary expression like -1, -a, +a, +1...
 	node, ok := arg.(*ast.UnaryExpr)
 	if !ok {
-		// Any other expression is not supported
-		// it could be something like this:
+		// Any other expression is not supported.
+		// It could be something like this:
 		// time.Date(2023, 2 * a, 3 + b, 4, 5, 6, 7, time.UTC)
 		return nil, false
 	}
@@ -352,7 +348,7 @@ func (w *lintTimeDate) checkArgSign(arg ast.Node, fieldName timeDateArgument) (*
 			),
 		})
 	default:
-		// Other unary expressions are not supported
+		// Other unary expressions are not supported.
 		//
 		// It could be something like this:
 		// ^1, ^0x1234
@@ -364,7 +360,7 @@ func (w *lintTimeDate) checkArgSign(arg ast.Node, fieldName timeDateArgument) (*
 }
 
 // isLeapYear checks if the year is a leap year.
-// this is used to check if the date is valid according to Go implementation.
+// This is used to check if the date is valid according to Go implementation.
 func (lintTimeDate) isLeapYear(year int64) bool {
 	// We cannot use the classic formula of
 	// year%4 == 0 && (year%100 != 0 || year%400 == 0)

--- a/test/time_date_test.go
+++ b/test/time_date_test.go
@@ -9,4 +9,5 @@ import (
 func TestTimeDate(t *testing.T) {
 	testRule(t, "time_date_decimal_literal", &rule.TimeDateRule{})
 	testRule(t, "time_date_nil_timezone", &rule.TimeDateRule{})
+	testRule(t, "time_date_out_of_bounds", &rule.TimeDateRule{})
 }

--- a/testdata/time_date_decimal_literal.go
+++ b/testdata/time_date_decimal_literal.go
@@ -87,31 +87,8 @@ var (
 	_ = time.Date(2023, 10, 10, 10, 10, 10, 100, time.UTC)
 	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, time.UTC)
 	_ = time.Date(2023, 1, 2, 3, 4, 5, 6, time.UTC)
-)
 
-// uncommon notations
-// these notations are supported by Go, the rule should not report it
-// it's out of the scope of the rule
-var (
-	// negative values can be used
-	// Go will compute 2022-10-28 20:55:54.999999994 +0000 UTC
-	_ = time.Date(2023, -1, -2, -3, -4, -5, -6, time.UTC)
-
-	// value out of the expected scale for a field, are OK.
-	// Go will compute 2024-02-02 04:11:10 +0000 UTC
-	_ = time.Date(2023, 13, 32, 27, 70, 70, 0, time.UTC)
-
-	// using gigantic nanoseconds to move into the future
-	// Go will compute 2054-09-10 04:50:45 +0000 UTC
-	_ = time.Date(2023, 1, 2, 3, 4, 5, 1000000000000000000, time.UTC)
-)
-
-// Common user errors with dates
-// it's out of the scope of the rule
-var (
-	// there is no February 29th in 2023, Go will compute 2023-03-01 03:04:05 +0000 UTC
-	_ = time.Date(2023, 2, 29, 3, 4, 5, 0, time.UTC)
-
-	// June has only 30 days, Go will compute 2023-07-01 03:04:05 +0000 UTC
-	_ = time.Date(2023, 6, 31, 3, 4, 5, 0, time.UTC)
+	i = 4
+	j = 1
+	_ = time.Date(2023+i, 1+i, 2*i, i+j, i-j, 0, 0, time.UTC)
 )

--- a/testdata/time_date_out_of_bounds.go
+++ b/testdata/time_date_out_of_bounds.go
@@ -1,0 +1,146 @@
+package pkg
+
+import "time"
+
+// these notations are supported by Go, the rule reports them anyway
+var (
+	// The month argument is 0 considered as January by Go, but the rule reports it anyway
+	_ = time.Date(2023, 0, 2, 3, 4, 5, 6, time.UTC) // MATCH /time.Date month argument should not be zero/
+
+	// The day argument is 0 considered as the first day of the month by Go, but the rule reports it anyway
+	_ = time.Date(2023, 1, 0, 3, 4, 5, 6, time.UTC) // MATCH /time.Date day argument should not be zero/
+
+	// there is no need to use a plus sign in front of numbers
+	_ = time.Date(
+		+2023, // MATCH /time.Date year argument contains a useless plus sign: +2023/
+		+0b1,  // MATCH /time.Date month argument contains a useless plus sign: +0b1/
+		+02,   // MATCH /time.Date day argument contains a useless plus sign: +02/
+		+0o3,  // MATCH /time.Date hour argument contains a useless plus sign: +0o3/
+		+4,    // MATCH /time.Date minute argument contains a useless plus sign: +4/
+		+5,    // MATCH /time.Date second argument contains a useless plus sign: +5/
+		+6,    // MATCH /time.Date nanosecond argument contains a useless plus sign: +6/
+		time.UTC)
+
+	// time.Date supports negative values, but it's uncommon to use them.
+	// the rule reports them
+	_ = time.Date(
+		2023,
+		-0b1, // MATCH /time.Date month argument is negative: -0b1/
+		-02,  // MATCH /time.Date day argument is negative: -02/
+		-0o3, // MATCH /time.Date hour argument is negative: -0o3/
+		-0x4, // MATCH /time.Date minute argument is negative: -0x4/
+		-5,   // MATCH /time.Date second argument is negative: -5/
+		-6,   // MATCH /time.Date nanosecond argument is negative: -6/
+		time.UTC)
+
+	// using gigantic nanoseconds to move into the future
+	// Go will compute 2054-09-10 04:50:45 +0000 UTC
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 1000000000000000000, time.UTC) // MATCH /time.Date nanosecond argument should be between 0 and 999999999: 1000000000000000000/
+
+)
+
+// Common user errors with dates
+var (
+	// June has only 30 days, so there is no June 31st
+	_ = time.Date(2023, 6, 31, 3, 4, 5, 0, time.UTC) // MATCH /time.Date day argument is 31, but June has only 30 days/
+
+	// there is no January 32nd
+	_ = time.Date(2024, 1, 32, 3, 4, 5, 0, time.UTC) // MATCH /time.Date day argument is 32, but January has only 31 days/
+
+	// there is no February 29th in 2023 (not a leap year)
+	_ = time.Date(2023, 2, 29, 3, 4, 5, 0, time.UTC) // MATCH /time.Date day argument is 29, but February 2023 has only 28 days/
+
+	// there is no February 30th
+	_ = time.Date(2024, 2, 30, 3, 4, 5, 0, time.UTC) // MATCH /time.Date day argument is 30, but February 2024 has only 29 days/
+)
+
+// day and month arguments are swapped
+var (
+	_ = time.Date(2023, 30, 6, 3, 4, 5, 0, time.UTC)
+	// MATCH:59 /time.Date month argument should be between 1 and 12: 30/
+	// MATCH:59 /time.Date month and day arguments appear to be swapped: 2023-06-30 vs 2023-30-06/
+
+	// month and day arguments are swapped, but there is no June 31st
+	_ = time.Date(2023, 31, 6, 3, 4, 5, 0, time.UTC) // MATCH /time.Date month argument should be between 1 and 12: 31/
+)
+
+// edge cases to validate the order of the checks
+var (
+
+	// here the month argument could have been swapped with the day argument
+	// but the day argument is zero
+	_ = time.Date(2023, 31, 0, 3, 4, 5, 0, time.UTC)
+	// MATCH:72 /time.Date day argument should not be zero/
+	// MATCH:72 /time.Date month argument should be between 1 and 12: 31/
+
+	// here the month argument could have been swapped with the day argument
+	// but the day argument is negative
+	_ = time.Date(2023, 31, -1, 3, 4, 5, 0, time.UTC)
+	// MATCH:78 /time.Date day argument is negative: -1/
+	// MATCH:78 /time.Date month argument should be between 1 and 12: 31/
+)
+
+// arguments are totally out of bounds
+var (
+	_ = time.Date(
+		2023,
+		13, // MATCH /time.Date month argument should be between 1 and 12: 13/
+		// here we cannot detect the number of days in the month, so it falls back to the default of 31
+		32,         // MATCH /time.Date day argument should be between 1 and 31: 32/
+		25,         // MATCH /time.Date hour argument should be between 0 and 23: 25/
+		60,         // MATCH /time.Date minute argument should be between 0 and 59: 60/
+		61,         // MATCH /time.Date second argument should be between 0 and 60: 61/
+		1000000000, // MATCH /time.Date nanosecond argument should be between 0 and 999999999: 1000000000/
+		time.UTC)
+)
+
+// valid time.Date calls that should not be reported by the rule
+// there are provided to prevent regression.
+var (
+	// a date before the start of era is valid
+	_ = time.Date(-500, 1, 2, 3, 4, 5, 6, time.UTC)
+
+	// a date in the future is valid
+	_ = time.Date(3000, 1, 2, 3, 4, 5, 6, time.UTC)
+
+	// 0, 1 and, -1 are valid and distinct years in Go
+	_ = time.Date(0, 1, 2, 3, 4, 5, 6, time.UTC)
+	_ = time.Date(-1, 1, 2, 3, 4, 5, 6, time.UTC)
+	_ = time.Date(1, 1, 2, 3, 4, 5, 6, time.UTC)
+
+	// midnight is a valid time
+	_ = time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	// 2023 is not a leap year, so February has only 28 days
+	_ = time.Date(2023, 2, 28, 3, 4, 5, 0, time.UTC)
+
+	// 2024 is a leap year, so February has 29 days
+	_ = time.Date(2024, 2, 29, 3, 4, 5, 0, time.UTC)
+
+	// 2020 is not a leap year, so February has only 28 days
+	_ = time.Date(2020, 2, 28, 3, 4, 5, 0, time.UTC)
+
+	// a leap second is valid
+	_ = time.Date(2016, 12, 31, 23, 59, 60, 0, time.UTC)
+)
+
+// these should not be reported by the rule
+var (
+	a int
+	_ = time.Date(2023, 1, a, 3, 4, 5, 6, time.UTC)
+	_ = time.Date(2023, 1, -a, 3, 4, 5, 6, time.UTC)
+	_ = time.Date(2023, 1, +a, 3, 4, 5, 6, time.UTC)
+	_ = time.Date(2023, 1, ^1, 3, 4, 5, 6, time.UTC)
+	_ = time.Date(2023, 1, ^a, 3, 4, 5, 6, time.UTC)
+
+	// obscure, but valid, notations that are ignored
+	_ = time.Date(
+		+-2023,
+		-+1,
+		+-+2,
+		-+-3,
+		+-+-4,
+		-+-+5,
+		+-+-+6,
+		time.UTC)
+)


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the GitHub Action build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

dates are checked with the following rules:
- no validation for year
- month must be between 1 and 12
- day must be between 1 and 31 for January, March, May, July, August, October, December
- day must be between 1 and 30 for April, June, September, November
- day must be between 1 and 28 for February, or 29 for leap years
- hour must be between 0 and 23
- minute must be between 0 and 59
- second must be between 0 and 59 (and 60 for leap seconds)
- nanosecond must be between 0 and 999999999, because otherwise you can use a second

Fixes #1369 

- #1369