### PR TITLE
unexported_return: exclude main package and test files

### DIFF
--- a/lint/file.go
+++ b/lint/file.go
@@ -24,6 +24,23 @@ type File struct {
 // IsTest returns if the file contains tests.
 func (f *File) IsTest() bool { return strings.HasSuffix(f.Name, "_test.go") }
 
+// IsImportable returns if the symbols defined in this file can be imported in other packages.
+//
+// Symbols from the package `main` or test files are not exported, so they cannot be imported.
+func (f *File) IsImportable() bool {
+	if f.IsTest() {
+		// Test files cannot be imported.
+		return false
+	}
+
+	if f.Pkg.IsMain() {
+		// The package `main` cannot be imported.
+		return false
+	}
+
+	return true
+}
+
 // Content returns the file's content.
 func (f *File) Content() []byte {
 	return f.content

--- a/rule/unexported_return.go
+++ b/rule/unexported_return.go
@@ -14,6 +14,12 @@ type UnexportedReturnRule struct{}
 
 // Apply applies the rule to given file.
 func (*UnexportedReturnRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	if !file.IsImportable() {
+		// Symbols defined in such files cannot be used in other packages.
+		// Therefore, we don't need to check for unexported return types.
+		return nil
+	}
+
 	var failures []lint.Failure
 
 	file.Pkg.TypeCheck()

--- a/test/unexported_return_test.go
+++ b/test/unexported_return_test.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestUnexportedReturn(t *testing.T) {
+	testRule(t, "unexported_return_package_foo", &rule.UnexportedReturnRule{})
+	testRule(t, "unexported_return_package_foo_test", &rule.UnexportedReturnRule{})
+	testRule(t, "unexported_return_package_footest_test", &rule.UnexportedReturnRule{})
+	testRule(t, "unexported_return_package_main", &rule.UnexportedReturnRule{})
+	testRule(t, "unexported_return_package_main_test", &rule.UnexportedReturnRule{})
+	testRule(t, "unexported_return_package_maintest_test", &rule.UnexportedReturnRule{})
+}

--- a/testdata/unexported_return_package_foo.go
+++ b/testdata/unexported_return_package_foo.go
@@ -1,0 +1,12 @@
+package foo
+
+// this is a file in a package
+//
+// such files SHOULD be linted by unexported_return rule
+// because symbols defined in test files cannot be used in other packages
+
+type foo struct{}
+
+func NewFoo() foo { // MATCH /exported func NewFoo returns unexported type foo.foo, which can be annoying to use/
+	return foo{}
+}

--- a/testdata/unexported_return_package_foo_test.go
+++ b/testdata/unexported_return_package_foo_test.go
@@ -1,0 +1,12 @@
+package foo
+
+// this is a test file in a package
+//
+// such files SHOULD NOT be linted by unexported_return rule
+// because symbols defined in test files cannot be used in other packages
+
+type foo struct{}
+
+func NewFoo() foo {
+	return foo{}
+}

--- a/testdata/unexported_return_package_footest_test.go
+++ b/testdata/unexported_return_package_footest_test.go
@@ -1,0 +1,12 @@
+package foo_test
+
+// this is a test file in a _test package
+//
+// such files SHOULD NOT be linted by unexported_return rule
+// because symbols defined in test files cannot be used in other packages
+
+type foo struct{}
+
+func NewFoo() foo {
+	return foo{}
+}

--- a/testdata/unexported_return_package_main.go
+++ b/testdata/unexported_return_package_main.go
@@ -1,0 +1,12 @@
+package main
+
+// this is a file in the main package
+//
+// such files SHOULD NOT be linted by unexported_return rule
+// because symbols defined in main package cannot be imported in other packages
+
+type foo struct{}
+
+func NewFoo() foo {
+	return foo{}
+}

--- a/testdata/unexported_return_package_main_test.go
+++ b/testdata/unexported_return_package_main_test.go
@@ -1,0 +1,12 @@
+package main
+
+// this is a test file in the main package
+//
+// such files SHOULD NOT be linted by unexported_return rule
+// because symbols defined in main package cannot be imported in other packages
+
+type foo struct{}
+
+func NewFoo() foo {
+	return foo{}
+}

--- a/testdata/unexported_return_package_maintest_test.go
+++ b/testdata/unexported_return_package_maintest_test.go
@@ -1,0 +1,12 @@
+package main_test
+
+// this is a test file in the main_test package
+//
+// such files SHOULD NOT be linted by unexported_return rule
+// because symbols defined in main package cannot be imported in other packages
+
+type foo struct{}
+
+func NewFoo() foo {
+	return foo{}
+}


### PR DESCRIPTION
The content of these files cannot be imported by other packages,
so they are excluded from the `unexported_return` rule.

Related to https://github.com/mgechev/revive/issues/1397#issuecomment-2943897721
