### PR TITLE
chore: go:fix inline for LintPattern.GetPattern

### DIFF
--- a/revivelib/pattern.go
+++ b/revivelib/pattern.go
@@ -11,9 +11,11 @@ func (p *LintPattern) IsExclude() bool {
 	return p.isExclude
 }
 
-// GetPattern returns the actual pattern
+// GetPattern returns the actual pattern.
 //
-// Deprecated: Use [Pattern].
+// Deprecated: Use [LintPattern.Pattern].
+//
+//go:fix inline
 func (p *LintPattern) GetPattern() string {
 	return p.Pattern()
 }


### PR DESCRIPTION
Now users can replace `LintPattern.GetPattern` with `LintPattern.Pattern` with the command:

```
go fix -inline ./...
```

See https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/inline#hdr-Analyzer_inline

Additionally, the PR corrects godoc.

Before:
<img width="350" height="108" alt="image" src="https://github.com/user-attachments/assets/7a2e5ba1-3458-4c23-bc54-6f7b08e31dcf" />


After:
<img width="357" height="110" alt="image" src="https://github.com/user-attachments/assets/04bbcc6f-1714-4cdd-92b4-720cfdd647a5" />
