### PR TITLE
chore: add .gitignore entries for popular IDE configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ vendor
 *.swp
 dist/
 *.log
+
+# Popular golang IDE config dirs
+.vscode/
+.idea/
+.vim/
+.nvim/


### PR DESCRIPTION
I find it useful for contributors to have their IDE's config directories in `.gitignore` by default.
This change may cover popular golang IDEs.


