### PR TITLE
chore: enable thelper linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - misspell
     - nolintlint
     - revive
+    - thelper
     - staticcheck
     - unused
 

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -59,6 +59,8 @@ func TestHomeConfigDir(t *testing.T) {
 }
 
 func setHome(t *testing.T, dir string) {
+	t.Helper()
+
 	homeEnv := "HOME"
 	if runtime.GOOS == "windows" {
 		homeEnv = "USERPROFILE"


### PR DESCRIPTION
It allows us to report errors at the right place in the tests.

There was only one function that was not using the helper.
It has been fixed to use it.
