### PR TITLE
exported: ignore exported symbols from the main package

### DIFF
--- a/rule/exported.go
+++ b/rule/exported.go
@@ -110,11 +110,11 @@ func (r *ExportedRule) Configure(arguments lint.Arguments) error {
 
 // Apply applies the rule to given file.
 func (r *ExportedRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
-	var failures []lint.Failure
-	if file.IsTest() {
-		return failures
+	if !file.IsImportable() {
+		return nil
 	}
 
+	var failures []lint.Failure
 	walker := lintExported{
 		file: file,
 		onFailure: func(failure lint.Failure) {

--- a/test/exported_test.go
+++ b/test/exported_test.go
@@ -47,3 +47,7 @@ func TestCheckDirectiveComment(t *testing.T) {
 func TestCheckDeprecationComment(t *testing.T) {
 	testRule(t, "exported_issue_1231", &rule.ExportedRule{}, &lint.RuleConfig{})
 }
+
+func TestExportedMainPackage(t *testing.T) {
+	testRule(t, "exported_main", &rule.ExportedRule{}, &lint.RuleConfig{})
+}

--- a/testdata/exported_main.go
+++ b/testdata/exported_main.go
@@ -1,0 +1,4 @@
+// Symbols declared in main package cannot be imported.
+package main
+
+type Foo struct{}


### PR DESCRIPTION
This PR modifies the `exported` rule: add a check to ignore exported symbols from the `main` package.

Fixes #1397