### PR TITLE
fix: gosec issue in epoch-naming

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,9 +53,6 @@ linters:
         text: 'package should be `formatter_test` instead of `formatter`'
       - linters:
           - gosec
-        path: rule/epoch_naming.go
-      - linters:
-          - gosec
         path: rule/context_keys_type.go
       - linters:
           - gosec

--- a/rule/epoch_naming.go
+++ b/rule/epoch_naming.go
@@ -24,7 +24,11 @@ func (*EpochNamingRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure 
 		},
 	}
 
-	file.Pkg.TypeCheck()
+	if err := file.Pkg.TypeCheck(); err != nil {
+		return []lint.Failure{
+			lint.NewInternalFailure(fmt.Sprintf("Unable to type check file %q: %v", file.Name, err)),
+		}
+	}
 	ast.Walk(walker, file.AST)
 
 	return failures

--- a/testdata/epoch_naming.go
+++ b/testdata/epoch_naming.go
@@ -56,8 +56,7 @@ var (
 func foo() {
 	anotherInvalid := time.Now().Unix() // MATCH /var anotherInvalid should have one of these suffixes: Sec, Second, Seconds/
 	anotherValidSec := time.Now().Unix()
-	_ = time.Now().Unix()  // assignment to blank identifier - ignored
-	_ := time.Now().Unix() // short declaration with blank identifier - should be ignored
+	_ = time.Now().Unix() // assignment to blank identifier - ignored
 	println(anotherInvalid, anotherValidSec)
 
 	// Edge cases that should NOT be flagged (no variable declaration)
@@ -88,6 +87,7 @@ type Config struct {
 
 func structTest() {
 	c := Config{timestamp: time.Now().Unix()} // struct field - OK (no variable for the timestamp value itself)
+	_ = c
 }
 
 // Regular assignment (=) should be checked


### PR DESCRIPTION
This won't cause any issues because `epoch-naming` has not been released yet.