### PR TITLE
chore: use alias `linters.Arguments` instead of `[]any`

### DIFF
--- a/test/add_constant_test.go
+++ b/test/add_constant_test.go
@@ -13,7 +13,7 @@ func TestAddConstantWithDefaultArguments(t *testing.T) {
 
 func TestAddConstantWithArguments(t *testing.T) {
 	testRule(t, "add_constant", &rule.AddConstantRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{
+		Arguments: lint.Arguments{map[string]any{
 			"maxLitCount": "2",
 			"allowStrs":   "\"\"",
 			"allowInts":   "0,1,2",
@@ -22,7 +22,7 @@ func TestAddConstantWithArguments(t *testing.T) {
 		}},
 	})
 	testRule(t, "add_constant", &rule.AddConstantRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{
+		Arguments: lint.Arguments{map[string]any{
 			"max-lit-count": "2",
 			"allow-strs":    `""`,
 			"allow-ints":    "0,1,2",

--- a/test/argument_limit_test.go
+++ b/test/argument_limit_test.go
@@ -13,7 +13,7 @@ func TestArgumentsLimitDefault(t *testing.T) {
 
 func TestArgumentsLimit(t *testing.T) {
 	testRule(t, "argument_limit", &rule.ArgumentsLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(3)},
+		Arguments: lint.Arguments{int64(3)},
 	})
 }
 

--- a/test/banned_characters_test.go
+++ b/test/banned_characters_test.go
@@ -16,6 +16,6 @@ func TestBannedCharactersDefault(t *testing.T) {
 // One banned character from the list is not present in the fixture file.
 func TestBannedCharacters(t *testing.T) {
 	testRule(t, "banned_characters", &rule.BannedCharsRule{}, &lint.RuleConfig{
-		Arguments: []any{"Ω", "Σ", "σ", "1"},
+		Arguments: lint.Arguments{"Ω", "Σ", "σ", "1"},
 	})
 }

--- a/test/cognitive_complexity_test.go
+++ b/test/cognitive_complexity_test.go
@@ -13,6 +13,6 @@ func TestCognitiveComplexityDefault(t *testing.T) {
 
 func TestCognitiveComplexity(t *testing.T) {
 	testRule(t, "cognitive_complexity", &rule.CognitiveComplexityRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(0)},
+		Arguments: lint.Arguments{int64(0)},
 	})
 }

--- a/test/comment_spacings_test.go
+++ b/test/comment_spacings_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCommentSpacings(t *testing.T) {
 	testRule(t, "comment_spacings", &rule.CommentSpacingsRule{}, &lint.RuleConfig{
-		Arguments: []any{"myOwnDirective:", "+optional"},
+		Arguments: lint.Arguments{"myOwnDirective:", "+optional"},
 	},
 	)
 }

--- a/test/comments_density_test.go
+++ b/test/comments_density_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestCommentsDensity(t *testing.T) {
 	testRule(t, "comments_density_1", &rule.CommentsDensityRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(60)},
+		Arguments: lint.Arguments{int64(60)},
 	})
 
 	testRule(t, "comments_density_2", &rule.CommentsDensityRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(90)},
+		Arguments: lint.Arguments{int64(90)},
 	})
 
 	testRule(t, "comments_density_3", &rule.CommentsDensityRule{}, &lint.RuleConfig{})

--- a/test/context_as_argument_test.go
+++ b/test/context_as_argument_test.go
@@ -13,14 +13,14 @@ func TestContextAsArgumentDefault(t *testing.T) {
 
 func TestContextAsArgument(t *testing.T) {
 	testRule(t, "context_as_argument", &rule.ContextAsArgumentRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"allowTypesBefore": "AllowedBeforeType,AllowedBeforeStruct,*AllowedBeforePtrStruct,*testing.T",
 			},
 		},
 	})
 	testRule(t, "context_as_argument", &rule.ContextAsArgumentRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"allow-types-before": "AllowedBeforeType,AllowedBeforeStruct,*AllowedBeforePtrStruct,*testing.T",
 			},

--- a/test/cyclomatic_test.go
+++ b/test/cyclomatic_test.go
@@ -14,9 +14,9 @@ func TestCyclomaticDefault(t *testing.T) {
 func TestCyclomatic(t *testing.T) {
 	testRule(t, "cyclomatic_default", &rule.CyclomaticRule{}, &lint.RuleConfig{})
 	testRule(t, "cyclomatic", &rule.CyclomaticRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(1)},
+		Arguments: lint.Arguments{int64(1)},
 	})
 	testRule(t, "cyclomatic_2", &rule.CyclomaticRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(3)},
+		Arguments: lint.Arguments{int64(3)},
 	})
 }

