### PR TITLE
var-naming: handle possible panic

### DIFF
--- a/rule/var_naming.go
+++ b/rule/var_naming.go
@@ -93,7 +93,7 @@ func (r *VarNamingRule) Configure(arguments lint.Arguments) error {
 					}
 					n, ok := name.(string)
 					if !ok {
-						return fmt.Errorf("invalid third argument to the var-naming rule: expected element %d of extraBadPackageNames to be a string, but got type %T", i, name)
+						return fmt.Errorf("invalid third argument to the var-naming rule: expected element %d of extraBadPackageNames to be a string, but got %v(%T)", i, name, name)
 					}
 					r.extraBadPackageNames[strings.ToLower(n)] = struct{}{}
 				}

--- a/rule/var_naming.go
+++ b/rule/var_naming.go
@@ -87,11 +87,15 @@ func (r *VarNamingRule) Configure(arguments lint.Arguments) error {
 				if !ok {
 					return fmt.Errorf("invalid third argument to the var-naming rule. Expecting extraBadPackageNames of type slice of strings, but %T", v)
 				}
-				for _, name := range extraBadPackageNames {
+				for i, name := range extraBadPackageNames {
 					if r.extraBadPackageNames == nil {
 						r.extraBadPackageNames = map[string]struct{}{}
 					}
-					r.extraBadPackageNames[strings.ToLower(name.(string))] = struct{}{}
+					n, ok := name.(string)
+					if !ok {
+						return fmt.Errorf("invalid third argument to the var-naming rule: expected element %d of extraBadPackageNames to be a string, but got type %T", i, name)
+					}
+					r.extraBadPackageNames[strings.ToLower(n)] = struct{}{}
 				}
 			}
 		}

--- a/rule/var_naming_test.go
+++ b/rule/var_naming_test.go
@@ -117,6 +117,11 @@ func TestVarNamingRule_Configure(t *testing.T) {
 			arguments: lint.Arguments{[]any{""}, []any{""}, []any{map[string]any{"extraBadPackageNames": []int{1}}}},
 			wantErr:   errors.New("invalid third argument to the var-naming rule. Expecting extraBadPackageNames of type slice of strings, but []int"),
 		},
+		{
+			name:      "invalid third argument value type for extraBadPackageNames",
+			arguments: lint.Arguments{[]any{""}, []any{""}, []any{map[string]any{"extraBadPackageNames": []any{"helpers", 1}}}},
+			wantErr:   errors.New("invalid third argument to the var-naming rule: expected element 1 of extraBadPackageNames to be a string, but got type int"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/rule/var_naming_test.go
+++ b/rule/var_naming_test.go
@@ -120,7 +120,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 		{
 			name:      "invalid third argument value type for extraBadPackageNames",
 			arguments: lint.Arguments{[]any{""}, []any{""}, []any{map[string]any{"extraBadPackageNames": []any{"helpers", 1}}}},
-			wantErr:   errors.New("invalid third argument to the var-naming rule: expected element 1 of extraBadPackageNames to be a string, but got type int"),
+			wantErr:   errors.New("invalid third argument to the var-naming rule: expected element 1 of extraBadPackageNames to be a string, but got 1(int)"),
 		},
 	}
 

--- a/rule/var_naming_test.go
+++ b/rule/var_naming_test.go
@@ -119,8 +119,8 @@ func TestVarNamingRule_Configure(t *testing.T) {
 		},
 		{
 			name:      "invalid third argument value type for extraBadPackageNames",
-			arguments: lint.Arguments{[]any{""}, []any{""}, []any{map[string]any{"extraBadPackageNames": []any{"helpers", 1}}}},
-			wantErr:   errors.New("invalid third argument to the var-naming rule: expected element 1 of extraBadPackageNames to be a string, but got 1(int)"),
+			arguments: lint.Arguments{[]any{""}, []any{""}, []any{map[string]any{"extraBadPackageNames": []any{"helpers", 5}}}},
+			wantErr:   errors.New("invalid third argument to the var-naming rule: expected element 1 of extraBadPackageNames to be a string, but got 5(int)"),
 		},
 	}
 


### PR DESCRIPTION
This PR fixes a panic when running revive with the following configuration:

```toml
[rule.var-naming]
arguments = [[], [], [{ extra-bad-package-names = ["helpers", 123] }]]
```

Before:
```console
❯ ./revive -config revive.toml ./...
panic: interface conversion: interface {} is int64, not string

goroutine 1 [running]:
github.com/mgechev/revive/rule.(*VarNamingRule).Configure(0x1053e2ec0, {0x140001d37d0, 0x3, 0xa?})
        /Users/alexandear/src/github.com/mgechev/revive/rule/var_naming.go:94 +0x554
github.com/mgechev/revive/config.GetLintingRules(0x140001cdab0, {0x10540a7e0, 0x0, 0x8?})
        /Users/alexandear/src/github.com/mgechev/revive/config/config.go:158 +0x3c8
github.com/mgechev/revive/revivelib.New(0x140001cdab0, 0x0, 0x0, {0x0, 0x0, 0x140000021c0?})
        /Users/alexandear/src/github.com/mgechev/revive/revivelib/core.go:56 +0x240
github.com/mgechev/revive/cli.RunRevive({0x0, 0x0, 0x0})
        /Users/alexandear/src/github.com/mgechev/revive/cli/main.go:55 +0x8c
main.main()
        /Users/alexandear/src/github.com/mgechev/revive/main.go:7 +0x28
```

After:
```console
❯ ./revive -config revive.toml ./...
initializing revive - getting lint rules: cannot configure rule: "var-naming": invalid third argument to the var-naming rule: expected element 1 of extraBadPackageNames to be a string, but got type int64
```

Follows #1404