### PR TITLE
package-comments: ignore //nolint comments

### DIFF
--- a/rule/package_comments.go
+++ b/rule/package_comments.go
@@ -143,7 +143,7 @@ func (l *lintPackageComments) Visit(_ ast.Node) ast.Visitor {
 		}
 	}
 
-	if l.fileAst.Doc == nil {
+	if isEmptyDoc(l.fileAst.Doc) {
 		for _, failure := range l.checkPackageComment() {
 			l.onFailure(failure)
 		}
@@ -161,4 +161,8 @@ func (l *lintPackageComments) Visit(_ ast.Node) ast.Visitor {
 		})
 	}
 	return nil
+}
+
+func isEmptyDoc(commentGroup *ast.CommentGroup) bool {
+	return commentGroup == nil || commentGroup.Text() == ""
 }

--- a/testdata/golint/package_doc7.go
+++ b/testdata/golint/package_doc7.go
@@ -1,0 +1,2 @@
+//nolint:dupl
+package foo


### PR DESCRIPTION
The same as #1366 but with less changes.