--- a/test/defer_test.go
+++ b/test/defer_test.go
@@ -13,15 +13,15 @@ func TestDefer(t *testing.T) {
 
 func TestDeferLoopDisabled(t *testing.T) {
 	testRule(t, "defer_loop_disabled", &rule.DeferRule{}, &lint.RuleConfig{
-		Arguments: []any{[]any{"return", "recover", "callChain", "methodCall"}},
+		Arguments: lint.Arguments{[]any{"return", "recover", "callChain", "methodCall"}},
 	})
 	testRule(t, "defer_loop_disabled", &rule.DeferRule{}, &lint.RuleConfig{
-		Arguments: []any{[]any{"return", "recover", "call-chain", "method-call"}},
+		Arguments: lint.Arguments{[]any{"return", "recover", "call-chain", "method-call"}},
 	})
 }
 
 func TestDeferOthersDisabled(t *testing.T) {
 	testRule(t, "defer_only_loop_enabled", &rule.DeferRule{}, &lint.RuleConfig{
-		Arguments: []any{[]any{"loop"}},
+		Arguments: lint.Arguments{[]any{"loop"}},
 	})
 }

--- a/test/dot_imports_test.go
+++ b/test/dot_imports_test.go
@@ -13,12 +13,12 @@ func TestDotImportsDefault(t *testing.T) {
 
 func TestDotImports(t *testing.T) {
 	testRule(t, "dot_imports", &rule.DotImportsRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{
+		Arguments: lint.Arguments{map[string]any{
 			"allowedPackages": []any{"errors", "context", "github.com/BurntSushi/toml"},
 		}},
 	})
 	testRule(t, "dot_imports", &rule.DotImportsRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{
+		Arguments: lint.Arguments{map[string]any{
 			"allowed-packages": []any{"errors", "context", "github.com/BurntSushi/toml"},
 		}},
 	})

--- a/test/early_return_test.go
+++ b/test/early_return_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestEarlyReturn(t *testing.T) {
 	testRule(t, "early_return", &rule.EarlyReturnRule{})
-	testRule(t, "early_return_scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{"preserveScope"}})
-	testRule(t, "early_return_scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{"preserve-scope"}})
-	testRule(t, "early_return_jump", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{"allowJump"}})
-	testRule(t, "early_return_jump", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{"allow-jump"}})
-	testRule(t, "early_return_jump_scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: []any{"allow-jump", "preserve-scope"}})
+	testRule(t, "early_return_scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"preserveScope"}})
+	testRule(t, "early_return_scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"preserve-scope"}})
+	testRule(t, "early_return_jump", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"allowJump"}})
+	testRule(t, "early_return_jump", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"allow-jump"}})
+	testRule(t, "early_return_jump_scope", &rule.EarlyReturnRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"allow-jump", "preserve-scope"}})
 }

--- a/test/enforce_map_style_test.go
+++ b/test/enforce_map_style_test.go
@@ -13,12 +13,12 @@ func TestEnforceMapStyle_any(t *testing.T) {
 
 func TestEnforceMapStyle_make(t *testing.T) {
 	testRule(t, "enforce_map_style_make", &rule.EnforceMapStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"make"},
+		Arguments: lint.Arguments{"make"},
 	})
 }
 
 func TestEnforceMapStyle_literal(t *testing.T) {
 	testRule(t, "enforce_map_style_literal", &rule.EnforceMapStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"literal"},
+		Arguments: lint.Arguments{"literal"},
 	})
 }

--- a/test/enforce_repeated_arg_type_style_test.go
+++ b/test/enforce_repeated_arg_type_style_test.go
@@ -13,35 +13,35 @@ func TestEnforceRepeatedArgTypeStyleDefault(t *testing.T) {
 
 func TestEnforceRepeatedArgTypeStyleShort(t *testing.T) {
 	testRule(t, "enforce_repeated_arg_type_style_short_args", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"short"},
+		Arguments: lint.Arguments{"short"},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_short_return", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"short"},
+		Arguments: lint.Arguments{"short"},
 	})
 
 	testRule(t, "enforce_repeated_arg_type_style_short_args", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle": `short`,
 			},
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_short_args", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"func-arg-style": `short`,
 			},
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_short_return", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcRetValStyle": `short`,
 			},
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_short_return", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"func-ret-val-style": `short`,
 			},
@@ -51,21 +51,21 @@ func TestEnforceRepeatedArgTypeStyleShort(t *testing.T) {
 
 func TestEnforceRepeatedArgTypeStyleFull(t *testing.T) {
 	testRule(t, "enforce_repeated_arg_type_style_full_args", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"full"},
+		Arguments: lint.Arguments{"full"},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_full_return", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"full"},
+		Arguments: lint.Arguments{"full"},
 	})
 
 	testRule(t, "enforce_repeated_arg_type_style_full_args", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle": `full`,
 			},
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_full_return", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcRetValStyle": `full`,
 			},
@@ -75,14 +75,14 @@ func TestEnforceRepeatedArgTypeStyleFull(t *testing.T) {
 
 func TestEnforceRepeatedArgTypeStyleMixed(t *testing.T) {
 	testRule(t, "enforce_repeated_arg_type_style_full_args", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle": `full`,
 			},
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_full_args", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle":    `full`,
 				"funcRetValStyle": `any`,
@@ -90,7 +90,7 @@ func TestEnforceRepeatedArgTypeStyleMixed(t *testing.T) {
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_full_args", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle":    `full`,
 				"funcRetValStyle": `short`,
@@ -99,14 +99,14 @@ func TestEnforceRepeatedArgTypeStyleMixed(t *testing.T) {
 	})
 
 	testRule(t, "enforce_repeated_arg_type_style_full_return", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcRetValStyle": `full`,
 			},
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_full_return", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle":    `any`,
 				"funcRetValStyle": `full`,
@@ -114,7 +114,7 @@ func TestEnforceRepeatedArgTypeStyleMixed(t *testing.T) {
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_full_return", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle":    `short`,
 				"funcRetValStyle": `full`,
@@ -123,7 +123,7 @@ func TestEnforceRepeatedArgTypeStyleMixed(t *testing.T) {
 	})
 
 	testRule(t, "enforce_repeated_arg_type_style_mixed_full_short", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle":    `full`,
 				"funcRetValStyle": `short`,
@@ -131,7 +131,7 @@ func TestEnforceRepeatedArgTypeStyleMixed(t *testing.T) {
 		},
 	})
 	testRule(t, "enforce_repeated_arg_type_style_mixed_short_full", &rule.EnforceRepeatedArgTypeStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"funcArgStyle":    `short`,
 				"funcRetValStyle": `full`,

--- a/test/enforce_slice_style_test.go
+++ b/test/enforce_slice_style_test.go
@@ -13,18 +13,18 @@ func TestEnforceSliceStyle_any(t *testing.T) {
 
 func TestEnforceSliceStyle_make(t *testing.T) {
 	testRule(t, "enforce_slice_style_make", &rule.EnforceSliceStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"make"},
+		Arguments: lint.Arguments{"make"},
 	})
 }
 
 func TestEnforceSliceStyle_literal(t *testing.T) {
 	testRule(t, "enforce_slice_style_literal", &rule.EnforceSliceStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"literal"},
+		Arguments: lint.Arguments{"literal"},
 	})
 }
 
 func TestEnforceSliceStyle_nil(t *testing.T) {
 	testRule(t, "enforce_slice_style_nil", &rule.EnforceSliceStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"nil"},
+		Arguments: lint.Arguments{"nil"},
 	})
 }

