### PR TITLE
unexported-return: do not allow unexported interfaces

### DIFF
--- a/rule/unexported_return.go
+++ b/rule/unexported_return.go
@@ -80,27 +80,9 @@ func (*UnexportedReturnRule) Name() string {
 func exportedType(typ types.Type) bool {
 	switch t := typ.(type) {
 	case *types.Alias:
-		obj := t.Obj()
-		switch {
-		// Builtin types have no package.
-		case obj.Pkg() == nil:
-		case obj.Exported():
-		default:
-			_, ok := t.Underlying().(*types.Interface)
-			return ok
-		}
-		return true
+		return exportedTypeName(t.Obj())
 	case *types.Named:
-		obj := t.Obj()
-		switch {
-		// Builtin types have no package.
-		case obj.Pkg() == nil:
-		case obj.Exported():
-		default:
-			_, ok := t.Underlying().(*types.Interface)
-			return ok
-		}
-		return true
+		return exportedTypeName(t.Obj())
 	case *types.Map:
 		return exportedType(t.Key()) && exportedType(t.Elem())
 	case interface {
@@ -108,6 +90,11 @@ func exportedType(typ types.Type) bool {
 	}: // array, slice, pointer, chan
 		return exportedType(t.Elem())
 	}
-	// Be conservative about other types, such as struct, interface, etc.
+	// Be conservative about other unnamed types, such as struct, interface, etc.
 	return true
+}
+
+func exportedTypeName(obj *types.TypeName) bool {
+	// Builtin types have no package.
+	return obj.Pkg() == nil || obj.Exported()
 }

--- a/testdata/golint/unexported_return.go
+++ b/testdata/golint/unexported_return.go
@@ -59,6 +59,15 @@ func ExportedIntReturner() int { // MATCH /exported func ExportedIntReturner ret
 	return int{}
 }
 
+type unexportedInterface interface {
+	UnexportedInterface()
+}
+
+// UnexportedInterfacePointer returns an unexported interface pointer type from this package.
+func UnexportedInterfacePointer() *unexportedInterface { // MATCH /exported func UnexportedInterfacePointer returns unexported type *foo.unexportedInterface, which can be annoying to use/
+	return nil
+}
+
 type config struct {
 	N int
 }


### PR DESCRIPTION
The current implementation of `unexported-return` rule allows returning unexported interface types.

```go
type unexportedInterface any

func New() unexportedInterface {
        return nil
}
```

Closes #1457