### PR TITLE
feature: secrets-serialization rule to warn about exported struct fields with JSON serialization that have a high chance of containing secrets or other sensitive information

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,7 @@ var allRules = append([]lint.Rule{
 	&rule.IdenticalSwitchBranchesRule{},
 	&rule.UselessFallthroughRule{},
 	&rule.PackageDirectoryMismatchRule{},
+	&rule.SecretsSerializationRule{},
 }, defaultRules...)
 
 // allFormatters is a list of all available formatters to output the linting results.

--- a/revive.toml
+++ b/revive.toml
@@ -40,6 +40,7 @@ warningCode = 1
 [rule.receiver-naming]
 [rule.redefines-builtin-id]
 [rule.redundant-build-tag]
+[rule.secrets-serialization]
 [rule.superfluous-else]
 [rule.time-date]
 [rule.time-equal]

--- a/rule/secrets_serialization.go
+++ b/rule/secrets_serialization.go
@@ -72,7 +72,7 @@ func (r *SecretsSerializationRule) Apply(file *lint.File, _ lint.Arguments) []li
 
 func (r *SecretsSerializationRule) isLikelySecret(name string) bool {
 	for _, indicator := range r.secretFieldIndicators {
-		if strings.Contains(name, indicator) {
+		if strings.Contains(name, strings.ToLower(indicator)) {
 			return true
 		}
 	}

--- a/rule/secrets_serialization.go
+++ b/rule/secrets_serialization.go
@@ -92,7 +92,7 @@ func (r *SecretsSerializationRule) getList(arg any, argName string) ([]string, e
 	for _, v := range args {
 		val, ok := v.(string)
 		if !ok {
-			return nil, fmt.Errorf("invalid argument to the secrets-serialization rule: expecting %s of type slice of strings, got slice of type %T", argName, val)
+			return nil, fmt.Errorf("invalid argument to the secrets-serialization rule: expecting %s of type slice of strings, got slice of type %T", argName, v)
 		}
 		list = append(list, val)
 	}

--- a/rule/secrets_serialization.go
+++ b/rule/secrets_serialization.go
@@ -1,0 +1,85 @@
+package rule
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"github.com/mgechev/revive/lint"
+)
+
+var defaultSecretFieldIndicators = []string{
+	"bearer", "secret", "token", "password", "key", "apikey", "auth", "credential", "credentials",
+}
+
+type SecretsSerializationRule struct {
+	secretFieldIndicators []string
+}
+
+func (r *SecretsSerializationRule) Name() string {
+	return "secrets-serialization"
+}
+
+func (r *SecretsSerializationRule) Configure(arguments lint.Arguments) error {
+	if len(arguments) < 1 {
+		r.secretFieldIndicators = defaultSecretFieldIndicators
+		return nil
+	}
+	list := arguments[0].([]interface{})
+	for _, item := range list {
+		r.secretFieldIndicators = append(r.secretFieldIndicators, item.(string))
+	}
+	return nil
+}
+
+func (r *SecretsSerializationRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	var failures []lint.Failure
+	walker := func(node ast.Node) bool {
+		genDecl, ok := node.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			return true
+		}
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			for _, field := range structType.Fields.List {
+				for _, fieldName := range field.Names {
+					name := strings.ToLower(fieldName.Name)
+					if r.isLikelySecret(name) && r.isExported(fieldName.Name) {
+						if field.Tag != nil && strings.Contains(field.Tag.Value, `json:"-"`) {
+							continue
+						}
+						failures = append(failures, lint.Failure{
+							Confidence: 1,
+							Node:       field,
+							Category:   "security",
+							Failure:    "Struct field '" + fieldName.Name + "' may contain secrets but is not excluded from JSON serialization (missing `json:\"-\"`)",
+						})
+					}
+				}
+			}
+		}
+		return true
+	}
+	ast.Inspect(file.AST, walker)
+	return failures
+}
+
+func (r *SecretsSerializationRule) isLikelySecret(name string) bool {
+	for _, indicator := range r.secretFieldIndicators {
+		if strings.Contains(name, indicator) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *SecretsSerializationRule) isExported(name string) bool {
+	return name[0] >= 'A' && name[0] <= 'Z'
+}

--- a/rule/secrets_serialization.go
+++ b/rule/secrets_serialization.go
@@ -86,13 +86,13 @@ func (r *SecretsSerializationRule) isExported(name string) bool {
 func (r *SecretsSerializationRule) getList(arg any, argName string) ([]string, error) {
 	args, ok := arg.([]any)
 	if !ok {
-		return nil, fmt.Errorf("invalid argument to the secrets-serialization rule. Expecting a %s of type slice with secret indicators, got %T", argName, arg)
+		return nil, fmt.Errorf("invalid argument to the secrets-serialization rule: expecting %s of type slice of strings, got %T", argName, arg)
 	}
 	var list []string
 	for _, v := range args {
 		val, ok := v.(string)
 		if !ok {
-			return nil, fmt.Errorf("invalid %v values of the secrets-serialization rule. Expecting slice of strings but got element of type %T", v, arg)
+			return nil, fmt.Errorf("invalid argument to the secrets-serialization rule: expecting %s of type slice of strings, got slice of type %T", argName, val)
 		}
 		list = append(list, val)
 	}

--- a/rule/secrets_serialization_test.go
+++ b/rule/secrets_serialization_test.go
@@ -1,0 +1,52 @@
+package rule_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
+)
+
+func TestSecretsSerializationConfigure(t *testing.T) {
+	type argumentsTest struct {
+		name      string
+		arguments lint.Arguments
+		wantErr   error
+	}
+	tests := []argumentsTest{
+		{
+			name: "String Slice",
+			arguments: lint.Arguments{
+				[]any{"foo", "Bar"}},
+			wantErr: nil,
+		},
+		{
+			name: "Int Slice",
+			arguments: lint.Arguments{
+				[]any{1, 2}},
+			wantErr: errors.New("invalid argument to the secrets-serialization rule: expecting secretFieldIndicators of type slice of strings, got slice of type int"),
+		},
+		{
+			name: "Not a Slice",
+			arguments: lint.Arguments{
+				"this is not a slice"},
+			wantErr: errors.New("invalid argument to the secrets-serialization rule: expecting secretFieldIndicators of type slice of strings, got string"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r rule.SecretsSerializationRule
+			err := r.Configure(tt.arguments)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("Configure() unexpected non-nil error %q", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr.Error() {
+				t.Errorf("Configure() unexpected error: got %q, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/test/secrets_serialization_test.go
+++ b/test/secrets_serialization_test.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+	"github.com/mgechev/revive/rule"
+)
+
+func TestSecretsSerialization(t *testing.T) {
+	testRule(t, "secrets_serialization_default", &rule.SecretsSerializationRule{}, &lint.RuleConfig{})
+	testRule(t, "secrets_serialization_custom", &rule.SecretsSerializationRule{}, &lint.RuleConfig{
+		Arguments: []any{[]any{"foo", "bar"}},
+	})
+}

--- a/testdata/secrets_serialization_custom.go
+++ b/testdata/secrets_serialization_custom.go
@@ -1,0 +1,10 @@
+package fixtures
+
+type SecretsSerializationCustom struct {
+	Foo         string `json:"-"`
+	Bar         string // MATCH /Struct field 'Bar' may contain secrets but is not excluded from JSON serialization (missing `json:"-"`)/
+	BearerToken string
+	AuthToken   string `json:"-"`
+	Apikey      string
+	credential  string
+}

--- a/testdata/secrets_serialization_default.go
+++ b/testdata/secrets_serialization_default.go
@@ -1,0 +1,10 @@
+package fixtures
+
+type SecretsSerializationDefault struct {
+	Foo         string
+	Bar         string
+	BearerToken string // MATCH /Struct field 'BearerToken' may contain secrets but is not excluded from JSON serialization (missing `json:"-"`)/
+	AuthToken   string `json:"-"`
+	Apikey      string //MATCH /Struct field 'Apikey' may contain secrets but is not excluded from JSON serialization (missing `json:"-"`)/
+	credential  string
+}


### PR DESCRIPTION
This PR proposes a new rule called secrets-serialization that scans for structs with exported fields that have a high chance of containing secrets. By default this list includes the following:

"BearerToken", "Secret", "Token", "Password", "Key", "APIKey", "Auth", "Credential", "ClientSecret", "AccessToken", "AuthToken"

but these values can be overridden with a configuration argument for specific use cases. Whenever the rule comes across a field with a name from this list and finds that the field does not have json serialization disabled with `json:"-"` then a warning will be raised.

The idea here is that many enterprise environments using structured logging simply rely on json serialization and then inadvertently log secrets such as passwords or other sensitive information including PII etc. It would be good to have a rule that does static code analysis to warn about potential security vulnerabilities in this context. By offering a rule argument to set the list of fields to consider the rule can be customized for application or business specific use cases. 

