### PR TITLE
unexported-return: allow unexported type aliases for exported types

### DIFF
--- a/rule/unexported_return.go
+++ b/rule/unexported_return.go
@@ -86,8 +86,9 @@ func exportedType(typ types.Type) bool {
 		case obj.Pkg() == nil:
 		case obj.Exported():
 		default:
-			_, ok := t.Underlying().(*types.Interface)
-			return ok
+			// If an alias itself is not exported, recursively check
+			// that the aliased type is exported.
+			return exportedType(t.Rhs())
 		}
 		return true
 	case *types.Named:

--- a/testdata/golint/unexported_return.go
+++ b/testdata/golint/unexported_return.go
@@ -59,6 +59,15 @@ func ExportedIntReturner() int { // MATCH /exported func ExportedIntReturner ret
 	return int{}
 }
 
+type unexportedInterface interface {
+	UnexportedInterface()
+}
+
+// UnexportedInterfaceReturner returns an unexported interface type from this package.
+func UnexportedInterfaceReturner() unexportedInterface {
+	return nil
+}
+
 type config struct {
 	N int
 }
@@ -81,8 +90,24 @@ type b = A
 type A func(*config)
 
 // WithA ...
-func WithA(n int) b { // MATCH /exported func WithA returns unexported type foo.b, which can be annoying to use/
+func WithA(n int) b {
 	return func(c *config) {
 		c.N = n
 	}
+}
+
+// Check that we allow unexported type aliases if there is an “exported” type
+// that can be used instead of an alias.
+
+type funTypeAlias1 = func()
+
+type funTypeAlias = funTypeAlias1
+
+var funFunc func() func() // unaliased signature
+
+func init() { funFunc = Fun }
+
+// Fun returns an aliased function type.
+func Fun() funTypeAlias {
+	return func() {}
 }


### PR DESCRIPTION
Allow unexported type aliases if there is an “exported” type that can be used instead of an alias.

Closes #1455