### PR TITLE
feature: new rule identical-switch-conditions

### DIFF
--- a/rule/identical_switch_conditions.go
+++ b/rule/identical_switch_conditions.go
@@ -1,0 +1,77 @@
+package rule
+
+import (
+	"fmt"
+	"go/ast"
+
+	"github.com/mgechev/revive/internal/astutils"
+	"github.com/mgechev/revive/lint"
+)
+
+// IdenticalSwitchConditionsRule warns on switch case clauses with identical conditions.
+type IdenticalSwitchConditionsRule struct{}
+
+// Apply applies the rule to given file.
+func (*IdenticalSwitchConditionsRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	var failures []lint.Failure
+
+	onFailure := func(failure lint.Failure) {
+		failures = append(failures, failure)
+	}
+
+	w := &lintIdenticalSwitchConditions{file: file, onFailure: onFailure}
+	for _, decl := range file.AST.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+
+		ast.Walk(w, fn.Body)
+	}
+
+	return failures
+}
+
+// Name returns the rule name.
+func (*IdenticalSwitchConditionsRule) Name() string {
+	return "identical-switch-conditions"
+}
+
+type lintIdenticalSwitchConditions struct {
+	file      *lint.File // only necessary to retrieve the line number of branches
+	onFailure func(lint.Failure)
+}
+
+func (w *lintIdenticalSwitchConditions) Visit(node ast.Node) ast.Visitor {
+	switchStmt, ok := node.(*ast.SwitchStmt)
+	if !ok { // not a switch statement, keep walking the AST
+		return w
+	}
+
+	if switchStmt.Tag != nil {
+		return w // Not interested in tagged switches
+	}
+
+	hashes := map[string]int{} // map hash(condition code) -> condition line
+	for _, cc := range switchStmt.Body.List {
+		caseClause := cc.(*ast.CaseClause)
+		caseClauseLine := w.file.ToPosition(caseClause.Pos()).Line
+		for _, expr := range caseClause.List {
+			hash := astutils.NodeHash(expr)
+			if matchLine, ok := hashes[hash]; ok {
+				w.onFailure(lint.Failure{
+					Confidence: 1.0,
+					Node:       caseClause,
+					Category:   lint.FailureCategoryLogic,
+					Failure:    fmt.Sprintf(`case clause at line %d has the same condition`, matchLine),
+				})
+			}
+
+			hashes[hash] = caseClauseLine
+		}
+
+		ast.Walk(w, caseClause)
+	}
+
+	return nil // switch branches already analyzed
+}

--- a/test/identical_switch_conditions_test.go
+++ b/test/identical_switch_conditions_test.go
@@ -1,0 +1,11 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestIdenticalSwitchConditions(t *testing.T) {
+	testRule(t, "identical_switch_conditions", &rule.IdenticalSwitchConditionsRule{})
+}

--- a/testdata/identical_switch_conditions.go
+++ b/testdata/identical_switch_conditions.go
@@ -1,0 +1,41 @@
+package fixtures
+
+func enforceSwitchStyle3() {
+
+	switch expression { // skipt tagged switch
+	case value:
+	default:
+	}
+
+	switch {
+	case a > 0, a < 0:
+	case a == 0:
+	case a < 0: // MATCH /case clause at line 11 has the same condition/
+	default:
+	}
+
+	switch {
+	case a > 0, a < 0, a > 0: // MATCH /case clause at line 18 has the same condition/
+	case a == 0:
+	case a < 0: // MATCH /case clause at line 18 has the same condition/
+	default:
+	}
+
+	switch something {
+	case 1:
+		switch {
+		case a > 0, a < 0, a > 0: // MATCH /case clause at line 27 has the same condition/
+		case a == 0:
+		}
+	default:
+	}
+
+	switch {
+	case a == 0:
+		switch {
+		case a > 0, a < 0, a > 0: // MATCH /case clause at line 36 has the same condition/
+		case a == 0:
+		}
+	default:
+	}
+}


### PR DESCRIPTION
This PR adds `identical-switch-conditions`, a new rule to warn on switch case clauses with repeated conditions.

(partially) Closes #1444: I propose to have 2 rules: one for switch and another for if...else if.

/!\ Will add doc in a future commit. Open to review.

cc: @ccoVeille 