### PR TITLE
feature: detect useless options in spanner struct tag

### DIFF
--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -562,13 +562,18 @@ func checkYAMLTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (messa
 
 func checkSpannerTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (message string, succeeded bool) {
 	if tag.Name == "-" {
+		if len(tag.Options) > 0 {
+			return fmt.Sprintf("useless option(s) %s for ignored field", strings.Join(tag.Options, ",")), false
+		}
 		return "", true
 	}
+
 	for _, opt := range tag.Options {
 		if !checkCtx.isUserDefined(keySpanner, opt) {
 			return fmt.Sprintf(msgUnknownOption, opt), false
 		}
 	}
+
 	return "", true
 }
 

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -48,6 +48,7 @@ type TomlUser struct {
 }
 
 type SpannerUserOptions struct {
-	ID        int    `spanner:"user_id,mySpannerOption"`
-	Name      string `spanner:"full_name,unknownOption"` // MATCH /unknown option "unknownOption" in spanner tag/
+	ID   int    `spanner:"user_id,mySpannerOption"`
+	A    int    `spanner:"-,mySpannerOption"`       // MATCH /useless option(s) mySpannerOption for ignored field in spanner tag/
+	Name string `spanner:"full_name,unknownOption"` // MATCH /unknown option "unknownOption" in spanner tag/
 }


### PR DESCRIPTION
In spanner struct tags, `-` is used to ignore the field therefore any option following `-` is useless.

This PR evolves the spanner struct tag checker to spot useless options attached to ignored fields.
