### PR TITLE
refactor: remove unused checkNumberOfArguments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - revive
     - thelper
     - staticcheck
+    - unparam
     - unused
 
   exclusions:

--- a/rule/banned_characters.go
+++ b/rule/banned_characters.go
@@ -20,10 +20,6 @@ const bannedCharsRuleName = "banned-characters"
 // Configuration implements the [lint.ConfigurableRule] interface.
 func (r *BannedCharsRule) Configure(arguments lint.Arguments) error {
 	if len(arguments) > 0 {
-		err := checkNumberOfArguments(1, arguments, bannedCharsRuleName)
-		if err != nil {
-			return err
-		}
 		list, err := r.getBannedCharsList(arguments)
 		if err != nil {
 			return err

--- a/rule/max_control_nesting.go
+++ b/rule/max_control_nesting.go
@@ -112,11 +112,6 @@ func (r *MaxControlNestingRule) Configure(arguments lint.Arguments) error {
 		return nil
 	}
 
-	check := checkNumberOfArguments(1, arguments, r.Name())
-	if check != nil {
-		return check
-	}
-
 	maxNesting, ok := arguments[0].(int64) // Alt. non panicking version
 	if !ok {
 		return errors.New(`invalid value passed as argument number to the "max-control-nesting" rule`)

--- a/rule/max_public_structs.go
+++ b/rule/max_public_structs.go
@@ -25,11 +25,6 @@ func (r *MaxPublicStructsRule) Configure(arguments lint.Arguments) error {
 		return nil
 	}
 
-	err := checkNumberOfArguments(1, arguments, r.Name())
-	if err != nil {
-		return err
-	}
-
 	maxStructs, ok := arguments[0].(int64) // Alt. non panicking version
 	if !ok {
 		return errors.New(`invalid value passed as argument number to the "max-public-structs" rule`)

--- a/rule/struct_tag.go
+++ b/rule/struct_tag.go
@@ -105,11 +105,6 @@ func (r *StructTagRule) Configure(arguments lint.Arguments) error {
 		return nil
 	}
 
-	err := checkNumberOfArguments(1, arguments, r.Name())
-	if err != nil {
-		return err
-	}
-
 	r.userDefined = map[tagKey][]string{}
 	r.omittedTags = map[tagKey]struct{}{}
 	for _, arg := range arguments {

--- a/rule/utils.go
+++ b/rule/utils.go
@@ -1,7 +1,6 @@
 package rule
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"regexp"
@@ -49,14 +48,6 @@ func srcLine(src []byte, p token.Position) string {
 		hi++
 	}
 	return string(src[lo:hi])
-}
-
-// checkNumberOfArguments fails if the given number of arguments is not, at least, the expected one.
-func checkNumberOfArguments(expected int, args lint.Arguments, ruleName string) error {
-	if len(args) < expected {
-		return fmt.Errorf("not enough arguments for %s rule, expected %d, got %d. Please check the rule's documentation", ruleName, expected, len(args))
-	}
-	return nil
 }
 
 // isRuleOption returns true if arg and name are the same after normalization.


### PR DESCRIPTION
This was found by enabling the `unparam` linter.

```console
❯ golangci-lint run --enable-only unparam
rule/utils.go:55:29: checkNumberOfArguments - expected always receives 1 (unparam)
func checkNumberOfArguments(expected int, args lint.Arguments, ruleName string) error {
                            ^
1 issues:
* unparam: 1
* ```