### PR TITLE
docs: remove redundant license from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ If you disable them in the config file, revive will run over 6x faster than goli
   - [Contributors](#contributors)
     - [Maintainers](#maintainers)
     - [All](#all)
-  - [License](#license)
 
 <!-- /TOC -->
 
@@ -839,12 +838,6 @@ _Open a PR to add your project_.
 
 ### All
 
-This project exists thanks to all the people who contribute.
+We are grateful to everyone who has contributed to this project.
 
-<a href="https://github.com/mgechev/revive/graphs/contributors">
-  <img alt="All Contributors" src="https://contrib.rocks/image?repo=mgechev/revive&max=500" />
-</a>
-
-## License
-
-MIT
+[<img alt="All Contributors" src="https://contrib.rocks/image?repo=mgechev/revive&max=500">](https://github.com/mgechev/revive/graphs/contributors)


### PR DESCRIPTION
GitHub already shows the license.

<img width="445" alt="image" src="https://github.com/user-attachments/assets/1a5c5ad2-f637-4e09-8c2d-f799e0cb4b96" />

Also, this fixes displaying the license on revive.run.

