### PR TITLE
fix: rule `struct-tag` false positive on `validate:omitempty`

### DIFF
--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -843,6 +843,7 @@ var validateSingleOptions = map[string]struct{}{
 	"multibyte":                     {},
 	"number":                        {},
 	"numeric":                       {},
+	"omitempty":                     {},
 	"port":                          {},
 	"postcode_iso3166_alpha2":       {},
 	"postcode_iso3166_alpha2_field": {},

--- a/testdata/struct_tag.go
+++ b/testdata/struct_tag.go
@@ -156,6 +156,7 @@ type MapStruct struct {
 }
 
 type ValidateUser struct {
+	Id          string `validate:"omitempty,min=3,max=32"`
 	Username    string `validate:"required,min=3,max=32"`
 	Email       string `validate:"required,email"`
 	Password    string `validate:"required,min=8,max=32"`


### PR DESCRIPTION
Closes #1524 by adding `omitempty` to the list of accepted options for `validate`
