### PR TITLE
refactor: test utils functions by removing redundant test instructions parsing and simplifying asserting functions

### DIFF
--- a/test/golint_test.go
+++ b/test/golint_test.go
@@ -63,12 +63,9 @@ func TestAll(t *testing.T) {
 				t.Fatalf("Failed reading %s: %v", fi.Name(), err)
 			}
 
-			fileInfo, err := os.Stat(filePath)
-			if err != nil {
-				t.Fatalf("Failed reading %s: %v", fi.Name(), err)
-			}
+			ins := parseInstructions(t, filePath, src)
 
-			if err := assertFailures(t, filepath.Dir(baseDir), fileInfo, src, rules, map[string]lint.RuleConfig{}); err != nil {
+			if err := assertFailures(t, filePath, rules, map[string]lint.RuleConfig{}, ins); err != nil {
 				t.Errorf("Linting %s: %v", fi.Name(), err)
 			}
 		})


### PR DESCRIPTION
Avoids parsing instructions twice and simplifies signature of asserting functions

1. Original code parsed test instructions twice:

```golang
	if parseInstructions(t, fullFilePath, src) == nil {   // first parsing
		assertSuccess(t, baseDir, stat, []lint.Rule{rule}, c)
		return
	}
	assertFailures(t, baseDir, stat, src, []lint.Rule{rule}, c) // second parsing inside assertFailures
```

2. Functions `assertSuccess` and `assertFailures` both took `baseDir string, fi os.FileInfo` as arguments to do exactly the same file path reconstruction that callers already do. Simplified both to receive the file path.