### PR TITLE
test: fix testpackage lint issues for test and ifelse

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - musttag
     - nolintlint
     - revive
+    - testpackage
     - thelper
     - staticcheck
     - unparam
@@ -30,6 +31,18 @@ linters:
       - linters:
           - godoclint
         text: 'symbol should have a godoc \("Visit"\)'
+      - linters:
+          - testpackage
+        text: 'package should be `rule_test` instead of `rule`'
+      - linters:
+          - testpackage
+        text: 'package should be `lint_test` instead of `lint`'
+      - linters:
+          - testpackage
+        text: 'package should be `cli_test` instead of `cli`'
+      - linters:
+          - testpackage
+        text: 'package should be `formatter_test` instead of `formatter`'
 
   settings:
     gocritic:

--- a/internal/ifelse/branch_test.go
+++ b/internal/ifelse/branch_test.go
@@ -1,24 +1,26 @@
-package ifelse
+package ifelse_test
 
 import (
 	"go/ast"
 	"go/token"
 	"testing"
+
+	"github.com/mgechev/revive/internal/ifelse"
 )
 
 func TestBlockBranch(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		block := &ast.BlockStmt{List: []ast.Stmt{}}
-		b := BlockBranch(block)
-		if b.BranchKind != Empty {
+		b := ifelse.BlockBranch(block)
+		if b.BranchKind != ifelse.Empty {
 			t.Errorf("want Empty branch, got %v", b.BranchKind)
 		}
 	})
 	t.Run("non empty", func(t *testing.T) {
 		stmt := &ast.ReturnStmt{}
 		block := &ast.BlockStmt{List: []ast.Stmt{stmt}}
-		b := BlockBranch(block)
-		if b.BranchKind != Return {
+		b := ifelse.BlockBranch(block)
+		if b.BranchKind != ifelse.Return {
 			t.Errorf("want Return branch, got %v", b.BranchKind)
 		}
 	})
@@ -28,33 +30,33 @@ func TestStmtBranch(t *testing.T) {
 	cases := []struct {
 		name string
 		stmt ast.Stmt
-		kind BranchKind
-		call *Call
+		kind ifelse.BranchKind
+		call *ifelse.Call
 	}{
 		{
 			name: "ReturnStmt",
 			stmt: &ast.ReturnStmt{},
-			kind: Return,
+			kind: ifelse.Return,
 		},
 		{
 			name: "BreakStmt",
 			stmt: &ast.BranchStmt{Tok: token.BREAK},
-			kind: Break,
+			kind: ifelse.Break,
 		},
 		{
 			name: "ContinueStmt",
 			stmt: &ast.BranchStmt{Tok: token.CONTINUE},
-			kind: Continue,
+			kind: ifelse.Continue,
 		},
 		{
 			name: "GotoStmt",
 			stmt: &ast.BranchStmt{Tok: token.GOTO},
-			kind: Goto,
+			kind: ifelse.Goto,
 		},
 		{
 			name: "EmptyStmt",
 			stmt: &ast.EmptyStmt{},
-			kind: Empty,
+			kind: ifelse.Empty,
 		},
 		{
 			name: "ExprStmt with DeviatingFunc (panic)",
@@ -63,8 +65,8 @@ func TestStmtBranch(t *testing.T) {
 					Fun: &ast.Ident{Name: "panic"},
 				},
 			},
-			kind: Panic,
-			call: &Call{Name: "panic"},
+			kind: ifelse.Panic,
+			call: &ifelse.Call{Name: "panic"},
 		},
 		{
 			name: "ExprStmt with DeviatingFunc (os.Exit)",
@@ -76,8 +78,8 @@ func TestStmtBranch(t *testing.T) {
 					},
 				},
 			},
-			kind: Exit,
-			call: &Call{Pkg: "os", Name: "Exit"},
+			kind: ifelse.Exit,
+			call: &ifelse.Call{Pkg: "os", Name: "Exit"},
 		},
 		{
 			name: "ExprStmt with non-deviating func",
@@ -86,7 +88,7 @@ func TestStmtBranch(t *testing.T) {
 					Fun: &ast.Ident{Name: "foo"},
 				},
 			},
