### PR TITLE
chore: bump go.mod version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mgechev/revive
 
-go 1.24.0
+go 1.25.0
 
 require (
 	codeberg.org/chavacava/garif v0.2.0


### PR DESCRIPTION
This pull request makes a minor update to the Go module version in the `go.mod` file, upgrading the Go language version requirement from 1.24.0 to 1.25.0.

closes #1654
