### PR TITLE
fix: default formatter generates an extra new line

### DIFF
--- a/formatter/default.go
+++ b/formatter/default.go
@@ -21,8 +21,14 @@ func (*Default) Name() string {
 // Format formats the failures gotten from the lint.
 func (*Default) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
 	var buf bytes.Buffer
+	first := true
+	prefix := ""
 	for failure := range failures {
-		fmt.Fprintf(&buf, "%v: %s\n", failure.Position.Start, failure.Failure)
+		fmt.Fprintf(&buf, "%s%v: %s", prefix, failure.Position.Start, failure.Failure)
+		if first {
+			first = false
+			prefix = "\n"
+		}
 	}
 	return buf.String(), nil
 }

--- a/formatter/default.go
+++ b/formatter/default.go
@@ -21,14 +21,10 @@ func (*Default) Name() string {
 // Format formats the failures gotten from the lint.
 func (*Default) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
 	var buf bytes.Buffer
-	first := true
 	prefix := ""
 	for failure := range failures {
 		fmt.Fprintf(&buf, "%s%v: %s", prefix, failure.Position.Start, failure.Failure)
-		if first {
-			first = false
-			prefix = "\n"
-		}
+		prefix = "\n"
 	}
 	return buf.String(), nil
 }


### PR DESCRIPTION
The default formatter generates an extra empty line at the end of the failure list

<img width="1365" height="169" alt="image" src="https://github.com/user-attachments/assets/a799a18d-8ec1-495f-8d7a-09c194699daf" />

This PR removes the artifact.

<img width="940" height="147" alt="image" src="https://github.com/user-attachments/assets/af55a22a-2951-42b1-98e7-a02afe0e6bed" />