-			kind: Regular,
+			kind: ifelse.Regular,
 		},
 		{
 			name: "LabeledStmt wrapping ReturnStmt",
@@ -94,7 +96,7 @@ func TestStmtBranch(t *testing.T) {
 				Label: &ast.Ident{Name: "lbl"},
 				Stmt:  &ast.ReturnStmt{},
 			},
-			kind: Return,
+			kind: ifelse.Return,
 		},
 		{
 			name: "LabeledStmt wrapping ExprStmt",
@@ -102,21 +104,21 @@ func TestStmtBranch(t *testing.T) {
 				Label: &ast.Ident{Name: "lbl"},
 				Stmt:  &ast.ExprStmt{X: &ast.CallExpr{Fun: &ast.Ident{Name: "foo"}}},
 			},
-			kind: Regular,
+			kind: ifelse.Regular,
 		},
 		{
 			name: "BlockStmt with ReturnStmt",
 			stmt: &ast.BlockStmt{List: []ast.Stmt{&ast.ReturnStmt{}}},
-			kind: Return,
+			kind: ifelse.Return,
 		},
 		{
 			name: "BlockStmt with ExprStmt",
 			stmt: &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{X: &ast.CallExpr{Fun: &ast.Ident{Name: "foo"}}}}},
-			kind: Regular,
+			kind: ifelse.Regular,
 		},
 	}
 	for _, c := range cases {
-		b := StmtBranch(c.stmt)
+		b := ifelse.StmtBranch(c.stmt)
 		if b.BranchKind != c.kind {
 			t.Errorf("%s: want %v, got %v", c.name, c.kind, b.BranchKind)
 		}
@@ -131,37 +133,37 @@ func TestStmtBranch(t *testing.T) {
 func TestBranch_String_LongString(t *testing.T) {
 	tests := []struct {
 		name     string
-		branch   Branch
+		branch   ifelse.Branch
 		wantStr  string
 		wantLong string
 	}{
 		{
 			name:     "Return branch",
-			branch:   Branch{BranchKind: Return},
+			branch:   ifelse.Branch{BranchKind: ifelse.Return},
 			wantStr:  "{ ... return }",
 			wantLong: "a return statement",
 		},
 		{
 			name:     "Panic branch with Call",
-			branch:   Branch{BranchKind: Panic, Call: Call{Name: "panic"}},
+			branch:   ifelse.Branch{BranchKind: ifelse.Panic, Call: ifelse.Call{Name: "panic"}},
 			wantStr:  "{ ... panic() }",
 			wantLong: "call to panic function",
 		},
 		{
 			name:     "Exit branch with Call",
-			branch:   Branch{BranchKind: Exit, Call: Call{Pkg: "os", Name: "Exit"}},
+			branch:   ifelse.Branch{BranchKind: ifelse.Exit, Call: ifelse.Call{Pkg: "os", Name: "Exit"}},
 			wantStr:  "{ ... os.Exit() }",
 			wantLong: "call to os.Exit function",
 		},
 		{
 			name:     "Empty branch",
-			branch:   Branch{BranchKind: Empty},
+			branch:   ifelse.Branch{BranchKind: ifelse.Empty},
 			wantStr:  "{ }",
 			wantLong: "an empty block",
 		},
 		{
 			name:     "Regular branch",
-			branch:   Branch{BranchKind: Regular},
+			branch:   ifelse.Branch{BranchKind: ifelse.Regular},
 			wantStr:  "{ ... }",
 			wantLong: "a regular statement",
 		},
@@ -179,27 +181,27 @@ func TestBranch_String_LongString(t *testing.T) {
 func TestBranch_HasDecls(t *testing.T) {
 	tests := []struct {
 		name  string
-		block []ast.Stmt
+		block *ast.BlockStmt
 		want  bool
 	}{
 		{
 			name:  "DeclStmt",
-			block: []ast.Stmt{&ast.DeclStmt{}},
+			block: &ast.BlockStmt{List: []ast.Stmt{&ast.DeclStmt{}}},
 			want:  true,
 		},
 		{
 			name:  "AssignStmt with :=",
-			block: []ast.Stmt{&ast.AssignStmt{Tok: token.DEFINE}},
+			block: &ast.BlockStmt{List: []ast.Stmt{&ast.AssignStmt{Tok: token.DEFINE}}},
 			want:  true,
 		},
 		{
 			name:  "ExprStmt",
-			block: []ast.Stmt{&ast.ExprStmt{}},
+			block: &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{}}},
 			want:  false,
 		},
 	}
 	for _, tt := range tests {
-		b := Branch{block: tt.block}
+		b := ifelse.BlockBranch(tt.block)
 		if got := b.HasDecls(); got != tt.want {
 			t.Errorf("%s: want HasDecls to be %v, got %v", tt.name, tt.want, got)
 		}
@@ -209,42 +211,42 @@ func TestBranch_HasDecls(t *testing.T) {
 func TestBranch_IsShort(t *testing.T) {
 	tests := []struct {
 		name  string
-		block []ast.Stmt
+		block *ast.BlockStmt
 		want  bool
 	}{
 		{
 			name:  "nil block",
-			block: nil,
+			block: &ast.BlockStmt{},
 			want:  true,
 		},
 		{
 			name:  "single ExprStmt",
-			block: []ast.Stmt{&ast.ExprStmt{}},
+			block: &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{}}},
 			want:  true,
 		},
 		{
 			name:  "single BlockStmt",
-			block: []ast.Stmt{&ast.BlockStmt{}},
+			block: &ast.BlockStmt{List: []ast.Stmt{&ast.BlockStmt{}}},
 			want:  false,
 		},
 		{
 			name:  "two short statements",
-			block: []ast.Stmt{&ast.ExprStmt{}, &ast.ExprStmt{}},
+			block: &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{}, &ast.ExprStmt{}}},
 			want:  true,
 		},
 		{
 			name:  "second non-short statement",
-			block: []ast.Stmt{&ast.ExprStmt{}, &ast.BlockStmt{}},
+			block: &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{}, &ast.BlockStmt{}}},
 			want:  false,
 		},
 		{
 			name:  "three statements (should return false)",
-			block: []ast.Stmt{&ast.ExprStmt{}, &ast.ExprStmt{}, &ast.ExprStmt{}},
+			block: &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{}, &ast.ExprStmt{}, &ast.ExprStmt{}}},
 			want:  false,
 		},
 	}
 	for _, tt := range tests {
-		b := Branch{block: tt.block}
+		b := ifelse.BlockBranch(tt.block)
 		if got := b.IsShort(); got != tt.want {
 			t.Errorf("%s: want IsShort to be %v, got %v", tt.name, tt.want, got)
 		}

--- a/test/add_constant_test.go
+++ b/test/add_constant_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/argument_limit_test.go
+++ b/test/argument_limit_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/atomic_test.go
+++ b/test/atomic_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/banned_characters_test.go
+++ b/test/banned_characters_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/bare_return_test.go
+++ b/test/bare_return_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/bool_literal_in_expr_test.go
+++ b/test/bool_literal_in_expr_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/call_to_gc_test.go
+++ b/test/call_to_gc_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/cognitive_complexity_test.go
+++ b/test/cognitive_complexity_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/comment_spacings_test.go
+++ b/test/comment_spacings_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/comments_density_test.go
+++ b/test/comments_density_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/confusing_naming_test.go
+++ b/test/confusing_naming_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/confusing_results_test.go
+++ b/test/confusing_results_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/constant_logical_expr_test.go
+++ b/test/constant_logical_expr_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/context_as_argument_test.go
+++ b/test/context_as_argument_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/cyclomatic_test.go
+++ b/test/cyclomatic_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/datarace_test.go
+++ b/test/datarace_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/deep_exit_test.go
+++ b/test/deep_exit_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/defer_test.go
+++ b/test/defer_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/disable_annotations_test.go
+++ b/test/disable_annotations_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/dot_imports_test.go
+++ b/test/dot_imports_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/duplicated_imports_test.go
+++ b/test/duplicated_imports_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/early_return_test.go
+++ b/test/early_return_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/empty_block_test.go
+++ b/test/empty_block_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/empty_lines_test.go
+++ b/test/empty_lines_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/enforce_map_style_test.go
+++ b/test/enforce_map_style_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/enforce_repeated_arg_type_style_test.go
+++ b/test/enforce_repeated_arg_type_style_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/enforce_slice_style_test.go
+++ b/test/enforce_slice_style_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/enforce_switch_style_test.go
+++ b/test/enforce_switch_style_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/error_strings_custom_functions_test.go
+++ b/test/error_strings_custom_functions_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/exported_test.go
+++ b/test/exported_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/file_filter_test.go
+++ b/test/file_filter_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/file_header_test.go
+++ b/test/file_header_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/file_length_limit_test.go
+++ b/test/file_length_limit_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/filename_format_test.go
+++ b/test/filename_format_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/flag_param_test.go
+++ b/test/flag_param_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/forbidden_call_in_wg_go_test.go
+++ b/test/forbidden_call_in_wg_go_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/function_length_test.go
+++ b/test/function_length_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/function_result_limit_test.go
+++ b/test/function_result_limit_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/get_return_test.go
+++ b/test/get_return_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/golint_test.go
+++ b/test/golint_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"flag"

--- a/test/identical_branches_test.go
+++ b/test/identical_branches_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/identical_ifelseif_branches_test.go
+++ b/test/identical_ifelseif_branches_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/identical_ifelseif_conditions_test.go
+++ b/test/identical_ifelseif_conditions_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/identical_switch_branches_test.go
+++ b/test/identical_switch_branches_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/identical_switch_conditions_test.go
+++ b/test/identical_switch_conditions_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/if_return_test.go
+++ b/test/if_return_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/import_alias_naming_test.go
+++ b/test/import_alias_naming_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/import_shadowing_test.go
+++ b/test/import_shadowing_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/imports_blocklist_test.go
+++ b/test/imports_blocklist_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/indent_error_flow_test.go
+++ b/test/indent_error_flow_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/inefficient_map_lookup_test.go
+++ b/test/inefficient_map_lookup_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/issue1100_test.go
+++ b/test/issue1100_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/json_data_format_test.go
+++ b/test/json_data_format_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/line_length_limit_test.go
+++ b/test/line_length_limit_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/max_control_nesting_test.go
+++ b/test/max_control_nesting_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/max_public_structs_test.go
+++ b/test/max_public_structs_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/modifies_param_test.go
+++ b/test/modifies_param_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/modifies_value_receiver_test.go
+++ b/test/modifies_value_receiver_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/nested_structs_test.go
+++ b/test/nested_structs_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/optimize_operands_order_test.go
+++ b/test/optimize_operands_order_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/package_directory_mismatch_test.go
+++ b/test/package_directory_mismatch_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/range_val_address_test.go
+++ b/test/range_val_address_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/range_val_in_closure_test.go
+++ b/test/range_val_in_closure_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/receiver_naming_test.go
+++ b/test/receiver_naming_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/redefines_builtin_id_test.go
+++ b/test/redefines_builtin_id_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/redundant_build_tag_test.go
+++ b/test/redundant_build_tag_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/redundant_import_alias_test.go
+++ b/test/redundant_import_alias_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/redundant_test_main_exit_test.go
+++ b/test/redundant_test_main_exit_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/string_format_test.go
+++ b/test/string_format_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/string_of_int_test.go
+++ b/test/string_of_int_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/superfluous_else_test.go
+++ b/test/superfluous_else_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/time_date_test.go
+++ b/test/time_date_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/time_equal_test.go
+++ b/test/time_equal_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/time_naming_test.go
+++ b/test/time_naming_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unchecked_type_assertion_test.go
+++ b/test/unchecked_type_assertion_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unconditional_recursion_test.go
+++ b/test/unconditional_recursion_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unexported_naming_test.go
+++ b/test/unexported_naming_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unexported_return_test.go
+++ b/test/unexported_return_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unhandled_error_test.go
+++ b/test/unhandled_error_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unnecessary_format_test.go
+++ b/test/unnecessary_format_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unnecessary_if_test.go
+++ b/test/unnecessary_if_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unnecessary_stmt_test.go
+++ b/test/unnecessary_stmt_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unreachable_code_test.go
+++ b/test/unreachable_code_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unsecure_url_scheme_test.go
+++ b/test/unsecure_url_scheme_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unused_param_test.go
+++ b/test/unused_param_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/unused_receiver_test.go
+++ b/test/unused_receiver_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/use_any_test.go
+++ b/test/use_any_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/use_errors_new_test.go
+++ b/test/use_errors_new_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/use_fmt_print_test.go
+++ b/test/use_fmt_print_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/use_waitgroup_go_test.go
+++ b/test/use_waitgroup_go_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/useless_break_test.go
+++ b/test/useless_break_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/useless_fallthrough_test.go
+++ b/test/useless_fallthrough_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"encoding/json"

--- a/test/var_naming_test.go
+++ b/test/var_naming_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"

--- a/test/waitgroup_by_value_test.go
+++ b/test/waitgroup_by_value_test.go
@@ -1,4 +1,4 @@
-package test
+package test_test
 
 import (
 	"testing"


### PR DESCRIPTION
This PR fixes `testpackage` lint issues for `test` and `ifelse` package tests.

Updates #1362.