### PR TITLE
struct-tag: support spanner struct tag

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1104,7 +1104,7 @@ _Configuration_: N/A
 
 _Description_: Struct tags are not checked at compile time.
 This rule spots errors in struct tags of the following types:
-asn1, bson, datastore, default, json, mapstructure, properties, protobuf, required, toml, url, validate, xml, yaml.
+asn1, bson, datastore, default, json, mapstructure, properties, protobuf, required, spanner, toml, url, validate, xml, yaml.
 
 _Configuration_: (optional) list of user defined options.
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -35,6 +35,7 @@ const (
 	keyValidate     tagKey = "validate"
 	keyXML          tagKey = "xml"
 	keyYAML         tagKey = "yaml"
+	keySpanner		tagKey = "spanner"
 )
 
 type tagChecker func(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeeded bool)
@@ -54,6 +55,7 @@ var tagCheckers = map[tagKey]tagChecker{
 	keyValidate:     checkValidateTag,
 	keyXML:          checkXMLTag,
 	keyYAML:         checkYAMLTag,
+	keySpanner:		 checkSpannerTag,
 }
 
 type checkContext struct {
@@ -198,7 +200,7 @@ func (w lintStructTagRule) checkTagNameIfNeed(checkCtx *checkContext, tag *struc
 
 	key := tagKey(tag.Key)
 	switch key {
-	case keyBSON, keyJSON, keyXML, keyYAML, keyProtobuf:
+	case keyBSON, keyJSON, keyXML, keyYAML, keyProtobuf, keySpanner:
 	default:
 		return "", true
 	}
@@ -555,6 +557,18 @@ func checkYAMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messa
 		}
 	}
 
+	return "", true
+}
+
+func checkSpannerTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
+	if tag.Name == "-" {
+		return "", true
+	}
+	for _, opt := range tag.Options {
+		if !checkCtx.isUserDefined(keySpanner, opt) {
+			return fmt.Sprintf(msgUnknownOption, opt), false
+		}
+	}
 	return "", true
 }
 

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -30,12 +30,12 @@ const (
 	keyProperties   tagKey = "properties"
 	keyProtobuf     tagKey = "protobuf"
 	keyRequired     tagKey = "required"
+	keySpanner      tagKey = "spanner"
 	keyTOML         tagKey = "toml"
 	keyURL          tagKey = "url"
 	keyValidate     tagKey = "validate"
 	keyXML          tagKey = "xml"
 	keyYAML         tagKey = "yaml"
-	keySpanner      tagKey = "spanner"
 )
 
 type tagChecker func(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeeded bool)
@@ -50,12 +50,12 @@ var tagCheckers = map[tagKey]tagChecker{
 	keyProperties:   checkPropertiesTag,
 	keyProtobuf:     checkProtobufTag,
 	keyRequired:     checkRequiredTag,
+	keySpanner:      checkSpannerTag,
 	keyTOML:         checkTOMLTag,
 	keyURL:          checkURLTag,
 	keyValidate:     checkValidateTag,
 	keyXML:          checkXMLTag,
 	keyYAML:         checkYAMLTag,
-	keySpanner:      checkSpannerTag,
 }
 
 type checkContext struct {

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -35,7 +35,7 @@ const (
 	keyValidate     tagKey = "validate"
 	keyXML          tagKey = "xml"
 	keyYAML         tagKey = "yaml"
-	keySpanner		tagKey = "spanner"
+	keySpanner      tagKey = "spanner"
 )
 
 type tagChecker func(checkCtx *checkContext, tag *structtag.Tag, fieldType ast.Expr) (message string, succeeded bool)
@@ -55,7 +55,7 @@ var tagCheckers = map[tagKey]tagChecker{
 	keyValidate:     checkValidateTag,
 	keyXML:          checkXMLTag,
 	keyYAML:         checkYAMLTag,
-	keySpanner:		 checkSpannerTag,
+	keySpanner:      checkSpannerTag,
 }
 
 type checkContext struct {

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -21,6 +21,7 @@ func TestStructTagWithUserOptions(t *testing.T) {
 			"mapstructure,myMapstructureOption",
 			"validate,displayName",
 			"toml,unknown",
+			"spanner,mySpannerOption",
 		},
 	})
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -88,6 +88,12 @@ type TestDuplicatedProtobufTags struct {
 	C int `protobuf:"varint,name=c"` // MATCH /duplicated tag name "c" in protobuf tag/
 }
 
+type SpannerDuplicatedTags struct {
+	A int `spanner:"field_a"`
+	B int `spanner:"field_a"` // MATCH /duplicated tag name "field_a" in spanner tag/
+	C int `spanner:"field_c"`
+}
+
 // test case from
 // sigs.k8s.io/kustomize/api/types/helmchartargs.go
 
@@ -181,4 +187,12 @@ type PropertiesTags struct {
 	Field string            `properties:"date,layout=2006-01-02"` // MATCH /layout option is only applicable to fields of type time.Time in properties tag/
 	Field []string          `properties:",default=a;b;c"`
 	Field map[string]string `properties:"myName,omitempty"` // MATCH /unknown or malformed option "omitempty" in properties tag/
+}
+
+type SpannerUser struct {
+	ID        int       `spanner:"user_id"`
+	Name      string    `spanner:"full_name"`
+	Email     string    `spanner:"-"`                    // Valid: ignore field
+	CreatedAt time.Time `spanner:"created_at"`
+	UpdatedAt time.Time `spanner:"updated_at,unknown"`   // MATCH /unknown option "unknown" in spanner tag/
 }

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -46,3 +46,8 @@ type TomlUser struct {
 	Username string `toml:"username,omitempty"`
 	Location string `toml:"location,unknown"`
 }
+
+type SpannerUserOptions struct {
+	ID        int    `spanner:"user_id,mySpannerOption"`
+	Name      string `spanner:"full_name,unknownOption"` // MATCH /unknown option "unknownOption" in spanner tag/
+}


### PR DESCRIPTION
<!-- ### IMPORTANT ### -->
<!-- Please do not create a Pull Request without creating an issue first.** -->
<!-- If you're fixing a typo or improving the documentation, you may not have to open an issue. -->

<!-- ### CHECKLIST ### -->
<!-- Please, describe in details what's your motivation for this PR -->
<!-- Did you add tests? -->
<!-- Does your code follow the coding style of the rest of the repository? -->
<!-- Does the GitHub Action build passes? -->

<!-- ### FOOTER (OPTIONAL) ### -->
<!-- If you're closing an issue, add "Closes #XXXX" in your comment. This way, the PR will be linked to the issue automatically. -->

## Description
Adds support for Google Cloud Spanner struct tags to the `struct-tag` rule.

## Changes

- Added `keySpanner` constant for the spanner tag key
- Implemented `checkSpannerTag` function with validation for:
  - Special case `spanner:"-"` (ignore field during decoding)
  - Regular field name mappings like `spanner:"column_name"`
  - User-defined options through configuration
- Added spanner to tag name checking logic
- Added spanner to the tagCheckers map

## Testing

The implementation follows the same pattern as existing tag checkers (JSON, XML, YAML, etc.) and handles the documented spanner tag behavior from the official Go client library.

Closes #1475
