### PR TITLE
feature: Add nil timezone handling detection to time-date rule

### DIFF
--- a/rule/time_date.go
+++ b/rule/time_date.go
@@ -66,7 +66,18 @@ func (w lintTimeDate) Visit(n ast.Node) ast.Visitor {
 		return w
 	}
 
-	// The last argument is a timezone, there is no need to check it, also it has a different type
+	// The last argument is a timezone, check it
+	tzArg := ce.Args[timeDateArity-1]
+	if astutils.IsIdent(tzArg, "nil") {
+		w.onFailure(lint.Failure{
+			Category:   "time",
+			Node:       tzArg,
+			Confidence: 1,
+			Failure:    "time.Date timezone argument cannot be nil, it would panic on runtime",
+		})
+	}
+
+	// All the other arguments should be decimal integers.
 	for pos, arg := range ce.Args[:timeDateArity-1] {
 		bl, ok := arg.(*ast.BasicLit)
 		if !ok {

--- a/test/time_date_test.go
+++ b/test/time_date_test.go
@@ -8,4 +8,5 @@ import (
 
 func TestTimeDate(t *testing.T) {
 	testRule(t, "time_date_decimal_literal", &rule.TimeDateRule{})
+	testRule(t, "time_date_nil_timezone", &rule.TimeDateRule{})
 }

--- a/testdata/time_date_nil_timezone.go
+++ b/testdata/time_date_nil_timezone.go
@@ -1,0 +1,40 @@
+package pkg
+
+import "time"
+
+var (
+	// a nil timezone will panic at runtime
+	// this is an invalid usage
+	// it should be reported as an error
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, nil) // MATCH /time.Date timezone argument cannot be nil, it would panic on runtime/
+)
+
+func _() {
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, nil) // MATCH /time.Date timezone argument cannot be nil, it would panic on runtime/
+}
+
+func _() {
+	// this is a valid usage
+	// it should not be reported as an error
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, time.UTC)
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, time.Local)
+
+	loc := time.LoadLocation("Europe/Paris")
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, loc)
+
+	loc := time.FixedZone("UTC-8", -8*60*60)
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, loc)
+
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, time.FixedZone("UTC-8", -8*60*60))
+}
+
+// this would be difficult to detect
+// and are for now not reported
+// even if they panic at runtime
+func _() {
+	var loc *time.Location
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, loc)
+
+	loc, _ = time.LoadLocation("whatever")
+	_ = time.Date(2023, 1, 2, 3, 4, 5, 0, loc)
+}


### PR DESCRIPTION
This is the follow-up of something that was raised during another review

>We could check if the timezone is not `nil` (will panic) (almost nobody uses nil for the timezone but ...)
>_Originally posted by @chavacava in https://github.com/mgechev/revive/pull/1370#discussion_r2103846865_
            