### PR TITLE
chore: enable unparam.check-exported

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -223,6 +223,8 @@ linters:
         - name: var-declaration
         - name: var-naming
         - name: waitgroup-by-value
+    unparam:
+      check-exported: true
 
 formatters:
   enable:

--- a/formatter/default.go
+++ b/formatter/default.go
@@ -23,7 +23,10 @@ func (*Default) Format(failures <-chan lint.Failure, _ lint.Config) (string, err
 	var buf bytes.Buffer
 	prefix := ""
 	for failure := range failures {
-		fmt.Fprintf(&buf, "%s%v: %s", prefix, failure.Position.Start, failure.Failure)
+		_, err := fmt.Fprintf(&buf, "%s%v: %s", prefix, failure.Position.Start, failure.Failure)
+		if err != nil {
+			return "", err
+		}
 		prefix = "\n"
 	}
 	return buf.String(), nil

--- a/formatter/plain.go
+++ b/formatter/plain.go
@@ -22,7 +22,10 @@ func (*Plain) Name() string {
 func (*Plain) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
 	var sb strings.Builder
 	for failure := range failures {
-		fmt.Fprintf(&sb, "%v: %s %s\n", failure.Position.Start, failure.Failure, ruleDescriptionURL(failure.RuleName))
+		_, err := fmt.Fprintf(&sb, "%v: %s %s\n", failure.Position.Start, failure.Failure, ruleDescriptionURL(failure.RuleName))
+		if err != nil {
+			return "", err
+		}
 	}
 	return sb.String(), nil
 }

--- a/formatter/stylish.go
+++ b/formatter/stylish.go
@@ -33,7 +33,7 @@ func formatFailure(failure lint.Failure, severity lint.Severity) []string {
 }
 
 // Format formats the failures gotten from the lint.
-func (*Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string, error) {
+func (*Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string, error) { //nolint:unparam // always returns nil error
 	var result [][]string
 	totalErrors := 0
 	total := 0

--- a/formatter/unix.go
+++ b/formatter/unix.go
@@ -24,7 +24,10 @@ func (*Unix) Name() string {
 func (*Unix) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
 	var sb strings.Builder
 	for failure := range failures {
-		fmt.Fprintf(&sb, "%v: [%s] %s\n", failure.Position.Start, failure.RuleName, failure.Failure)
+		_, err := fmt.Fprintf(&sb, "%v: [%s] %s\n", failure.Position.Start, failure.RuleName, failure.Failure)
+		if err != nil {
+			return "", err
+		}
 	}
 	return sb.String(), nil
 }

--- a/revivelib/core.go
+++ b/revivelib/core.go
@@ -204,7 +204,7 @@ func (i *ArrayFlags) String() string {
 }
 
 // Set value for array flags.
-func (i *ArrayFlags) Set(value string) error {
+func (i *ArrayFlags) Set(value string) error { //nolint:unparam // always returns nil
 	*i = append(*i, value)
 
 	return nil

--- a/rule/early_return.go
+++ b/rule/early_return.go
@@ -21,7 +21,7 @@ type EarlyReturnRule struct {
 // Configure validates the rule configuration, and configures the rule accordingly.
 //
 // Configuration implements the [lint.ConfigurableRule] interface.
-func (e *EarlyReturnRule) Configure(arguments lint.Arguments) error {
+func (e *EarlyReturnRule) Configure(arguments lint.Arguments) error { //nolint:unparam // always returns nil
 	for _, arg := range arguments {
 		sarg, ok := arg.(string)
 		if !ok {

--- a/rule/indent_error_flow.go
+++ b/rule/indent_error_flow.go
@@ -14,7 +14,7 @@ type IndentErrorFlowRule struct {
 // Configure validates the rule configuration, and configures the rule accordingly.
 //
 // Configuration implements the [lint.ConfigurableRule] interface.
-func (e *IndentErrorFlowRule) Configure(arguments lint.Arguments) error {
+func (e *IndentErrorFlowRule) Configure(arguments lint.Arguments) error { //nolint:unparam // always returns nil
 	for _, arg := range arguments {
 		sarg, ok := arg.(string)
 		if !ok {

--- a/rule/superfluous_else.go
+++ b/rule/superfluous_else.go
@@ -16,7 +16,7 @@ type SuperfluousElseRule struct {
 // Configure validates the rule configuration, and configures the rule accordingly.
 //
 // Configuration implements the [lint.ConfigurableRule] interface.
-func (e *SuperfluousElseRule) Configure(arguments lint.Arguments) error {
+func (e *SuperfluousElseRule) Configure(arguments lint.Arguments) error { //nolint:unparam // always returns nil
 	for _, arg := range arguments {
 		sarg, ok := arg.(string)
 		if !ok {


### PR DESCRIPTION
Fix [unparam](https://golangci-lint.run/docs/linters/configuration/#unparam) issues:

```console
❯ golangci-lint run
formatter/default.go:22:78: (*Default).Format - result 1 (error) is always nil (unparam)
func (*Default) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
                                                                             ^
formatter/friendly.go:29:86: (*Friendly).Format - result 1 (error) is always nil (unparam)
func (f *Friendly) Format(failures <-chan lint.Failure, config lint.Config) (string, error) {
                                                                                     ^
formatter/plain.go:22:76: (*Plain).Format - result 1 (error) is always nil (unparam)
func (*Plain) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
                                                                           ^
formatter/stylish.go:36:83: (*Stylish).Format - result 1 (error) is always nil (unparam)
func (*Stylish) Format(failures <-chan lint.Failure, config lint.Config) (string, error) {
                                                                                  ^
formatter/unix.go:24:75: (*Unix).Format - result 1 (error) is always nil (unparam)
func (*Unix) Format(failures <-chan lint.Failure, _ lint.Config) (string, error) {
                                                                          ^
revivelib/core.go:207:40: (*ArrayFlags).Set - result 0 (error) is always nil (unparam)
func (i *ArrayFlags) Set(value string) error {
                                       ^
rule/early_return.go:24:63: (*EarlyReturnRule).Configure - result 0 (error) is always nil (unparam)
func (e *EarlyReturnRule) Configure(arguments lint.Arguments) error {
                                                              ^
rule/indent_error_flow.go:17:67: (*IndentErrorFlowRule).Configure - result 0 (error) is always nil (unparam)
func (e *IndentErrorFlowRule) Configure(arguments lint.Arguments) error {
                                                                  ^
rule/superfluous_else.go:19:67: (*SuperfluousElseRule).Configure - result 0 (error) is always nil (unparam)
func (e *SuperfluousElseRule) Configure(arguments lint.Arguments) error {
                                                                  ^
9 issues:
* unparam: 9
```
