### PR TITLE
feature: detect identical-branches in switch statements

### DIFF
--- a/internal/astutils/ast_utils.go
+++ b/internal/astutils/ast_utils.go
@@ -3,6 +3,8 @@ package astutils
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"go/ast"
 	"go/printer"
@@ -158,4 +160,14 @@ func GoFmt(x any) string {
 	fs := token.NewFileSet()
 	gofmtConfig.Fprint(&buf, fs, x)
 	return buf.String()
+}
+
+// NodeHash yields the MD5 hash of the given AST node.
+func NodeHash(node ast.Node) string {
+	hasher := func(in string) string {
+		binHash := md5.Sum([]byte(in))
+		return hex.EncodeToString(binHash[:])
+	}
+	str := GoFmt(node)
+	return hasher(str)
 }

--- a/internal/ifelse/branch_kind.go
+++ b/internal/ifelse/branch_kind.go
@@ -54,9 +54,7 @@ func (k BranchKind) Branch() Branch { return Branch{BranchKind: k} }
 // String returns a brief string representation.
 func (k BranchKind) String() string {
 	switch k {
-	case Empty:
-		return ""
-	case Regular:
+	case Empty, Regular:
 		return ""
 	case Return:
 		return "return"

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -480,8 +480,8 @@ func checkURLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messag
 	var delimiter = ""
 	for _, opt := range tag.Options {
 		switch opt {
-		case "int", "omitempty", "numbered", "brackets":
-		case "unix", "unixmilli", "unixnano": // TODO : check that the field is of type time.Time
+		case "int", "omitempty", "numbered", "brackets",
+			"unix", "unixmilli", "unixnano": // TODO : check that the field is of type time.Time
 		case "comma", "semicolon", "space":
 			if delimiter == "" {
 				delimiter = opt
@@ -597,9 +597,7 @@ func typeValueMatch(t ast.Expr, val string) bool {
 	case "int":
 		_, err := strconv.ParseInt(val, 10, 64)
 		typeMatches = err == nil
-	case "string":
-	case "nil":
-	default:
+	default: // "string", "nil", ...
 		// unchecked type
 	}
 

--- a/testdata/identical_branches.go
+++ b/testdata/identical_branches.go
@@ -38,7 +38,7 @@ func identicalBranches() {
 		println("else")
 	}
 
-	if true { // MATCH /"if...else if" chain with identical branches (lines [41 49])/
+	if true { // MATCH /"if...else if" chain with identical branches (lines 41 and 49)/
 		print("something")
 	} else if true {
 		print("something else")
@@ -50,7 +50,7 @@ func identicalBranches() {
 		print("something")
 	}
 
-	if true { // MATCH /"if...else if" chain with identical branches (lines [53 59])/
+	if true { // MATCH /"if...else if" chain with identical branches (lines 53 and 59)/
 		print("something")
 	} else if true {
 		print("something else")
@@ -66,7 +66,7 @@ func identicalBranches() {
 		print("something")
 	} else if true {
 		print("something else")
-		if true { // MATCH /"if...else if" chain with identical branches (lines [69 71])/
+		if true { // MATCH /"if...else if" chain with identical branches (lines 69 and 71)/
 			print("something")
 		} else if false {
 			print("something")
@@ -92,10 +92,10 @@ func identicalBranches() {
 	} else if d {
 		bar()
 	}
-	// MATCH:86 /"if...else if" chain with identical branches (lines [86 90])/
-	// MATCH:86 /"if...else if" chain with identical branches (lines [88 92])/
+	// MATCH:86 /"if...else if" chain with identical branches (lines 86 and 90)/
+	// MATCH:86 /"if...else if" chain with identical branches (lines 88 and 92)/
 
-	if createFile() { // json:{"MATCH": "\"if...else if\" chain with identical branches (lines [98 102])","Confidence": 0.8}
+	if createFile() { // json:{"MATCH": "\"if...else if\" chain with identical branches (lines 98 and 102)","Confidence": 0.8}
 		doSomething()
 	} else if !delete() {
 		return new("cannot delete file")
@@ -106,11 +106,80 @@ func identicalBranches() {
 	}
 
 	// Test confidence is reset
-	if a { // json:{"MATCH": "\"if...else if\" chain with identical branches (lines [109 111])","Confidence": 1}
+	if a { // json:{"MATCH": "\"if...else if\" chain with identical branches (lines 109 and 111)","Confidence": 1}
 		foo()
 	} else if b {
 		foo()
 	} else {
+		bar()
+	}
+
+	switch a { // MATCH /"switch" with identical branches (lines 119 and 123)/
+	// expected values
+	case 1:
+		foo()
+	case 2:
+		bar()
+	case 3:
+		foo()
+	default:
+		return newError("blah")
+	}
+
+	// MATCH:131 /"switch" with identical branches (lines 133 and 137)/
+	// MATCH:131 /"switch" with identical branches (lines 135 and 139)/
+	switch a {
+	// expected values
+	case 1:
+		foo()
+	case 2:
+		bar()
+	case 3:
+		foo()
+	default:
+		bar()
+	}
+
+	switch a { // MATCH /"switch" with identical branches (lines 145 and 147)/
+	// expected values
+	case 1:
+		foo()
+	case 3:
+		foo()
+	default:
+		if true { // MATCH /"if...else if" chain with identical branches (lines 150 and 152)/
+			something()
+		} else if true {
+			something()
+		} else {
+			if true { // MATCH /both branches of the if are identical/
+				print("identical")
+			} else {
+				print("identical")
+			}
+		}
+	}
+
+	// Skip untagged switch
+	switch {
+	case a > b:
+		foo()
+	default:
+		foo()
+	}
+
+	// Do not warn on fallthrough
+	switch a {
+	case 1:
+		foo()
+		fallthrough
+	case 2:
+		fallthrough
+	case 3:
+		foo()
+	case 4:
+		fallthrough
+	default:
 		bar()
 	}
 }


### PR DESCRIPTION
This PR extends `identical-branches` rule to analyse `switch` statements.

Notes:
1. Only un-tagged switches are not analysed because the order of case evaluation might be important thus two identical branches might exist but can not be merged into one case.
2. Branches ending with a `fallthrough` are not taken into account because the semantics of such branches is defined by the subsequent branch.
3. There are a lot of identical switch branches out there. For example, running the rule against Kubernetes code-base results in ~290 failures. Most of these failures do not spot actual logic problems in the code but more a "style" problem.

Closes #1442 