### PR TITLE
doc: clearly identify configuration examples

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -117,7 +117,7 @@ _Configuration_:
 - `allowFloats` (`allowfloats`, `allow-floats`): (string) comma-separated list of allowed floats
 - `ignoreFuncs` (`ignorefuncs`, `ignore-funcs`): (string) comma-separated list of function names regexp patterns to exclude
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.add-constant]
@@ -140,7 +140,7 @@ Enforcing a maximum number of parameters helps to keep the code readable and mai
 
 _Configuration_: (int) the maximum number of parameters allowed per function.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.argument-limit]
@@ -159,7 +159,7 @@ _Description_: Checks given banned characters in identifiers(func, var, const). 
 
 _Configuration_: This rule requires a slice of strings, the characters to ban.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.banned-characters]
@@ -202,7 +202,7 @@ Enforcing a maximum complexity per function helps to keep code readable and main
 
 _Configuration_: (int) the maximum function complexity
 
-Example:
+Configuration example:
 
 ```toml
 [rule.cognitive-complexity]
@@ -226,7 +226,7 @@ _Configuration_: ([]string) list of exceptions. For example, to accept comments 
 
 You need to add both `"mypragma:"` and `"+optional"` in the configuration
 
-Example:
+Configuration example:
 
 ```toml
 [rule.comment-spacings]
@@ -240,7 +240,7 @@ metric = _comment lines / (lines of code + comment lines) * 100_
 
 _Configuration_: (int) the minimum expected comments lines density.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.comments-density]
@@ -274,7 +274,7 @@ _Configuration_:
 
 - `allowTypesBefore` (`allowtypesbefore`, `allow-types-before`): (string) comma-separated list of types that may be before 'context.Context'
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.context-as-argument]
@@ -303,7 +303,7 @@ Enforcing a maximum complexity per function helps to keep code readable and main
 
 _Configuration_: (int) the maximum function complexity
 
-Example:
+Configuration example:
 
 ```toml
 [rule.cyclomatic]
@@ -347,7 +347,7 @@ These gotchas are [described here](https://blog.learngoprogramming.com/gotchas-o
 _Configuration_: By default, all warnings are enabled but it is possible selectively enable them through configuration.
 For example to enable only `call-chain` and `loop`:
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.defer]
@@ -370,7 +370,7 @@ _Configuration_:
 
 - `allowedPackages` (`allowedpackages`, `allowed-packages`): (list of strings) comma-separated list of allowed dot import packages
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.dot-imports]
@@ -429,7 +429,7 @@ _Configuration_: ([]string) rule flags. Available flags are:
 - `allowJump` (`allowjump`, `allow-jump`): suggest a new jump (`return`, `continue` or `break` statement) if it could unnest multiple statements.
 By default, only relocation of _existing_ jumps (i.e. from the `else` clause) are suggested.
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.early-return]
@@ -465,7 +465,7 @@ _Configuration_: (string) Specifies the enforced style for map initialization. T
 - "make": Enforces the usage of `make(map[type]type)`.
 - "literal": Enforces the usage of `map[type]type{}`.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.enforce-map-style]
@@ -526,7 +526,7 @@ _Configuration_: (string) Specifies the enforced style for slice initialization.
 - "literal": Enforces the usage of `[]type{}`.
 - "nil": Enforces the usage of `var []type`.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.enforce-slice-style]
@@ -543,7 +543,7 @@ _Configuration_: ([]string) Specifies what to enforced: occurrence and/or positi
 - "allowNoDefault": allows `switch` without `default` case clause.
 - "allowDefaultNotLast": allows `default` case clause to be not the last clause of the `switch`.
 
-Examples:
+Configuration examples:
 
 To enforce that all `switch` statements have a `default` clause as its the last case clause:
 
@@ -590,7 +590,7 @@ More [information here](https://go.dev/wiki/CodeReviewComments#error-strings).
 _Configuration_: ([]string) the list of additional error functions to check.
 The format of values is `package.FunctionName`.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.error-strings]
@@ -626,7 +626,7 @@ by _repetitive_ in failure messages
 - `disableChecksOnTypes` (`disablechecksontypes`, `disable-checks-on-types`) disable all checks on type declarations
 - `disableChecksOnVariables` (`disablechecksonvariables`, `disable-checks-on-variables`) disable all checks on variable declarations
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.exported]
@@ -654,7 +654,7 @@ _Description_: This rule helps to enforce a common header for all source files i
 
 _Configuration_: (string) the header to look for in source files.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.file-header]
@@ -671,7 +671,7 @@ _Configuration_:
 - `skipComments` (`skipcomments`, `skip-comments`): (bool) if true ignore and do not count lines containing just comments (default `false`);
 - `skipBlankLines` (`skipblanklines`, `skip-blank-lines`): (bool) if true ignore and do not count lines made up purely of whitespace (default `false`).
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.file-length-limit]
@@ -690,7 +690,7 @@ Optionally, the rule can be configured to enforce other forms.
 
 _Configuration_: (string) regular expression for source filenames.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.filename-format]
@@ -711,7 +711,7 @@ _Description_: Functions too long (with many statements and/or lines) can be har
 
 _Configuration_: (int,int) the maximum allowed statements and lines. Must be non-negative integers. Set to 0 to disable the check
 
-Example:
+Configuration example:
 
 ```toml
 [rule.function-length]