--- a/test/enforce_switch_style_test.go
+++ b/test/enforce_switch_style_test.go
@@ -10,12 +10,12 @@ import (
 func TestEnforceSwitchStyle(t *testing.T) {
 	testRule(t, "enforce_switch_style", &rule.EnforceSwitchStyleRule{})
 	testRule(t, "enforce_switch_style_allow_no_default", &rule.EnforceSwitchStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"allowNoDefault"},
+		Arguments: lint.Arguments{"allowNoDefault"},
 	})
 	testRule(t, "enforce_switch_style_allow_not_last", &rule.EnforceSwitchStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"allowDefaultNotLast"},
+		Arguments: lint.Arguments{"allowDefaultNotLast"},
 	})
 	testRule(t, "enforce_switch_style_allow_no_default_allow_not_last", &rule.EnforceSwitchStyleRule{}, &lint.RuleConfig{
-		Arguments: []any{"allowNoDefault", "allowDefaultNotLast"},
+		Arguments: lint.Arguments{"allowNoDefault", "allowDefaultNotLast"},
 	})
 }

--- a/test/error_strings_custom_functions_test.go
+++ b/test/error_strings_custom_functions_test.go
@@ -8,15 +8,13 @@ import (
 )
 
 func TestErrorStringsWithCustomFunctions(t *testing.T) {
-	args := []any{"pkgErrors.Wrap"}
 	testRule(t, "error_strings_with_custom_functions", &rule.ErrorStringsRule{}, &lint.RuleConfig{
-		Arguments: args,
+		Arguments: lint.Arguments{"pkgErrors.Wrap"},
 	})
 }
 
 func TestErrorStringsIssue1243(t *testing.T) {
-	args := []any{"errors.Wrap"}
 	testRule(t, "error_strings_issue_1243", &rule.ErrorStringsRule{}, &lint.RuleConfig{
-		Arguments: args,
+		Arguments: lint.Arguments{"errors.Wrap"},
 	})
 }

--- a/test/exported_test.go
+++ b/test/exported_test.go
@@ -8,35 +8,27 @@ import (
 )
 
 func TestExportedWithDisableStutteringCheck(t *testing.T) {
-	args := []any{"disableStutteringCheck"}
-
-	testRule(t, "exported_issue_555", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: args})
+	testRule(t, "exported_issue_555", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"disableStutteringCheck"}})
 }
 
 func TestExportedWithChecksOnMethodsOfPrivateTypes(t *testing.T) {
-	args := []any{"checkPrivateReceivers"}
-
-	testRule(t, "exported_issue_552", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: args})
+	testRule(t, "exported_issue_552", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"checkPrivateReceivers"}})
 }
 
 func TestExportedReplacingStuttersByRepetitive(t *testing.T) {
-	args := []any{"sayRepetitiveInsteadOfStutters"}
-
-	testRule(t, "exported_issue_519", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: args})
+	testRule(t, "exported_issue_519", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"sayRepetitiveInsteadOfStutters"}})
 }
 
 func TestCheckPublicInterfaceOption(t *testing.T) {
-	args := []any{"checkPublicInterface"}
-
-	testRule(t, "exported_issue_1002", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: args})
+	testRule(t, "exported_issue_1002", &rule.ExportedRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"checkPublicInterface"}})
 }
 
 func TestCheckDisablingOnDeclarationTypes(t *testing.T) {
 	testRule(t, "exported_issue_1045", &rule.ExportedRule{}, &lint.RuleConfig{
-		Arguments: []any{"disableChecksOnConstants", "disableChecksOnFunctions", "disableChecksOnMethods", "disableChecksOnTypes", "disableChecksOnVariables"},
+		Arguments: lint.Arguments{"disableChecksOnConstants", "disableChecksOnFunctions", "disableChecksOnMethods", "disableChecksOnTypes", "disableChecksOnVariables"},
 	})
 	testRule(t, "exported_issue_1045", &rule.ExportedRule{}, &lint.RuleConfig{
-		Arguments: []any{"disable-checks-on-constants", "disable-checks-on-functions", "disable-checks-on-methods", "disable-checks-on-types", "disable-checks-on-variables"},
+		Arguments: lint.Arguments{"disable-checks-on-constants", "disable-checks-on-functions", "disable-checks-on-methods", "disable-checks-on-types", "disable-checks-on-variables"},
 	})
 }
 

