### PR TITLE
feature: add warnings on 'slices.Delete' in 'modifies-parameter' check

### DIFF
--- a/testdata/modifies_param.go
+++ b/testdata/modifies_param.go
@@ -1,5 +1,7 @@
 package fixtures
 
+import "slices"
+
 func one(a int) {
 	a, b := 1, 2 // MATCH /parameter 'a' seems to be modified/
 	a++          // MATCH /parameter 'a' seems to be modified/
@@ -22,4 +24,43 @@ func three(s *foo) {
 // non regression test for issue 355
 func issue355(_ *foo) {
 	_ = "foooooo"
+}
+
+func testSlicesDeleteAssigned(s []int) {
+	s = slices.Delete(s, 0, 1)                     // MATCH /parameter 's' is modified by slices.Delete/
+	s = slices.DeleteFunc(s, func(e string) bool { // MATCH /parameter 's' is modified by slices.DeleteFunc/
+		return true
+	})
+	_ = slices.Delete(s, 0, 1)                     // MATCH /parameter 's' is modified by slices.Delete/
+	_ = slices.DeleteFunc(s, func(e string) bool { // MATCH /parameter 's' is modified by slices.DeleteFunc/
+		return true
+	})
+	s, b := slices.Delete(s, 0, 1), 2 // MATCH /parameter 's' is modified by slices.Delete/
+}
+
+func testSlicesDeleteCloned(s []int) {
+	s2 := slices.Clone(s)
+	s2 = slices.Delete(s2, 0, 1)
+	_ = slices.Delete(slices.Clone(s), 0, 1)
+	_ = slices.DeleteFunc(slices.Clone(s), func(e string) bool {
+		return e == "test"
+	})
+}
+
+func testSlicesDeleteCopied(s []int) {
+	c := make([]int, len(s))
+	copy(c, s)
+	c = slices.Delete(c, 0, 1)
+}
+
+func testMultipleParams(a, b, s []int) {
+	a = slices.Delete(a, 0, 1) // MATCH /parameter 'a' is modified by slices.Delete/
+	b = slices.Delete(b, 1, 2) // MATCH /parameter 'b' is modified by slices.Delete/
+	s = []int{1, 2, 3}         // MATCH /parameter 's' seems to be modified/
+	s = slices.Delete(s, 0, 1) // MATCH /parameter 's' is modified by slices.Delete/
+}
+
+func testAssignToNewVar(s []int) {
+	newSlice := s
+	newSlice = slices.Delete(newSlice, 0, 1)
 }


### PR DESCRIPTION
Add warnings when function parameter was passed to `slices.Delete` or `slices.DeleteFunc` function.
The implementation is kind-of hardcoded right now. I can make it more future-proof by creating a list of function names with positions of arguments it modifies if it even needed, WDYT?

Closes https://github.com/mgechev/revive/issues/1410.
