### PR TITLE
docs: add DeepWiki link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/mgechev/revive/actions/workflows/test.yaml/badge.svg)](https://github.com/mgechev/revive/actions/workflows/test.yaml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/mgechev/revive.svg)](https://pkg.go.dev/github.com/mgechev/revive)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mgechev/revive)
 
 Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
 **`Revive` provides a framework for development of custom rules,


### PR DESCRIPTION
This PR adds a link to `https://deepwiki.com/mgechev/revive` to README, so everyone can understand better the architecture of Revive.

## What is DeepWiki?

DeepWiki provides up-to-date documentation you can talk to, for every repo in the world. Think Deep Research for GitHub.