--- a/test/file_header_test.go
+++ b/test/file_header_test.go
@@ -13,27 +13,27 @@ func TestLintFileHeaderDefault(t *testing.T) {
 
 func TestLintFileHeader(t *testing.T) {
 	testRule(t, "lint_file_header1", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []any{"foobar"},
+		Arguments: lint.Arguments{"foobar"},
 	})
 
 	testRule(t, "lint_file_header2", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []any{"foobar"},
+		Arguments: lint.Arguments{"foobar"},
 	})
 
 	testRule(t, "lint_file_header3", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []any{"foobar"},
+		Arguments: lint.Arguments{"foobar"},
 	})
 
 	testRule(t, "lint_file_header4", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []any{"^\\sfoobar$"},
+		Arguments: lint.Arguments{"^\\sfoobar$"},
 	})
 
 	testRule(t, "lint_file_header5", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []any{"^\\sfoo.*bar$"},
+		Arguments: lint.Arguments{"^\\sfoo.*bar$"},
 	})
 
 	testRule(t, "lint_file_header6", &rule.FileHeaderRule{}, &lint.RuleConfig{
-		Arguments: []any{"foobar"},
+		Arguments: lint.Arguments{"foobar"},
 	})
 }
 
@@ -41,7 +41,7 @@ func BenchmarkLintFileHeader(b *testing.B) {
 	var t *testing.T
 	for i := 0; i <= b.N; i++ {
 		testRule(t, "lint_file_header1", &rule.FileHeaderRule{}, &lint.RuleConfig{
-			Arguments: []any{"foobar"},
+			Arguments: lint.Arguments{"foobar"},
 		})
 	}
 }

--- a/test/file_length_limit_test.go
+++ b/test/file_length_limit_test.go
@@ -9,27 +9,27 @@ import (
 
 func TestFileLengthLimit(t *testing.T) {
 	testRule(t, "file_length_limit_disabled", &rule.FileLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{},
+		Arguments: lint.Arguments{},
 	})
 	testRule(t, "file_length_limit_disabled", &rule.FileLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{"max": int64(0)}},
+		Arguments: lint.Arguments{map[string]any{"max": int64(0)}},
 	})
 	testRule(t, "file_length_limit_disabled", &rule.FileLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{"skipComments": true, "skipBlankLines": true}},
+		Arguments: lint.Arguments{map[string]any{"skipComments": true, "skipBlankLines": true}},
 	})
 	testRule(t, "file_length_limit_9", &rule.FileLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{"max": int64(9)}},
+		Arguments: lint.Arguments{map[string]any{"max": int64(9)}},
 	})
 	testRule(t, "file_length_limit_7_skip_comments", &rule.FileLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{"max": int64(7), "skipComments": true}},
+		Arguments: lint.Arguments{map[string]any{"max": int64(7), "skipComments": true}},
 	})
 	testRule(t, "file_length_limit_6_skip_blank", &rule.FileLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{"max": int64(6), "skipBlankLines": true}},
+		Arguments: lint.Arguments{map[string]any{"max": int64(6), "skipBlankLines": true}},
 	})
 	testRule(t, "file_length_limit_4_skip_comments_skip_blank", &rule.FileLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{"max": int64(4), "skipComments": true, "skipBlankLines": true}},
+		Arguments: lint.Arguments{map[string]any{"max": int64(4), "skipComments": true, "skipBlankLines": true}},
 	})
 	testRule(t, "file_length_limit_4_skip_comments_skip_blank", &rule.FileLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{map[string]any{"max": int64(4), "skip-comments": true, "skip-blank-lines": true}},
+		Arguments: lint.Arguments{map[string]any{"max": int64(4), "skip-comments": true, "skip-blank-lines": true}},
 	})
 }

--- a/test/filename_format_test.go
+++ b/test/filename_format_test.go
@@ -12,5 +12,5 @@ func TestLintFilenameFormat(t *testing.T) {
 
 	testRule(t, "filenamе_with_non_ascii_char", &rule.FilenameFormatRule{}, &lint.RuleConfig{})
 
-	testRule(t, "filename_with_underscores", &rule.FilenameFormatRule{}, &lint.RuleConfig{Arguments: []any{"^[A-Za-z][A-Za-z0-9]*.go$"}})
+	testRule(t, "filename_with_underscores", &rule.FilenameFormatRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"^[A-Za-z][A-Za-z0-9]*.go$"}})
 }

--- a/test/function_length_test.go
+++ b/test/function_length_test.go
@@ -13,18 +13,18 @@ func TestFuncLengthDefault(t *testing.T) {
 
 func TestFuncLengthLimitsStatements(t *testing.T) {
 	testRule(t, "function_length1", &rule.FunctionLength{}, &lint.RuleConfig{
-		Arguments: []any{int64(2), int64(100)},
+		Arguments: lint.Arguments{int64(2), int64(100)},
 	})
 }
 
 func TestFuncLengthLimitsLines(t *testing.T) {
 	testRule(t, "function_length2", &rule.FunctionLength{}, &lint.RuleConfig{
-		Arguments: []any{int64(100), int64(5)},
+		Arguments: lint.Arguments{int64(100), int64(5)},
 	})
 }
 
 func TestFuncLengthLimitsDeactivated(t *testing.T) {
 	testRule(t, "function_length3", &rule.FunctionLength{}, &lint.RuleConfig{
-		Arguments: []any{int64(0), int64(0)},
+		Arguments: lint.Arguments{int64(0), int64(0)},
 	})
 }

--- a/test/function_result_limit_test.go
+++ b/test/function_result_limit_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestFunctionResultsLimit(t *testing.T) {
 	testRule(t, "function_result_limit", &rule.FunctionResultsLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(3)},
+		Arguments: lint.Arguments{int64(3)},
 	})
 }

