### PR TITLE
chore: update GHA in renovate; change to indirect for tools

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,9 +15,15 @@
     {
       "matchManagers": ["gomod"],
       "matchFileNames": ["tools/go.mod"],
-      "matchDepTypes": ["indirect"],
+      "matchDepTypes": ["direct"],
       "groupName": "tools gomod",
       "extends": ["schedule:monthly"],
+      "enabled": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "extends": ["schedule:weekly"],
       "enabled": true
     }
   ],


### PR DESCRIPTION
Update renovate config:

- Update only direct dependencies for `tools/go.mod` to decrease PRs.
- Add config to update GH actions.