### PR TITLE
fix: rule `confusing-naming` false positive on multiple blank identifiers

### DIFF
--- a/rule/confusing_naming.go
+++ b/rule/confusing_naming.go
@@ -171,7 +171,7 @@ func checkStructFields(fields *ast.FieldList, structName string, w *lintConfusin
 			if id.Name == "_" {
 				continue
 			}
-			
+
 			normName := strings.ToUpper(id.Name)
 			if bl[normName] {
 				w.onFailure(lint.Failure{

--- a/rule/confusing_naming.go
+++ b/rule/confusing_naming.go
@@ -171,6 +171,7 @@ func checkStructFields(fields *ast.FieldList, structName string, w *lintConfusin
 			if id.Name == "_" {
 				continue
 			}
+			
 			normName := strings.ToUpper(id.Name)
 			if bl[normName] {
 				w.onFailure(lint.Failure{

--- a/rule/confusing_naming.go
+++ b/rule/confusing_naming.go
@@ -167,7 +167,7 @@ func checkStructFields(fields *ast.FieldList, structName string, w *lintConfusin
 	bl := make(map[string]bool, len(fields.List))
 	for _, f := range fields.List {
 		for _, id := range f.Names {
-			// Skip blank identifiers - they can appear multiple times for padding/alignment
+			// Skip blank identifiers
 			if id.Name == "_" {
 				continue
 			}

--- a/rule/confusing_naming.go
+++ b/rule/confusing_naming.go
@@ -167,6 +167,10 @@ func checkStructFields(fields *ast.FieldList, structName string, w *lintConfusin
 	bl := make(map[string]bool, len(fields.List))
 	for _, f := range fields.List {
 		for _, id := range f.Names {
+			// Skip blank identifiers - they can appear multiple times for padding/alignment
+			if id.Name == "_" {
+				continue
+			}
 			normName := strings.ToUpper(id.Name)
 			if bl[normName] {
 				w.onFailure(lint.Failure{

--- a/testdata/confusing_naming1.go
+++ b/testdata/confusing_naming1.go
@@ -93,5 +93,5 @@ type siginfoChild struct {
 	uid    uint32
 	status int32
 
-	_ [25]uint32 // Pad to 128 bytes
+	_ [25]uint32
 }

--- a/testdata/confusing_naming1.go
+++ b/testdata/confusing_naming1.go
@@ -81,3 +81,17 @@ type b[T any] struct{}
 
 func (x *b[T]) method() {
 }
+
+// Multiple blank identifiers should be allowed (for padding/alignment)
+type siginfoChild struct {
+	signo    int32
+	errno    int32
+	exitCode int32
+	_        int32
+
+	pid    int32
+	uid    uint32
+	status int32
+
+	_ [25]uint32 // Pad to 128 bytes
+}


### PR DESCRIPTION
## PR Summary
The `confusing-naming` rule was incorrectly reporting false positives when Go structs contained multiple blank identifier (`_`) fields, which are commonly used for padding and alignment. The rule's `checkStructFields` function was treating all field names equally, including blank identifiers, causing it to flag the second occurrence of `_` as differing only by capitalization from the first. This fix adds a simple check to skip blank identifiers before performing the capitalization comparison, as blank identifiers are special in Go and explicitly allowed to appear multiple times in the same struct according to the language specification.

Example:
```go
// test.go
package main

type siginfoChild struct {
    signo    int32
    errno    int32
    exitCode int32
    _        int32

    pid    int32
    uid    uint32
    status int32

    _ [25]uint32 // Pad to 128 bytes
}
```
Old output:
> Field '_' differs only by capitalization to other field in the struct type siginfoChild

Fixes #1535.