### PR TITLE
unexported-return: do not warn about exported alias

### DIFF
--- a/rule/unexported_return.go
+++ b/rule/unexported_return.go
@@ -78,7 +78,7 @@ func (*UnexportedReturnRule) Name() string {
 // It is imprecise, and will err on the side of returning true,
 // such as for composite types.
 func exportedType(typ types.Type) bool {
-	switch t := types.Unalias(typ).(type) {
+	switch t := typ.(type) {
 	case *types.Named:
 		obj := t.Obj()
 		switch {

--- a/testdata/golint/unexported_return.go
+++ b/testdata/golint/unexported_return.go
@@ -58,3 +58,20 @@ type int struct{}
 func ExportedIntReturner() int { // MATCH /exported func ExportedIntReturner returns unexported type foo.int, which can be annoying to use/
 	return int{}
 }
+
+type config struct {
+	N int
+}
+
+// Option is an option for [New].
+type Option = option
+
+// option is the hidden concrete implementation of Option.
+type option func(*config)
+
+// WithN sets N.
+func WithN(n int) Option {
+	return func(c *config) {
+		c.N = n
+	}
+}


### PR DESCRIPTION
Fixes #1406

`types.Unalias(typ)` was introduced in #1308, but the reason for its addition is unclear.