--- a/test/import_alias_naming_test.go
+++ b/test/import_alias_naming_test.go
@@ -18,13 +18,13 @@ func TestImportAliasNaming(t *testing.T) {
 
 func TestImportAliasNaming_CustomConfig(t *testing.T) {
 	testRule(t, "import_alias_naming_custom_config", &rule.ImportAliasNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{`^[a-z]+$`},
+		Arguments: lint.Arguments{`^[a-z]+$`},
 	})
 }
 
 func TestImportAliasNaming_CustomConfigWithMultipleRules(t *testing.T) {
 	testRule(t, "import_alias_naming_custom_config_with_multiple_values", &rule.ImportAliasNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"allowRegex": `^[a-z][a-z0-9]*$`,
 				"denyRegex":  `^((v\d+)|(v\d+alpha\d+))$`,
@@ -32,7 +32,7 @@ func TestImportAliasNaming_CustomConfigWithMultipleRules(t *testing.T) {
 		},
 	})
 	testRule(t, "import_alias_naming_custom_config_with_multiple_values", &rule.ImportAliasNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"allow-regex": `^[a-z][a-z0-9]*$`,
 				"deny-regex":  `^((v\d+)|(v\d+alpha\d+))$`,
@@ -43,7 +43,7 @@ func TestImportAliasNaming_CustomConfigWithMultipleRules(t *testing.T) {
 
 func TestImportAliasNaming_CustomConfigWithOnlyDeny(t *testing.T) {
 	testRule(t, "import_alias_naming_custom_config_with_only_deny", &rule.ImportAliasNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			map[string]any{
 				"denyRegex": `^((v\d+)|(v\d+alpha\d+))$`,
 			},

--- a/test/imports_blocklist_test.go
+++ b/test/imports_blocklist_test.go
@@ -8,27 +8,22 @@ import (
 )
 
 func TestImportsBlocklistOriginal(t *testing.T) {
-	args := []any{"crypto/md5", "crypto/sha1"}
-
 	testRule(t, "imports_blocklist_original", &rule.ImportsBlocklistRule{}, &lint.RuleConfig{
-		Arguments: args,
+		Arguments: lint.Arguments{"crypto/md5", "crypto/sha1"},
 	})
 }
 
 func TestImportsBlocklist(t *testing.T) {
-	args := []any{"github.com/full/match", "wildcard/**/between", "wildcard/backward/**", "**/wildcard/forward", "full"}
-
 	testRule(t, "imports_blocklist", &rule.ImportsBlocklistRule{}, &lint.RuleConfig{
-		Arguments: args,
+		Arguments: lint.Arguments{"github.com/full/match", "wildcard/**/between", "wildcard/backward/**", "**/wildcard/forward", "full"},
 	})
 }
 
 func BenchmarkImportsBlocklist(b *testing.B) {
-	args := []any{"github.com/full/match", "wildcard/**/between", "wildcard/backward/**", "**/wildcard/forward", "full"}
 	var t *testing.T
 	for i := 0; i <= b.N; i++ {
 		testRule(t, "imports_blocklist", &rule.ImportsBlocklistRule{}, &lint.RuleConfig{
-			Arguments: args,
+			Arguments: lint.Arguments{"github.com/full/match", "wildcard/**/between", "wildcard/backward/**", "**/wildcard/forward", "full"},
 		})
 	}
 }

--- a/test/indent_error_flow_test.go
+++ b/test/indent_error_flow_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestIndentErrorFlow(t *testing.T) {
 	testRule(t, "indent_error_flow", &rule.IndentErrorFlowRule{})
-	testRule(t, "indent_error_flow_scope", &rule.IndentErrorFlowRule{}, &lint.RuleConfig{Arguments: []any{"preserveScope"}})
-	testRule(t, "indent_error_flow_scope", &rule.IndentErrorFlowRule{}, &lint.RuleConfig{Arguments: []any{"preserve-scope"}})
+	testRule(t, "indent_error_flow_scope", &rule.IndentErrorFlowRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"preserveScope"}})
+	testRule(t, "indent_error_flow_scope", &rule.IndentErrorFlowRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"preserve-scope"}})
 }

--- a/test/issue1100_test.go
+++ b/test/issue1100_test.go
@@ -8,15 +8,15 @@ import (
 )
 
 func TestIssue1100(t *testing.T) {
-	args := []any{map[string]any{
-		"maxLitCount": "2",
-		"allowStrs":   "\"\"",
-		"allowInts":   "0,1,2",
-		"allowFloats": "0.0,1.0",
-		"ignoreFuncs": "os\\.(CreateFile|WriteFile|Chmod|FindProcess),\\.Println,ignoredFunc,\\.Info",
-	}}
-
 	testRule(t, "goUnknown/issue1100", &rule.AddConstantRule{}, &lint.RuleConfig{
-		Arguments: args,
+		Arguments: lint.Arguments{
+			map[string]any{
+				"maxLitCount": "2",
+				"allowStrs":   "\"\"",
+				"allowInts":   "0,1,2",
+				"allowFloats": "0.0,1.0",
+				"ignoreFuncs": "os\\.(CreateFile|WriteFile|Chmod|FindProcess),\\.Println,ignoredFunc,\\.Info",
+			},
+		},
 	})
 }

