### PR TITLE
fix: var-naming rule extraBadPackageNames type

### DIFF
--- a/rule/var_naming.go
+++ b/rule/var_naming.go
@@ -83,7 +83,7 @@ func (r *VarNamingRule) Configure(arguments lint.Arguments) error {
 			case isRuleOption(k, "skipPackageNameChecks"):
 				r.skipPackageNameChecks = fmt.Sprint(v) == "true"
 			case isRuleOption(k, "extraBadPackageNames"):
-				extraBadPackageNames, ok := v.([]string)
+				extraBadPackageNames, ok := v.([]any)
 				if !ok {
 					return fmt.Errorf("invalid third argument to the var-naming rule. Expecting extraBadPackageNames of type slice of strings, but %T", v)
 				}
@@ -91,7 +91,7 @@ func (r *VarNamingRule) Configure(arguments lint.Arguments) error {
 					if r.extraBadPackageNames == nil {
 						r.extraBadPackageNames = map[string]struct{}{}
 					}
-					r.extraBadPackageNames[strings.ToLower(name)] = struct{}{}
+					r.extraBadPackageNames[strings.ToLower(name.(string))] = struct{}{}
 				}
 			}
 		}

--- a/rule/var_naming_test.go
+++ b/rule/var_naming_test.go
@@ -36,7 +36,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 				[]any{map[string]any{
 					"upperCaseConst":        true,
 					"skipPackageNameChecks": true,
-					"extraBadPackageNames":  []string{"helpers", "models"},
+					"extraBadPackageNames":  []any{"helpers", "models"},
 				}},
 			},
 			wantErr:                   nil,
@@ -54,7 +54,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 				[]any{map[string]any{
 					"uppercaseconst":        true,
 					"skippackagenamechecks": true,
-					"extrabadpackagenames":  []string{"helpers", "models"},
+					"extrabadpackagenames":  []any{"helpers", "models"},
 				}},
 			},
 			wantErr:                   nil,
@@ -72,7 +72,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 				[]any{map[string]any{
 					"upper-case-const":         true,
 					"skip-package-name-checks": true,
-					"extra-bad-package-names":  []string{"helpers", "models"},
+					"extra-bad-package-names":  []any{"helpers", "models"},
 				}},
 			},
 			wantErr:                   nil,

--- a/test/var_naming_test.go
+++ b/test/var_naming_test.go
@@ -37,7 +37,7 @@ func TestVarNaming(t *testing.T) {
 	})
 	testRule(t, "var_naming_bad_package_name", &rule.VarNamingRule{}, &lint.RuleConfig{
 		Arguments: []any{[]any{}, []any{},
-			[]any{map[string]any{"skip-package-name-checks": false, "extra-bad-package-names": []string{"helpers"}}},
+			[]any{map[string]any{"skip-package-name-checks": false, "extra-bad-package-names": []any{"helpers"}}},
 		},
 	})
 }


### PR DESCRIPTION
```toml
[rule.var-naming]
arguments = [[], [], [{ extra-bad-package-names = ["helpers", "models"] }]]
```

```console
$ revive --version
version 1.10.0
$ revive ./...                                               
initializing revive - getting lint rules: cannot configure rule: "var-naming": invalid third argument to the var-naming rule. Expecting extraBadPackageNames of type slice of strings, but []interface {}
```

With my PR:
```console
$ ./revive ./...    
helpers/helpers.go:1:9: avoid bad package names
```

Related to #1312