### PR TITLE
refactor: enable few linters in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,20 +7,27 @@ linters:
   default: none
   enable:
     - dupword
+    - embeddedstructfieldcheck
     - gocritic
-    - godot
     - godoclint
+    - godot
     - govet
     - ineffassign
     - misspell
+    - modernize
     - musttag
     - nolintlint
+    - recvcheck
     - revive
+    - sloglint
+    - staticcheck
     - testpackage
     - thelper
-    - staticcheck
+    - thelper
+    - unconvert
     - unparam
     - unused
+    - wastedassign
 
   exclusions:
     warn-unused: true

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -19,7 +19,8 @@ func (*JSON) Name() string {
 
 // jsonObject defines a JSON object of an failure.
 type jsonObject struct {
-	Severity     lint.Severity `json:"Severity"`
+	Severity lint.Severity `json:"Severity"`
+	//nolint:embeddedstructfieldcheck // backward compatibility
 	lint.Failure `json:",inline"`
 }
 

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -39,6 +39,7 @@ func (*Sarif) Format(failures <-chan lint.Failure, cfg lint.Config) (string, err
 
 type reviveRunLog struct {
 	*garif.LogFile
+
 	run   *garif.Run
 	rules map[string]lint.RuleConfig
 }

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -43,7 +43,7 @@ func (*Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string
 		if currentType == lint.SeverityError {
 			totalErrors++
 		}
-		result = append(result, formatFailure(f, lint.Severity(currentType)))
+		result = append(result, formatFailure(f, currentType))
 	}
 
 	fileReport := map[string][][]string{}

--- a/internal/ifelse/branch.go
+++ b/internal/ifelse/branch.go
@@ -9,7 +9,8 @@ import (
 // Branch contains information about a branch within an if-else chain.
 type Branch struct {
 	BranchKind
-	Call  // The function called at the end for kind Panic or Exit.
+	Call // The function called at the end for kind Panic or Exit.
+
 	block []ast.Stmt
 }
 

--- a/lint/file.go
+++ b/lint/file.go
@@ -235,9 +235,8 @@ func (f *File) disabledIntervals(rules []Rule, mustSpecifyDisableReason bool, fa
 				continue
 			}
 			ruleNames := []string{}
-			tempNames := strings.Split(match[rulesPos], ",")
 
-			for _, name := range tempNames {
+			for name := range strings.SplitSeq(match[rulesPos], ",") {
 				name = strings.Trim(name, "\n")
 				if name != "" {
 					ruleNames = append(ruleNames, name)
@@ -274,7 +273,7 @@ func (f *File) disabledIntervals(rules []Rule, mustSpecifyDisableReason bool, fa
 	return getEnabledDisabledIntervals()
 }
 
-func (File) filterFailures(failures []Failure, disabledIntervals disabledIntervalsMap) []Failure {
+func (*File) filterFailures(failures []Failure, disabledIntervals disabledIntervalsMap) []Failure {
 	result := []Failure{}
 	for _, failure := range failures {
 		fStart := failure.Position.Start.Line

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -37,7 +37,7 @@ func New(reader ReadFile, maxOpenFiles int) Linter {
 	}
 }
 
-func (l Linter) readFile(path string) (result []byte, err error) {
+func (l *Linter) readFile(path string) (result []byte, err error) {
 	if l.fileReadTokens != nil {
 		// "take" a token by writing to the channel.
 		// It will block if no more space in the channel's buffer

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -21,7 +21,7 @@ func GetLogger() (*slog.Logger, error) {
 	debugModeEnabled := os.Getenv("DEBUG") != ""
 	if !debugModeEnabled {
 		// by default, suppress all logging output
-		return slog.New(slog.NewTextHandler(io.Discard, nil)), nil // TODO: change to slog.New(slog.DiscardHandler) when we switch to Go 1.24
+		return slog.New(slog.DiscardHandler), nil
 	}
 
 	fileWriter, err := os.Create(logFile)

--- a/rule/add_constant.go
+++ b/rule/add_constant.go
@@ -25,8 +25,7 @@ func newAllowList() allowList {
 }
 
 func (wl allowList) add(kind, list string) {
-	elems := strings.Split(list, ",")
-	for _, e := range elems {
+	for e := range strings.SplitSeq(list, ",") {
 		wl[kind][e] = true
 	}
 }
@@ -247,7 +246,7 @@ func (r *AddConstantRule) Configure(arguments lint.Arguments) error {
 				return fmt.Errorf("invalid argument to the ignoreFuncs parameter of add-constant rule, string expected. Got '%v' (%T)", v, v)
 			}
 
-			for _, exclude := range strings.Split(excludes, ",") {
+			for exclude := range strings.SplitSeq(excludes, ",") {
 				exclude = strings.Trim(exclude, " ")
 				if exclude == "" {
 					return errors.New("invalid argument to the ignoreFuncs parameter of add-constant rule, expected regular expression must not be empty")

--- a/rule/bool_literal_in_expr.go
+++ b/rule/bool_literal_in_expr.go
@@ -61,7 +61,7 @@ func (w *lintBoolLiteral) Visit(node ast.Node) ast.Visitor {
 	return w
 }
 
-func (w lintBoolLiteral) addFailure(node ast.Node, msg string, cat lint.FailureCategory) {
+func (w *lintBoolLiteral) addFailure(node ast.Node, msg string, cat lint.FailureCategory) {
 	w.onFailure(lint.Failure{
 		Confidence: 1,
 		Node:       node,

--- a/rule/exported.go
+++ b/rule/exported.go
@@ -411,14 +411,13 @@ func (w *lintExported) checkGoDocStatus(comment *ast.CommentGroup, name string) 
 // An "interesting line" is a comment line that is neither a directive (e.g. //go:...) or a deprecation comment
 // (lines from the first line with a prefix // Deprecated: to the end of the comment group)
 // Empty or spaces-only lines are discarded.
-func (lintExported) firstCommentLine(comment *ast.CommentGroup) (result string) {
+func (*lintExported) firstCommentLine(comment *ast.CommentGroup) (result string) {
 	if comment == nil {
 		return ""
 	}
 
 	commentWithoutDirectives := comment.Text() // removes directives from the comment block
-	lines := strings.Split(commentWithoutDirectives, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(commentWithoutDirectives, "\n") {
 		line := strings.TrimSpace(line)
 		if line == "" {
 			continue // ignore empty lines

--- a/rule/file_header.go
+++ b/rule/file_header.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/mgechev/revive/lint"
 )
@@ -55,7 +56,7 @@ func (r *FileHeaderRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure
 	if g == nil {
 		return failure
 	}
-	comment := ""
+	var comment strings.Builder
 	for _, c := range g.List {
 		text := c.Text
 		if multiRegexp.MatchString(text) {
@@ -63,7 +64,7 @@ func (r *FileHeaderRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure
 		} else if singleRegexp.MatchString(text) {
 			text = text[2:]
 		}
-		comment += text
+		comment.WriteString(text)
 	}
 
 	regex, err := regexp.Compile(r.header)
@@ -71,7 +72,7 @@ func (r *FileHeaderRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure
 		return newInternalFailureError(err)
 	}
 
-	if !regex.MatchString(comment) {
+	if !regex.MatchString(comment.String()) {
 		return failure
 	}
 	return nil

--- a/rule/filename_format.go
+++ b/rule/filename_format.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"unicode"
 
 	"github.com/mgechev/revive/lint"
@@ -31,16 +32,16 @@ func (r *FilenameFormatRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fai
 }
 
 func (*FilenameFormatRule) getMsgForNonASCIIChars(str string) string {
-	result := ""
+	var result strings.Builder
 	for _, c := range str {
 		if c <= unicode.MaxASCII {
 			continue
 		}
 
-		result += fmt.Sprintf(" Non ASCII character %c (%U) found.", c, c)
+		result.WriteString(fmt.Sprintf(" Non ASCII character %c (%U) found.", c, c))
 	}
 
-	return result
+	return result.String()
 }
 
 // Name returns the rule name.

--- a/rule/modifies_param.go
+++ b/rule/modifies_param.go
@@ -29,7 +29,7 @@ func (*ModifiesParamRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failur
 	}
 
 	w := lintModifiesParamRule{onFailure: onFailure}
-	ast.Walk(w, file.AST)
+	ast.Walk(&w, file.AST)
 	return failures
 }
 
@@ -57,13 +57,13 @@ func retrieveParamNames(pl []*ast.Field) map[string]bool {
 	return result
 }
 
-func (w lintModifiesParamRule) Visit(node ast.Node) ast.Visitor {
+func (w *lintModifiesParamRule) Visit(node ast.Node) ast.Visitor {
 	switch v := node.(type) {
 	case *ast.FuncDecl:
 		w.params = retrieveParamNames(v.Type.Params.List)
 	case *ast.IncDecStmt:
 		if id, ok := v.X.(*ast.Ident); ok {
-			checkParam(id, &w)
+			checkParam(id, w)
 		}
 	case *ast.AssignStmt:
 		lhs := v.Lhs
@@ -76,7 +76,7 @@ func (w lintModifiesParamRule) Visit(node ast.Node) ast.Visitor {
 			if i < len(v.Rhs) {
 				w.checkModifyingFunction(v.Rhs[i])
 			}
-			checkParam(id, &w)
+			checkParam(id, w)
 		}
 	case *ast.ExprStmt:
 		w.checkModifyingFunction(v.X)

--- a/rule/package_directory_mismatch.go
+++ b/rule/package_directory_mismatch.go
@@ -85,7 +85,7 @@ var skipDirs = map[string]struct{}{
 }
 
 // semanticallyEqual checks if package and directory names are semantically equal to each other.
-func (PackageDirectoryMismatchRule) semanticallyEqual(packageName, dirName string) bool {
+func (*PackageDirectoryMismatchRule) semanticallyEqual(packageName, dirName string) bool {
 	normDir := normalizePath(dirName)
 	normPkg := normalizePath(packageName)
 	return normDir == normPkg || normDir == "go"+normPkg

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -71,7 +71,7 @@ type checkContext struct {
 	isAtLeastGo124 bool
 }
 
-func (checkCtx checkContext) isUserDefined(key tagKey, opt string) bool {
+func (checkCtx *checkContext) isUserDefined(key tagKey, opt string) bool {
 	if checkCtx.userDefined == nil {
 		return false
 	}
@@ -803,8 +803,7 @@ func (w lintStructTagRule) addFailuref(n ast.Node, msg string, args ...any) {
 }
 
 func areValidateOpts(opts string) (string, bool) {
-	parts := strings.Split(opts, "|")
-	for _, opt := range parts {
+	for opt := range strings.SplitSeq(opts, "|") {
 		_, ok := validateSingleOptions[opt]
 		if !ok {
 			return opt, false

--- a/rule/time_date.go
+++ b/rule/time_date.go
@@ -86,7 +86,7 @@ type timeDateMonthYear struct {
 	year, month int64
 }
 
-func (w lintTimeDate) Visit(n ast.Node) ast.Visitor {
+func (w *lintTimeDate) Visit(n ast.Node) ast.Visitor {
 	ce, ok := n.(*ast.CallExpr)
 	if !ok || len(ce.Args) != timeDateArity {
 		return w
@@ -361,7 +361,7 @@ func (w *lintTimeDate) checkArgSign(arg ast.Node, fieldName timeDateArgument) (*
 
 // isLeapYear checks if the year is a leap year.
 // This is used to check if the date is valid according to Go implementation.
-func (lintTimeDate) isLeapYear(year int64) bool {
+func (*lintTimeDate) isLeapYear(year int64) bool {
 	// We cannot use the classic formula of
 	// year%4 == 0 && (year%100 != 0 || year%400 == 0)
 	// because we want to ensure what time.Date will compute
@@ -369,7 +369,7 @@ func (lintTimeDate) isLeapYear(year int64) bool {
 	return time.Date(int(year), 2, 29, 0, 0, 0, 0, time.UTC).Format("01-02") == "02-29"
 }
 
-func (w lintTimeDate) daysInMonth(year int64, month time.Month) int64 {
+func (w *lintTimeDate) daysInMonth(year int64, month time.Month) int64 {
 	switch month {
 	case time.April, time.June, time.September, time.November:
 		return 30

--- a/rule/unhandled_error.go
+++ b/rule/unhandled_error.go
@@ -151,8 +151,8 @@ func (*lintUnhandledErrors) isTypeError(t *types.Named) bool {
 }
 
 func (w *lintUnhandledErrors) returnsAnError(tt *types.Tuple) bool {
-	for i := range tt.Len() {
-		nt, ok := tt.At(i).Type().(*types.Named)
+	for v := range tt.Variables() {
+		nt, ok := v.Type().(*types.Named)
 		if ok && w.isTypeError(nt) {
 			return true
 		}

--- a/rule/unnecessary_if.go
+++ b/rule/unnecessary_if.go
@@ -72,8 +72,8 @@ func (w *lintUnnecessaryIf) Visit(node ast.Node) ast.Visitor {
 		return w // then and else branches do not have just one statement
 	}
 
-	replacement := ""
-	thenBool := false
+	var replacement string
+	var thenBool bool
 	switch thenStmt := thenStmts[0].(type) {
 	case *ast.ReturnStmt:
 		replacement, thenBool = w.replacementForReturnStmt(thenStmt, elseStmts)

--- a/rule/use_fmt_print.go
+++ b/rule/use_fmt_print.go
@@ -85,7 +85,7 @@ func (lintUseFmtPrint) callArgsAsStr(args []ast.Expr) string {
 	return strings.Join(strs, ", ")
 }
 
-func (UseFmtPrintRule) analyzeRedefinitions(decls []ast.Decl) (redefinesPrint, redefinesPrintln bool) {
+func (*UseFmtPrintRule) analyzeRedefinitions(decls []ast.Decl) (redefinesPrint, redefinesPrintln bool) {
 	for _, decl := range decls {
 		fnDecl, ok := decl.(*ast.FuncDecl)
 		if !ok {

--- a/rule/var_naming.go
+++ b/rule/var_naming.go
@@ -471,6 +471,7 @@ func getList(arg any, argName string) ([]string, error) {
 
 type syncSet struct {
 	sync.Mutex
+
 	elements map[string]struct{}
 }
 

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -228,7 +228,7 @@ func parseInstructions(t *testing.T, filename string, src []byte) []instruction 
 	for _, cg := range f.Comments {
 		ln := fset.Position(cg.Pos()).Line
 		raw := cg.Text()
-		for _, line := range strings.Split(raw, "\n") {
+		for line := range strings.SplitSeq(raw, "\n") {
 			if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "ignore") {
 				continue
 			}

--- a/test/var_naming_test.go
+++ b/test/var_naming_test.go
@@ -69,7 +69,7 @@ func TestVarNaming(t *testing.T) {
 
 func BenchmarkUpperCaseConstTrue(b *testing.B) {
 	var t *testing.T
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		testRule(t, "var_naming_upper_case_const_true", &rule.VarNamingRule{}, &lint.RuleConfig{
 			Arguments: []any{[]any{}, []any{}, []any{map[string]any{"upperCaseConst": true}}},
 		})


### PR DESCRIPTION
This PR enables the following linters:

- embeddedstructfieldcheck
- modernize
- recvcheck
- sloglint
- unconvert
- wastedassign