### PR TITLE
enforce-switch-style: handle type switches

### DIFF
--- a/testdata/enforce_switch_style.go
+++ b/testdata/enforce_switch_style.go
@@ -24,4 +24,34 @@ func enforceSwitchStyle3() {
 		print()
 		return
 	}
+
+	// Type switch: default last (ok)
+	switch v := expression.(type) {
+	case int:
+		print(v)
+	default:
+	}
+
+	// Type switch: default not last
+	switch v := expression.(type) {
+	default: // MATCH /default case clause must be the last one/
+		print(v)
+	case int:
+	}
+
+	// Type switch: no default
+	switch v := expression.(type) { // MATCH /switch must have a default case clause/
+	case int:
+		print(v)
+	}
+
+	// Type switch: must not fail when all branches jump
+	switch v := expression.(type) {
+	case int:
+		print(v)
+		break
+	case string:
+		print(v)
+		return
+	}
 }


### PR DESCRIPTION
This PR adds support for type-switch to the rule `enforce-switch-style`.

As described in the associated ticket, this is motivated by a bug we found in our codebase where we missed an else clause for a type-switch. And when trying to enforce the rule via golangci-lint, we found that the type-switch was ignored nonetheless.

Further investigation revealed that Revive is currently skipping type-switches.

This is how a failure will be reported:

```
example.go:766:3: enforce-switch-style: switch must have a default case clause (revive)
switch v := kv.(type) {
case *dns.SVCBMandatory:
        # ...
case *dns.SVCBAlpn:
        # ...
case *dns.SVCBNoDefaultAlpn:
        # ...
case *dns.SVCBPort:
```

Closes https://github.com/mgechev/revive/issues/1628
