### PR TITLE
chore: enable formatters in golangci-lint config

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,19 +19,6 @@ jobs:
           git diff --exit-code go.mod
           git diff --exit-code go.sum
 
-  gofmt:
-    name: Check unformatted Go code
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
-      - name: Run gofmt
-        run: |
-          find . -type f -name '*.go' -not -path './testdata/*' -exec gofmt -w {} +
-          git diff --exit-code
-
   lint-go:
     name: Lint Go
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,12 +92,15 @@ linters:
 
 formatters:
   enable:
+    - gci
     - gofmt
     - goimports
   settings:
-    goimports:
-      local-prefixes:
-        - github.com/mgechev/revive
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/mgechev/revive)
 
 issues:
   # Show all issues from a linter.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,14 +92,12 @@ linters:
 
 formatters:
   enable:
-    - gci
     - gofmt
+    - goimports
   settings:
-    gci:
-      sections:
-        - standard
-        - default
-        - prefix(github.com/mgechev/revive)
+    goimports:
+      local-prefixes:
+        - github.com/mgechev/revive
 
 issues:
   # Show all issues from a linter.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,6 +90,17 @@ linters:
         - name: var-declaration
         - name: var-naming
 
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/mgechev/revive)
+
 issues:
   # Show all issues from a linter.
   max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ build:
 
 lint:
 	revive --config revive.toml ./...
+	golangci-lint run
+
+fmt:
+	golangci-lint fmt
 
 test:
 	@go test -v -race ./...
-

--- a/cli/main.go
+++ b/cli/main.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/spf13/afero"
+
 	"github.com/mgechev/revive/config"
 	"github.com/mgechev/revive/revivelib"
-	"github.com/spf13/afero"
 )
 
 const (

--- a/formatter/friendly.go
+++ b/formatter/friendly.go
@@ -10,6 +10,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/fatih/color"
+
 	"github.com/mgechev/revive/lint"
 )
 

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"codeberg.org/chavacava/garif"
+
 	"github.com/mgechev/revive/lint"
 )
 

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
+
 	"github.com/mgechev/revive/lint"
 )
 

--- a/revivelib/core.go
+++ b/revivelib/core.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/mgechev/dots"
+
 	"github.com/mgechev/revive/config"
 	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/logging"

--- a/revivelib/core_test.go
+++ b/revivelib/core_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/fatih/color"
+
 	"github.com/mgechev/revive/config"
 	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/revivelib"

--- a/rule/cognitive_complexity.go
+++ b/rule/cognitive_complexity.go
@@ -5,8 +5,9 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/mgechev/revive/lint"
 	"golang.org/x/tools/go/ast/astutil"
+
+	"github.com/mgechev/revive/lint"
 )
 
 // CognitiveComplexityRule sets restriction for maximum cognitive complexity.

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/fatih/structtag"
+
 	"github.com/mgechev/revive/internal/astutils"
 	"github.com/mgechev/revive/lint"
 )

--- a/test/redundant_import_alias_test.go
+++ b/test/redundant_import_alias_test.go
@@ -1,8 +1,9 @@
 package test
 
 import (
-	"github.com/mgechev/revive/rule"
 	"testing"
+
+	"github.com/mgechev/revive/rule"
 )
 
 func TestRedundantImportAlias(t *testing.T) {


### PR DESCRIPTION
This PR enables `gofmt`, `gci`, and `goimports` formatters in golangci-lint config.
Additionally, the PR removes `gofmt` job from the GitHub Actions workflow, since formatting is now handled by `golangci-lint`.