@@ -726,7 +726,7 @@ _Description_: Functions returning too many results can be hard to understand/us
 
 _Configuration_: (int) the maximum allowed return values
 
-Example:
+Configuration example:
 
 ```toml
 [rule.function-result-limit]
@@ -796,14 +796,14 @@ _Note_: If both `allowRegex` and `denyRegex` are provided, the alias must comply
 If none are given (i.e. an empty map), the default value `^[a-z][a-z0-9]{0,}$` for allowRegex is used.
 Unknown keys will result in an error.
 
-Example (1):
+Configuration example (1):
 
 ```toml
 [rule.import-alias-naming]
 arguments = ["^[a-z][a-z0-9]{0,}$"]
 ```
 
-Examples (2):
+Configuration examples (2):
 
 ```toml
 [rule.import-alias-naming]
@@ -829,7 +829,7 @@ _Description_: Warns when importing block-listed packages.
 
 _Configuration_: block-list of package names (or regular expression package names).
 
-Example:
+Configuration example:
 
 ```toml
 [rule.imports-blocklist]
@@ -854,7 +854,7 @@ _Configuration_: ([]string) rule flags. Available flags are:
 
 - `preserveScope` (`preservescope`, `preserve-scope`): do not suggest refactorings that would increase variable scope
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.indent-error-flow]
@@ -889,7 +889,7 @@ and then a loop over `elements` is changed in an obvious but inefficient way:
         }
 ```
 
-Example:
+Configuration example:
 
 ```go
 aMap := map[string]bool{}{}
@@ -916,7 +916,7 @@ _Description_: Warns in the presence of code lines longer than a configured maxi
 
 _Configuration_: (int) maximum line length in characters.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.line-length-limit]
@@ -929,7 +929,7 @@ _Description_: Warns if nesting level of control structures (`if-then-else`, `fo
 
 _Configuration_: (int) maximum accepted nesting level of control structures (defaults to 5)
 
-Example:
+Configuration example:
 
 ```toml
 [rule.max-control-nesting]
@@ -945,7 +945,7 @@ This rule warns on files declaring more than a configured, maximum number of pub
 
 _Configuration_: (int) the maximum allowed public structs
 
-Example:
+Configuration example:
 
 ```toml
 [rule.max-public-structs]
@@ -1025,7 +1025,7 @@ For files in version directories (`v1`, `v2`, etc.), package name is checked if 
 
 _Configuration_: Named arguments for directory exclusions.
 
-Examples:
+Configuration examples:
 
 Default behavior excludes paths containing `testdata`
 
@@ -1082,7 +1082,7 @@ _Configuration_: (optional) list of key-value-pair-map (`[]map[string]any`).
 
 - `maxLength` (`maxlength`, `max-length`): (int) max length of receiver name
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.receiver-naming]
@@ -1149,7 +1149,7 @@ If you need to inverse the semantics you can add a `!` just before the first `/`
 
 3. The third string (optional) is a **message** containing the purpose for the regex, which will be used in lint errors.
 
-Example:
+Configuration example:
 
 ```toml
 [rule.string-format]
@@ -1192,7 +1192,7 @@ asn1, bson, datastore, default, json, mapstructure, properties, protobuf, requir
 
 _Configuration_: (optional) list of user defined options.
 
-Example:
+Configuration example:
 To accept the `inline` option in JSON tags (and `outline` and `gnu` in BSON tags) you must provide the following configuration
 
 ```toml
@@ -1209,7 +1209,7 @@ _Configuration_: ([]string) rule flags. Available flags are:
 
 - `preserveScope` (`preservescope`, `preserve-scope`): (string) do not suggest refactorings that would increase variable scope
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.superfluous-else]
@@ -1322,7 +1322,7 @@ foo, _ := bar(.*Baz).
 //   ^
 ```
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.unchecked-type-assertion]
@@ -1359,7 +1359,7 @@ _Description_: This rule warns when errors returned by a function are not explic
 
 _Configuration_: function names regexp patterns to ignore
 
-Example:
+Configuration example:
 
 ```toml
 [rule.unhandled-error]
@@ -1409,7 +1409,7 @@ _Description_: This rule warns on unused parameters. Functions or methods with u
 _Configuration_: Supports arguments with single of `map[string]any` with option `allowRegex` (`allowregex`, `allow-regex`) to provide additional
 to `_` mask to allowed unused parameter names.
 
-Examples:
+Configuration examples:
 
 This allows any names starting with `_`, not just `_` itself:
 
@@ -1434,7 +1434,7 @@ _Description_: This rule warns on unused method receivers. Methods with unused r
 _Configuration_:
 Supports arguments with single of `map[string]any` with option `allowRegex` to provide additional to `_` mask to allowed unused receiver names.
 
-Examples:
+Configuration examples:
 
 This allows any names starting with `_`, not just `_` itself:
 
@@ -1561,7 +1561,7 @@ to forbid using the values from the list as package names additionally to the st
 
 By default, the rule behaves exactly as the alternative in `golint` but optionally, you can relax it (see [golint/lint/issues/89](https://github.com/golang/lint/issues/89)).
 
-Examples:
+Configuration examples:
 
 ```toml
 [rule.var-naming]


### PR DESCRIPTION
Modify rule descriptions to clearly differentiate configuration examples from code examples.
