### PR TITLE
chore: enable dupword linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ version: "2"
 linters:
   default: none
   enable:
+    - dupword
     - gocritic
     - govet
     - ineffassign


### PR DESCRIPTION
There is no errors right now, but it could avoid future issues.
