### PR TITLE
test: improve config tests; check only exported funcs

### DIFF
--- a/config/testdata/invalidExcludePattern.toml
+++ b/config/testdata/invalidExcludePattern.toml
@@ -1,0 +1,2 @@
+[rule.var-naming]
+  exclude = ["~[invalid(regex"]

--- a/config/testdata/issue-969.toml
+++ b/config/testdata/issue-969.toml
@@ -1,0 +1,9 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+enableAllRules = false
+
+[rule.imports-blacklist] # deprecated name of import-blocklist rule

--- a/config/testdata/non-defaults.toml
+++ b/config/testdata/non-defaults.toml
@@ -1,0 +1,21 @@
+ignoreGeneratedHeader = true
+severity = "error"
+confidence = 0.5
+errorCode = 2
+warningCode = 1
+
+enableAllRules = false
+enableDefaultRules = true
+
+[rule.argument-limit]
+    severity="warning"
+    exclude=["excluded/file.go"]
+    arguments=[4]
+
+[rule.blank-imports]
+    disabled=true
+
+[rule.exported]
+    severity="error"
+    exclude=["excluded/file-exported.go"]
+    arguments=["check-private-receivers", "disable-stuttering-check"]


### PR DESCRIPTION
This PR:

1. Adds the test cases for issue #969, an invalid rule excludes pattern, non-defaults config rules.
2. Renames `config` package to `config_test` in `config/config_test.go` and fixes tests.

Updates #1362