--- a/test/line_length_limit_test.go
+++ b/test/line_length_limit_test.go
@@ -13,6 +13,6 @@ func TestLineLengthLimitDefault(t *testing.T) {
 
 func TestLineLengthLimit(t *testing.T) {
 	testRule(t, "line_length_limit", &rule.LineLengthLimitRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(100)},
+		Arguments: lint.Arguments{int64(100)},
 	})
 }

--- a/test/max_control_nesting_test.go
+++ b/test/max_control_nesting_test.go
@@ -13,7 +13,6 @@ func TestMaxControlNestingDefault(t *testing.T) {
 
 func TestMaxControlNesting(t *testing.T) {
 	testRule(t, "max_control_nesting", &rule.MaxControlNestingRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(2)},
-	},
-	)
+		Arguments: lint.Arguments{int64(2)},
+	})
 }

--- a/test/max_public_structs_test.go
+++ b/test/max_public_structs_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMaxPublicStructs(t *testing.T) {
 	testRule(t, "max_public_structs", &rule.MaxPublicStructsRule{}, &lint.RuleConfig{
-		Arguments: []any{int64(1)},
+		Arguments: lint.Arguments{int64(1)},
 	})
 }
 

--- a/test/package_directory_mismatch_test.go
+++ b/test/package_directory_mismatch_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestPackageDirectoryMismatch(t *testing.T) {
 	// Configure rule to ignore no directories so our tests in 'testdata/' can run
-	config := &lint.RuleConfig{Arguments: []any{map[string]any{"ignore-directories": []any{}}}}
+	config := &lint.RuleConfig{Arguments: lint.Arguments{map[string]any{"ignore-directories": []any{}}}}
 
 	testRule(t, "package_directory_mismatch/good/good", &rule.PackageDirectoryMismatchRule{}, config)
 	testRule(t, "package_directory_mismatch/bad/bad", &rule.PackageDirectoryMismatchRule{}, config)
@@ -72,7 +72,7 @@ func TestPackageDirectoryMismatchWithDefaultConfig(t *testing.T) {
 
 func TestPackageDirectoryMismatchWithTestDirectories(t *testing.T) {
 	// Test with new format that excludes specific test directories
-	config := &lint.RuleConfig{Arguments: []any{map[string]any{"ignore-directories": []any{"testinfo", "testutils"}}}}
+	config := &lint.RuleConfig{Arguments: lint.Arguments{map[string]any{"ignore-directories": []any{"testinfo", "testutils"}}}}
 
 	testRule(t, "package_directory_mismatch/testinfo/good", &rule.PackageDirectoryMismatchRule{}, config)
 	testRule(t, "package_directory_mismatch/testutils/good", &rule.PackageDirectoryMismatchRule{}, config)
@@ -80,7 +80,7 @@ func TestPackageDirectoryMismatchWithTestDirectories(t *testing.T) {
 
 func TestPackageDirectoryMismatchWithMultipleDirectories(t *testing.T) {
 	// Test with new named argument format that excludes both "testutils" and "testinfo"
-	config := &lint.RuleConfig{Arguments: []any{map[string]any{"ignoreDirectories": []any{"testutils", "testinfo"}}}}
+	config := &lint.RuleConfig{Arguments: lint.Arguments{map[string]any{"ignoreDirectories": []any{"testutils", "testinfo"}}}}
 
 	testRule(t, "package_directory_mismatch/testutils/good", &rule.PackageDirectoryMismatchRule{}, config)
 	testRule(t, "package_directory_mismatch/testinfo/good", &rule.PackageDirectoryMismatchRule{}, config)

--- a/test/receiver_naming_test.go
+++ b/test/receiver_naming_test.go
@@ -14,14 +14,14 @@ func TestReceiverNamingTypeParams(t *testing.T) {
 func TestReceiverNamingMaxLength(t *testing.T) {
 	testRule(t, "receiver_naming_issue_1040", &rule.ReceiverNamingRule{},
 		&lint.RuleConfig{
-			Arguments: []any{
+			Arguments: lint.Arguments{
 				map[string]any{"maxLength": int64(2)},
 			},
 		},
 	)
 	testRule(t, "receiver_naming_issue_1040", &rule.ReceiverNamingRule{},
 		&lint.RuleConfig{
-			Arguments: []any{
+			Arguments: lint.Arguments{
 				map[string]any{"max-length": int64(2)},
 			},
 		},

--- a/test/struct_tag_test.go
+++ b/test/struct_tag_test.go
@@ -13,7 +13,7 @@ func TestStructTag(t *testing.T) {
 
 func TestStructTagWithUserOptions(t *testing.T) {
 	testRule(t, "struct_tag_user_options", &rule.StructTagRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			"json,inline,outline",
 			"bson,gnu",
 			"url,myURLOption",
@@ -30,7 +30,7 @@ func TestStructTagWithUserOptions(t *testing.T) {
 
 func TestStructTagWithOmittedTags(t *testing.T) {
 	testRule(t, "struct_tag_user_options_omit", &rule.StructTagRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			"!validate",
 			"!toml",
 			"json,inline,outline",

--- a/test/superfluous_else_test.go
+++ b/test/superfluous_else_test.go
@@ -9,6 +9,6 @@ import (
 
 func TestSuperfluousElse(t *testing.T) {
 	testRule(t, "superfluous_else", &rule.SuperfluousElseRule{})
-	testRule(t, "superfluous_else_scope", &rule.SuperfluousElseRule{}, &lint.RuleConfig{Arguments: []any{"preserveScope"}})
-	testRule(t, "superfluous_else_scope", &rule.SuperfluousElseRule{}, &lint.RuleConfig{Arguments: []any{"preserve-scope"}})
+	testRule(t, "superfluous_else_scope", &rule.SuperfluousElseRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"preserveScope"}})
+	testRule(t, "superfluous_else_scope", &rule.SuperfluousElseRule{}, &lint.RuleConfig{Arguments: lint.Arguments{"preserve-scope"}})
 }

--- a/test/unchecked_type_assertion_test.go
+++ b/test/unchecked_type_assertion_test.go
@@ -14,14 +14,14 @@ func TestUncheckedDynamicCast(t *testing.T) {
 func TestUncheckedDynamicCastWithAcceptIgnored(t *testing.T) {
 	testRule(t, "unchecked_type_assertion_accept_ignored", &rule.UncheckedTypeAssertionRule{},
 		&lint.RuleConfig{
-			Arguments: []any{
+			Arguments: lint.Arguments{
 				map[string]any{"acceptIgnoredAssertionResult": true},
 			},
 		},
 	)
 	testRule(t, "unchecked_type_assertion_accept_ignored", &rule.UncheckedTypeAssertionRule{},
 		&lint.RuleConfig{
-			Arguments: []any{
+			Arguments: lint.Arguments{
 				map[string]any{"accept-ignored-assertion-result": true},
 			},
 		},

--- a/test/unhandled_error_test.go
+++ b/test/unhandled_error_test.go
@@ -12,14 +12,14 @@ func TestUnhandledError(t *testing.T) {
 }
 
 func TestUnhandledErrorWithIgnoreList(t *testing.T) {
-	args := []any{
-		`unhandledError1`,
-		`fmt\.Print`,
-		`os\.(Create|WriteFile|Chmod)`,
-		`net\..*`,
-		`bytes\.Buffer\.Write`,
-		`fixtures\.unhandledErrorStruct2\.reterr`,
-	}
-
-	testRule(t, "unhandled_error_w_ignorelist", &rule.UnhandledErrorRule{}, &lint.RuleConfig{Arguments: args})
+	testRule(t, "unhandled_error_w_ignorelist", &rule.UnhandledErrorRule{}, &lint.RuleConfig{
+		Arguments: lint.Arguments{
+			`unhandledError1`,
+			`fmt\.Print`,
+			`os\.(Create|WriteFile|Chmod)`,
+			`net\..*`,
+			`bytes\.Buffer\.Write`,
+			`fixtures\.unhandledErrorStruct2\.reterr`,
+		},
+	})
 }

--- a/test/unused_param_test.go
+++ b/test/unused_param_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestUnusedParam(t *testing.T) {
 	testRule(t, "unused_param", &rule.UnusedParamRule{})
-	testRule(t, "unused_param", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: []any{}})
-	testRule(t, "unused_param", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: []any{
+	testRule(t, "unused_param", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: lint.Arguments{}})
+	testRule(t, "unused_param", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: lint.Arguments{
 		map[string]any{"a": "^xxx"},
 	}})
-	testRule(t, "unused_param_custom_regex", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: []any{
+	testRule(t, "unused_param_custom_regex", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: lint.Arguments{
 		map[string]any{"allowRegex": "^xxx"},
 	}})
-	testRule(t, "unused_param_custom_regex", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: []any{
+	testRule(t, "unused_param_custom_regex", &rule.UnusedParamRule{}, &lint.RuleConfig{Arguments: lint.Arguments{
 		map[string]any{"allow-regex": "^xxx"},
 	}})
 }

--- a/test/unused_receiver_test.go
+++ b/test/unused_receiver_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestUnusedReceiver(t *testing.T) {
 	testRule(t, "unused_receiver", &rule.UnusedReceiverRule{})
-	testRule(t, "unused_receiver", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: []any{}})
-	testRule(t, "unused_receiver", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: []any{
+	testRule(t, "unused_receiver", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: lint.Arguments{}})
+	testRule(t, "unused_receiver", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: lint.Arguments{
 		map[string]any{"a": "^xxx"},
 	}})
-	testRule(t, "unused_receiver_custom_regex", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: []any{
+	testRule(t, "unused_receiver_custom_regex", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: lint.Arguments{
 		map[string]any{"allowRegex": "^xxx"},
 	}})
-	testRule(t, "unused_receiver_custom_regex", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: []any{
+	testRule(t, "unused_receiver_custom_regex", &rule.UnusedReceiverRule{}, &lint.RuleConfig{Arguments: lint.Arguments{
 		map[string]any{"allow-regex": "^xxx"},
 	}})
 }

--- a/test/var_naming_test.go
+++ b/test/var_naming_test.go
@@ -9,24 +9,24 @@ import (
 
 func TestVarNaming(t *testing.T) {
 	testRule(t, "var_naming", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{[]any{"ID"}, []any{"VM"}},
+		Arguments: lint.Arguments{[]any{"ID"}, []any{"VM"}},
 	})
 	testRule(t, "var_naming_skip_initialism_name_checks_true", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			[]any{},
 			[]any{},
 			[]any{map[string]any{"skip-initialism-name-checks": true}},
 		},
 	})
 	testRule(t, "var_naming_skip_initialism_name_checks_false", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			[]any{},
 			[]any{},
 			[]any{map[string]any{"skip-initialism-name-checks": false}},
 		},
 	})
 	testRule(t, "var_naming_allowlist_blocklist_skip_initialism_name_checks", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			[]any{"ID"},
 			[]any{"VM"},
 			[]any{map[string]any{"skip-initialism-name-checks": true}},
@@ -37,29 +37,29 @@ func TestVarNaming(t *testing.T) {
 
 	testRule(t, "var_naming_upper_case_const_false", &rule.VarNamingRule{}, &lint.RuleConfig{})
 	testRule(t, "var_naming_upper_case_const_true", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{[]any{}, []any{}, []any{map[string]any{"upperCaseConst": true}}},
+		Arguments: lint.Arguments{[]any{}, []any{}, []any{map[string]any{"upperCaseConst": true}}},
 	})
 	testRule(t, "var_naming_upper_case_const_true", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{[]any{}, []any{}, []any{map[string]any{"upper-case-const": true}}},
+		Arguments: lint.Arguments{[]any{}, []any{}, []any{map[string]any{"upper-case-const": true}}},
 	})
 
 	testRule(t, "var_naming_skip_package_name_checks_false", &rule.VarNamingRule{}, &lint.RuleConfig{})
 	testRule(t, "var_naming_skip_package_name_checks_true", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{[]any{}, []any{}, []any{map[string]any{"skipPackageNameChecks": true}}},
+		Arguments: lint.Arguments{[]any{}, []any{}, []any{map[string]any{"skipPackageNameChecks": true}}},
 	})
 	testRule(t, "var_naming_skip_package_name_checks_true", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{[]any{}, []any{}, []any{map[string]any{"skip-package-name-checks": true}}},
+		Arguments: lint.Arguments{[]any{}, []any{}, []any{map[string]any{"skip-package-name-checks": true}}},
 	})
 	testRule(t, "var_naming_meaningless_package_name", &rule.VarNamingRule{}, &lint.RuleConfig{})
 	testRule(t, "var_naming_meaningless_package_name", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			[]any{},
 			[]any{},
 			[]any{map[string]any{"skip-package-name-checks": false}},
 		},
 	})
 	testRule(t, "var_naming_bad_package_name", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			[]any{},
 			[]any{},
 			[]any{map[string]any{"skip-package-name-checks": false, "extra-bad-package-names": []any{"helpers"}}},
@@ -68,7 +68,7 @@ func TestVarNaming(t *testing.T) {
 	testRule(t, "var_naming_top_level_pkg", &rule.VarNamingRule{}, &lint.RuleConfig{})
 	testRule(t, "var_naming_std_lib_conflict", &rule.VarNamingRule{}, &lint.RuleConfig{})
 	testRule(t, "var_naming_std_lib_conflict_skip", &rule.VarNamingRule{}, &lint.RuleConfig{
-		Arguments: []any{
+		Arguments: lint.Arguments{
 			[]any{},
 			[]any{},
 			[]any{map[string]any{"skip-package-name-collision-with-go-std": true}},
@@ -80,7 +80,7 @@ func BenchmarkUpperCaseConstTrue(b *testing.B) {
 	var t *testing.T
 	for b.Loop() {
 		testRule(t, "var_naming_upper_case_const_true", &rule.VarNamingRule{}, &lint.RuleConfig{
-			Arguments: []any{[]any{}, []any{}, []any{map[string]any{"upperCaseConst": true}}},
+			Arguments: lint.Arguments{[]any{}, []any{}, []any{map[string]any{"upperCaseConst": true}}},
 		})
 	}
 }


### PR DESCRIPTION
This PR replaces `[]any` with `linters.Arguments` for consistency.

Used `gocritic.ruleguard` for these findings. But don't want to include `ruleguard` as it requires adding an indirect dependency `github.com/quasilyte/go-ruleguard/dsl` into `go.mod`. See https://github.com/quasilyte/go-ruleguard/issues/408

### How to reproduce locally

Add the following to `linters.settings.gocritic` in `.golangci.yml`:
```yaml
      settings:
        ruleguard:
          rules: '${config-path}/tools/ruleguard.go'
```

Create `tools/ruleguard.go`:

```go
//go:build ruleguard

// Package ruleguard defines custom rules for ruleguard linter.
package ruleguard

import "github.com/quasilyte/go-ruleguard/dsl"

func argsMustUseAlias(m dsl.Matcher) {
	// Flag []any literal used directly in Arguments field
	m.Match(`lint.RuleConfig{Arguments: []any{$*vals}}`).
		Report(`use lint.Arguments{} instead of []any{}`).
		Suggest(`lint.RuleConfig{Arguments: lint.Arguments{$vals}}`)

	m.Match(`lint.RuleConfig{$*pre, Arguments: []any{$*vals}, $*post}`).
		Report(`use lint.Arguments{} instead of []any{}`).
		Suggest(`lint.RuleConfig{$*pre, Arguments: lint.Arguments{$vals}, $*post}`)
}
```

Run commands:

```console
$ go get github.com/quasilyte/go-ruleguard/dsl
$ golangci-lint run
test/add_constant_test.go:15:56: ruleguard: use lint.Arguments{} instead of []any{} (gocritic)
        testRule(t, "add_constant", &rule.AddConstantRule{}, &lint.RuleConfig{
                                                              ^
...
test/var_naming_test.go:82:75: ruleguard: use lint.Arguments{} instead of []any{} (gocritic)
                testRule(t, "var_naming_upper_case_const_true", &rule.VarNamingRule{}, &lint.RuleConfig{
                                                                                        ^
110 issues:
* gocritic: 110
$ golangci-lint run --fix
0 issues.
```