### PR TITLE
fix: avoid false positive for blank identifier

### DIFF
--- a/rule/error_naming.go
+++ b/rule/error_naming.go
@@ -61,6 +61,17 @@ func (w lintErrors) Visit(_ ast.Node) ast.Visitor {
 			}
 
 			id := spec.Names[0]
+			if id.Name == "_" {
+				// avoid false positive for blank identifier
+
+				// The fact that the error variable is not used
+				// is out of the scope of the rule
+
+				// This pattern that can be found in benchmarks and examples
+				// should be allowed.
+				continue
+			}
+
 			prefix := "err"
 			if id.IsExported() {
 				prefix = "Err"

--- a/testdata/golint/error_naming.go
+++ b/testdata/golint/error_naming.go
@@ -19,9 +19,13 @@ var (
 	e1 = fmt.Errorf("blah %d", 4) // MATCH /error var e1 should have name of the form errFoo/
 	// E2 ...
 	E2 = fmt.Errorf("blah %d", 5) // MATCH /error var E2 should have name of the form ErrFoo/
+
+	_ = errors.New("ok")
 )
 
 func f() {
 	var whatever = errors.New("ok") // ok
 	_ = whatever
+
+	_ = errors.New("ok")
 }


### PR DESCRIPTION
The fact that the error variable is not used is out of the scope of the rule

This pattern that can be found in benchmarks and examples.
It should be allowed.

<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the GitHub Action build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->
