### PR TITLE
refactor: removes `get` from getters names

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -101,24 +101,24 @@ var (
 
 var originalUsage = flag.Usage
 
-func getLogo() string {
+func logo() string {
 	return color.YellowString(` _ __ _____   _(_)__  _____
 | '__/ _ \ \ / / \ \ / / _ \
 | | |  __/\ V /| |\ V /  __/
 |_|  \___| \_/ |_| \_/ \___|`)
 }
 
-func getCall() string {
+func call() string {
 	return color.MagentaString("revive -config c.toml -formatter friendly -exclude a.go -exclude b.go ./...")
 }
 
-func getBanner() string {
+func banner() string {
 	return fmt.Sprintf(`
 %s
 
 Example:
   %s
-`, getLogo(), getCall())
+`, logo(), call())
 }
 
 func buildDefaultConfigPath() string {
@@ -150,7 +150,7 @@ func initConfig() {
 	}
 
 	flag.Usage = func() {
-		fmt.Println(getBanner())
+		fmt.Println(banner())
 		originalUsage()
 	}
 

--- a/formatter/checkstyle.go
+++ b/formatter/checkstyle.go
@@ -43,7 +43,7 @@ func (*Checkstyle) Format(failures <-chan lint.Failure, config lint.Config) (str
 			Severity:   severity(config, failure),
 			RuleName:   failure.RuleName,
 		}
-		fn := failure.GetFilename()
+		fn := failure.Filename()
 		if issues[fn] == nil {
 			issues[fn] = []issue{}
 		}

--- a/formatter/friendly.go
+++ b/formatter/friendly.go
@@ -68,7 +68,7 @@ func (*Friendly) printHeaderRow(sb *strings.Builder, failure lint.Failure, sever
 }
 
 func (*Friendly) printFilePosition(sb *strings.Builder, failure lint.Failure) {
-	fmt.Fprintf(sb, "  %s:%d:%d", failure.GetFilename(), failure.Position.Start.Line, failure.Position.Start.Column)
+	fmt.Fprintf(sb, "  %s:%d:%d", failure.Filename(), failure.Position.Start.Line, failure.Position.Start.Column)
 }
 
 type statEntry struct {

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -27,7 +27,7 @@ func formatFailure(failure lint.Failure, severity lint.Severity) []string {
 	if severity == lint.SeverityWarning {
 		fName = color.YellowString(fURL)
 	}
-	return []string{failure.GetFilename(), pos, fName, fString}
+	return []string{failure.Filename(), pos, fName, fString}
 }
 
 // Format formats the failures gotten from the lint.

--- a/lint/failure.go
+++ b/lint/failure.go
@@ -81,7 +81,8 @@ type Failure struct {
 }
 
 // GetFilename returns the filename.
-// Deprecated: Use Filename.
+//
+// Deprecated: Use [Filename].
 func (f *Failure) GetFilename() string {
 	return f.Filename()
 }

--- a/lint/failure.go
+++ b/lint/failure.go
@@ -80,6 +80,12 @@ type Failure struct {
 	ReplacementLine string
 }
 
+// GetFilename returns the filename.
+// Deprecated: Use Filename.
+func (f *Failure) GetFilename() string {
+	return f.Filename()
+}
+
 // Filename returns the filename.
 func (f *Failure) Filename() string {
 	return f.Position.Start.Filename

--- a/lint/failure.go
+++ b/lint/failure.go
@@ -80,8 +80,8 @@ type Failure struct {
 	ReplacementLine string
 }
 
-// GetFilename returns the filename.
-func (f *Failure) GetFilename() string {
+// Filename returns the filename.
+func (f *Failure) Filename() string {
 	return f.Position.Start.Filename
 }
 

--- a/revivelib/core.go
+++ b/revivelib/core.go
@@ -75,9 +75,9 @@ func (r *Revive) Lint(patterns ...*LintPattern) (<-chan lint.Failure, error) {
 
 	for _, lintpkg := range patterns {
 		if lintpkg.IsExclude() {
-			excludePatterns = append(excludePatterns, lintpkg.GetPattern())
+			excludePatterns = append(excludePatterns, lintpkg.Pattern())
 		} else {
-			includePatterns = append(includePatterns, lintpkg.GetPattern())
+			includePatterns = append(includePatterns, lintpkg.Pattern())
 		}
 	}
 

--- a/revivelib/pattern.go
+++ b/revivelib/pattern.go
@@ -11,8 +11,8 @@ func (p *LintPattern) IsExclude() bool {
 	return p.isExclude
 }
 
-// GetPattern - returns the actual pattern
-func (p *LintPattern) GetPattern() string {
+// Pattern - returns the actual pattern
+func (p *LintPattern) Pattern() string {
 	return p.pattern
 }
 

--- a/revivelib/pattern.go
+++ b/revivelib/pattern.go
@@ -12,7 +12,8 @@ func (p *LintPattern) IsExclude() bool {
 }
 
 // GetPattern - returns the actual pattern
-// Deprecated: Use Pattern.
+//
+// Deprecated: Use [Pattern].
 func (p *LintPattern) GetPattern() string {
 	return p.Pattern()
 }

--- a/revivelib/pattern.go
+++ b/revivelib/pattern.go
@@ -11,6 +11,12 @@ func (p *LintPattern) IsExclude() bool {
 	return p.isExclude
 }
 
+// GetPattern - returns the actual pattern
+// Deprecated: Use Pattern.
+func (p *LintPattern) GetPattern() string {
+	return p.Pattern()
+}
+
 // Pattern - returns the actual pattern
 func (p *LintPattern) Pattern() string {
 	return p.pattern


### PR DESCRIPTION
This PR removes the prefix `get` from getter methods (see [Getters](https://go.dev/doc/effective_go#Getters))

Note: this PR includes modifications in 3 functions from `main` that are not strictly getters but removing the `get` prefix makes them read better.