### PR TITLE
chore: enforce American English spelling in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,8 @@ linters:
       disable:
         - fieldalignment
         - shadow
+    misspell:
+      locale: US
     nolintlint:
       allow-unused: true
       require-explanation: true


### PR DESCRIPTION
There is no error right now, but it could help to prevent future issues.
