### PR TITLE
feature: struct-tag warns on (useless) options on ignored fields

### DIFF
--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -574,6 +574,8 @@ func checkSpannerTag(checkCtx *checkContext, tag *structtag.Tag, _ ast.Expr) (me
 	return "", true
 }
 
+// checkOptionsOnIgnoredField checks if an ignored struct field (tag name "-") has any options specified.
+// It returns a message and false if there are useless options present, or an empty message and true if valid.
 func checkOptionsOnIgnoredField(tag *structtag.Tag) (message string, succeeded bool) {
 	if tag.Name != "-" {
 		return "", true
@@ -585,12 +587,12 @@ func checkOptionsOnIgnoredField(tag *structtag.Tag) (message string, succeeded b
 	case 1:
 		opt := strings.TrimSpace(tag.Options[0])
 		if opt == "" {
-			return "useless empty option for ignored field (remove the comma after -)", false
+			return "", true // accept "-," as options
 		}
 
 		return fmt.Sprintf("useless option %s for ignored field", opt), false
 	default:
-		return fmt.Sprintf("useless option(s) %s for ignored field", strings.Join(tag.Options, ",")), false
+		return fmt.Sprintf("useless options %s for ignored field", strings.Join(tag.Options, ",")), false
 	}
 }
 

--- a/testdata/go1.24/struct_tag.go
+++ b/testdata/go1.24/struct_tag.go
@@ -21,7 +21,7 @@ type decodeAndValidateRequest struct {
 	OptionalQuery    string          `json:"-" querystring:"queryfoo"`
 	optionalQuery    string          `json:"-" querystring:"queryfoo"` // MATCH /tag on not-exported field optionalQuery/
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
-	Tiret       string `json:"-,"`                   // MATCH /useless empty option for ignored field (remove the comma after -) in json tag/
+	Tiret       string `json:"-,"`
 	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in json tag/
 	ForOmitzero string `json:"forOmitZero,omitzero"` // Go 1.24 introduces omitzero
 }

--- a/testdata/go1.24/struct_tag.go
+++ b/testdata/go1.24/struct_tag.go
@@ -21,7 +21,7 @@ type decodeAndValidateRequest struct {
 	OptionalQuery    string          `json:"-" querystring:"queryfoo"`
 	optionalQuery    string          `json:"-" querystring:"queryfoo"` // MATCH /tag on not-exported field optionalQuery/
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
-	Tiret       string `json:"-,"`
+	Tiret       string `json:"-,"`                   // MATCH /useless empty option for ignored field (remove the comma after -) in json tag/
 	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in json tag/
 	ForOmitzero string `json:"forOmitZero,omitzero"` // Go 1.24 introduces omitzero
 }

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -23,7 +23,7 @@ type decodeAndValidateRequest struct {
 	OptionalQuery    string          `json:"-" querystring:"queryfoo"`
 	optionalQuery    string          `json:"-" querystring:"queryfoo"` // MATCH /tag on not-exported field optionalQuery/
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
-	Tiret       string `json:"-,"`                   // MATCH /useless empty option for ignored field (remove the comma after -) in json tag/
+	Tiret       string `json:"-,"`
 	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in json tag/
 	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /prior Go 1.24, option "omitzero" is unsupported in json tag/
 	// MATCH:30 /option can not be empty in json tag/

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -23,7 +23,7 @@ type decodeAndValidateRequest struct {
 	OptionalQuery    string          `json:"-" querystring:"queryfoo"`
 	optionalQuery    string          `json:"-" querystring:"queryfoo"` // MATCH /tag on not-exported field optionalQuery/
 	// No-reg test for bug https://github.com/mgechev/revive/issues/208
-	Tiret       string `json:"-,"`
+	Tiret       string `json:"-,"`                   // MATCH /useless empty option for ignored field (remove the comma after -) in json tag/
 	BadTiret    string `json:"other,"`               // MATCH /option can not be empty in json tag/
 	ForOmitzero string `json:"forOmitZero,omitzero"` // MATCH /prior Go 1.24, option "omitzero" is unsupported in json tag/
 	// MATCH:30 /option can not be empty in json tag/
@@ -192,7 +192,7 @@ type PropertiesTags struct {
 type SpannerUser struct {
 	ID        int       `spanner:"user_id"`
 	Name      string    `spanner:"full_name"`
-	Email     string    `spanner:"-"`                    // Valid: ignore field
+	Email     string    `spanner:"-"` // Valid: ignore field
 	CreatedAt time.Time `spanner:"created_at"`
-	UpdatedAt time.Time `spanner:"updated_at,unknown"`   // MATCH /unknown option "unknown" in spanner tag/
+	UpdatedAt time.Time `spanner:"updated_at,unknown"` // MATCH /unknown option "unknown" in spanner tag/
 }

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -1,5 +1,7 @@
 package fixtures
 
+import "time"
+
 type RangeAllocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -49,6 +51,49 @@ type TomlUser struct {
 
 type SpannerUserOptions struct {
 	ID   int    `spanner:"user_id,mySpannerOption"`
-	A    int    `spanner:"-,mySpannerOption"`       // MATCH /useless option(s) mySpannerOption for ignored field in spanner tag/
+	A    int    `spanner:"-,mySpannerOption"`       // MATCH /useless option mySpannerOption for ignored field in spanner tag/
 	Name string `spanner:"full_name,unknownOption"` // MATCH /unknown option "unknownOption" in spanner tag/
+}
+
+type uselessOptions struct {
+	A  int       `bson:"-,"`                                           // MATCH /useless empty option for ignored field (remove the comma after -) in bson tag/
+	B  int       `bson:"-,omitempty"`                                  // MATCH /useless option omitempty for ignored field in bson tag/
+	C  int       `bson:"-,omitempty,omitempty"`                        // MATCH /useless option(s) omitempty,omitempty for ignored field in bson tag/
+	D  int       `datastore:"-,"`                                      // MATCH /useless empty option for ignored field (remove the comma after -) in datastore tag/
+	E  int       `datastore:"-,omitempty"`                             // MATCH /useless option omitempty for ignored field in datastore tag/
+	F  int       `datastore:"-,omitempty,omitempty"`                   // MATCH /useless option(s) omitempty,omitempty for ignored field in datastore tag/
+	G  int       `json:"-,"`                                           // MATCH /useless empty option for ignored field (remove the comma after -) in json tag/
+	H  int       `json:"-,omitempty"`                                  // MATCH /useless option omitempty for ignored field in json tag/
+	I  int       `json:"-,omitempty,omitempty"`                        // MATCH /useless option(s) omitempty,omitempty for ignored field in json tag/
+	J  int       `mapstructure:"-,"`                                   // MATCH /useless empty option for ignored field (remove the comma after -) in mapstructure tag/
+	K  int       `mapstructure:"-,squash"`                             // MATCH /useless option squash for ignored field in mapstructure tag/
+	L  int       `mapstructure:"-,omitempty,omitempty"`                // MATCH /useless option(s) omitempty,omitempty for ignored field in mapstructure tag/
+	M  int       `properties:"-,"`                                     // MATCH /useless empty option for ignored field (remove the comma after -) in properties tag/
+	N  int       `properties:"-,default=15"`                           // MATCH /useless option default=15 for ignored field in properties tag/
+	O  time.Time `properties:"-,layout=2006-01-02,default=2006-01-02"` // MATCH /useless option(s) layout=2006-01-02,default=2006-01-02 for ignored field in properties tag/
+	P  int       `spanner:"-,"`                                        // MATCH /useless empty option for ignored field (remove the comma after -) in spanner tag/
+	Q  int       `spanner:"-,mySpannerOption"`                         // MATCH /useless option mySpannerOption for ignored field in spanner tag/
+	R  int       `spanner:"-,mySpannerOption,mySpannerOption"`         // MATCH /useless option(s) mySpannerOption,mySpannerOption for ignored field in spanner tag/
+	S  int       `toml:"-,"`                                           // MATCH /useless empty option for ignored field (remove the comma after -) in toml tag/
+	T  int       `toml:"-,omitempty"`                                  // MATCH /useless option omitempty for ignored field in toml tag/
+	U  int       `toml:"-,omitempty,omitempty"`                        // MATCH /useless option(s) omitempty,omitempty for ignored field in toml tag/
+	V  int       `url:"-,"`                                            // MATCH /useless empty option for ignored field (remove the comma after -) in url tag/
+	W  int       `url:"-,omitempty"`                                   // MATCH /useless option omitempty for ignored field in url tag/
+	X  int       `url:"-,omitempty,omitempty"`                         // MATCH /useless option(s) omitempty,omitempty for ignored field in url tag/
+	Y  int       `xml:"-,"`                                            // MATCH /useless empty option for ignored field (remove the comma after -) in xml tag/
+	Z  int       `xml:"-,omitempty"`                                   // MATCH /useless option omitempty for ignored field in xml tag/
+	Aa int       `xml:"-,omitempty,omitempty"`                         // MATCH /useless option(s) omitempty,omitempty for ignored field in xml tag/
+	Ba int       `yaml:"-,"`                                           // MATCH /useless empty option for ignored field (remove the comma after -) in yaml tag/
+	Ca int       `yaml:"-,omitempty"`                                  // MATCH /useless option omitempty for ignored field in yaml tag/
+	Da int       `yaml:"-,omitempty,omitempty"`                        // MATCH /useless option(s) omitempty,omitempty for ignored field in yaml tag/
+
+	// MATCH:59 /unknown option "" in bson tag/
+	// MATCH:62 /unknown option "" in datastore tag/
+	// MATCH:68 /unknown option "" in mapstructure tag/
+	// MATCH:71 /unknown or malformed option "" in properties tag/
+	// MATCH:74 /unknown option "" in spanner tag/
+	// MATCH:77 /unknown option "" in toml tag/
+	// MATCH:80 /unknown option "" in url tag/
+	// MATCH:83 /unknown option "" in xml tag/
+	// MATCH:86 /unknown option "" in yaml tag/
 }

--- a/testdata/struct_tag_user_options.go
+++ b/testdata/struct_tag_user_options.go
@@ -56,36 +56,36 @@ type SpannerUserOptions struct {
 }
 
 type uselessOptions struct {
-	A  int       `bson:"-,"`                                           // MATCH /useless empty option for ignored field (remove the comma after -) in bson tag/
-	B  int       `bson:"-,omitempty"`                                  // MATCH /useless option omitempty for ignored field in bson tag/
-	C  int       `bson:"-,omitempty,omitempty"`                        // MATCH /useless option(s) omitempty,omitempty for ignored field in bson tag/
-	D  int       `datastore:"-,"`                                      // MATCH /useless empty option for ignored field (remove the comma after -) in datastore tag/
-	E  int       `datastore:"-,omitempty"`                             // MATCH /useless option omitempty for ignored field in datastore tag/
-	F  int       `datastore:"-,omitempty,omitempty"`                   // MATCH /useless option(s) omitempty,omitempty for ignored field in datastore tag/
-	G  int       `json:"-,"`                                           // MATCH /useless empty option for ignored field (remove the comma after -) in json tag/
-	H  int       `json:"-,omitempty"`                                  // MATCH /useless option omitempty for ignored field in json tag/
-	I  int       `json:"-,omitempty,omitempty"`                        // MATCH /useless option(s) omitempty,omitempty for ignored field in json tag/
-	J  int       `mapstructure:"-,"`                                   // MATCH /useless empty option for ignored field (remove the comma after -) in mapstructure tag/
-	K  int       `mapstructure:"-,squash"`                             // MATCH /useless option squash for ignored field in mapstructure tag/
-	L  int       `mapstructure:"-,omitempty,omitempty"`                // MATCH /useless option(s) omitempty,omitempty for ignored field in mapstructure tag/
-	M  int       `properties:"-,"`                                     // MATCH /useless empty option for ignored field (remove the comma after -) in properties tag/
+	A  int       `bson:"-,"`
+	B  int       `bson:"-,omitempty"`           // MATCH /useless option omitempty for ignored field in bson tag/
+	C  int       `bson:"-,omitempty,omitempty"` // MATCH /useless options omitempty,omitempty for ignored field in bson tag/
+	D  int       `datastore:"-,"`
+	E  int       `datastore:"-,omitempty"`           // MATCH /useless option omitempty for ignored field in datastore tag/
+	F  int       `datastore:"-,omitempty,omitempty"` // MATCH /useless options omitempty,omitempty for ignored field in datastore tag/
+	G  int       `json:"-,"`
+	H  int       `json:"-,omitempty"`           // MATCH /useless option omitempty for ignored field in json tag/
+	I  int       `json:"-,omitempty,omitempty"` // MATCH /useless options omitempty,omitempty for ignored field in json tag/
+	J  int       `mapstructure:"-,"`
+	K  int       `mapstructure:"-,squash"`              // MATCH /useless option squash for ignored field in mapstructure tag/
+	L  int       `mapstructure:"-,omitempty,omitempty"` // MATCH /useless options omitempty,omitempty for ignored field in mapstructure tag/
+	M  int       `properties:"-,"`
 	N  int       `properties:"-,default=15"`                           // MATCH /useless option default=15 for ignored field in properties tag/
-	O  time.Time `properties:"-,layout=2006-01-02,default=2006-01-02"` // MATCH /useless option(s) layout=2006-01-02,default=2006-01-02 for ignored field in properties tag/
-	P  int       `spanner:"-,"`                                        // MATCH /useless empty option for ignored field (remove the comma after -) in spanner tag/
-	Q  int       `spanner:"-,mySpannerOption"`                         // MATCH /useless option mySpannerOption for ignored field in spanner tag/
-	R  int       `spanner:"-,mySpannerOption,mySpannerOption"`         // MATCH /useless option(s) mySpannerOption,mySpannerOption for ignored field in spanner tag/
-	S  int       `toml:"-,"`                                           // MATCH /useless empty option for ignored field (remove the comma after -) in toml tag/
-	T  int       `toml:"-,omitempty"`                                  // MATCH /useless option omitempty for ignored field in toml tag/
-	U  int       `toml:"-,omitempty,omitempty"`                        // MATCH /useless option(s) omitempty,omitempty for ignored field in toml tag/
-	V  int       `url:"-,"`                                            // MATCH /useless empty option for ignored field (remove the comma after -) in url tag/
-	W  int       `url:"-,omitempty"`                                   // MATCH /useless option omitempty for ignored field in url tag/
-	X  int       `url:"-,omitempty,omitempty"`                         // MATCH /useless option(s) omitempty,omitempty for ignored field in url tag/
-	Y  int       `xml:"-,"`                                            // MATCH /useless empty option for ignored field (remove the comma after -) in xml tag/
-	Z  int       `xml:"-,omitempty"`                                   // MATCH /useless option omitempty for ignored field in xml tag/
-	Aa int       `xml:"-,omitempty,omitempty"`                         // MATCH /useless option(s) omitempty,omitempty for ignored field in xml tag/
-	Ba int       `yaml:"-,"`                                           // MATCH /useless empty option for ignored field (remove the comma after -) in yaml tag/
-	Ca int       `yaml:"-,omitempty"`                                  // MATCH /useless option omitempty for ignored field in yaml tag/
-	Da int       `yaml:"-,omitempty,omitempty"`                        // MATCH /useless option(s) omitempty,omitempty for ignored field in yaml tag/
+	O  time.Time `properties:"-,layout=2006-01-02,default=2006-01-02"` // MATCH /useless options layout=2006-01-02,default=2006-01-02 for ignored field in properties tag/
+	P  int       `spanner:"-,"`
+	Q  int       `spanner:"-,mySpannerOption"`                 // MATCH /useless option mySpannerOption for ignored field in spanner tag/
+	R  int       `spanner:"-,mySpannerOption,mySpannerOption"` // MATCH /useless options mySpannerOption,mySpannerOption for ignored field in spanner tag/
+	S  int       `toml:"-,"`
+	T  int       `toml:"-,omitempty"`           // MATCH /useless option omitempty for ignored field in toml tag/
+	U  int       `toml:"-,omitempty,omitempty"` // MATCH /useless options omitempty,omitempty for ignored field in toml tag/
+	V  int       `url:"-,"`
+	W  int       `url:"-,omitempty"`           // MATCH /useless option omitempty for ignored field in url tag/
+	X  int       `url:"-,omitempty,omitempty"` // MATCH /useless options omitempty,omitempty for ignored field in url tag/
+	Y  int       `xml:"-,"`
+	Z  int       `xml:"-,omitempty"`           // MATCH /useless option omitempty for ignored field in xml tag/
+	Aa int       `xml:"-,omitempty,omitempty"` // MATCH /useless options omitempty,omitempty for ignored field in xml tag/
+	Ba int       `yaml:"-,"`
+	Ca int       `yaml:"-,omitempty"`           // MATCH /useless option omitempty for ignored field in yaml tag/
+	Da int       `yaml:"-,omitempty,omitempty"` // MATCH /useless options omitempty,omitempty for ignored field in yaml tag/
 
 	// MATCH:59 /unknown option "" in bson tag/
 	// MATCH:62 /unknown option "" in datastore tag/


### PR DESCRIPTION
This PR completes #1483 by detecting useless options on other known struct tags.

For some tags, using `-` to indicate "ignore field" is not formally defined nor documented but open source code bases use it.

