### PR TITLE
comment-spacings: ignore //#nosec directive by default

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -260,6 +260,11 @@ _Configuration_: ([]string) list of exceptions. For example, to accept comments 
 
 You need to add both `"mypragma:"` and `"+optional"` in the configuration
 
+The following comment prefixes are allowed by default:
+
+- `//#nosec` — [gosec](https://github.com/securego/gosec) security scanner directive
+- Go directive comments matching `//[a-z0-9]+:[a-z0-9]` (e.g. `//nolint:linter`, `//go:generate`, `//revive:disable:rule`)
+
 Configuration example:
 
 ```toml

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -264,7 +264,7 @@ The following comment prefixes are allowed by default:
 
 - `//#nosec` — [gosec](https://github.com/securego/gosec) security scanner directive
 - Go directive comments matching `//[a-z0-9]+:[a-z0-9]` (e.g. `//nolint:linter`, `//go:generate`, `//revive:disable:rule`),
-as well as comments starting with `//line `, `//extern `, and `//export `
+as well as comments starting with "//line ", "//extern ", and "//export "
 
 Configuration example:
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -263,7 +263,7 @@ You need to add both `"mypragma:"` and `"+optional"` in the configuration
 The following comment prefixes are allowed by default:
 
 - `//#nosec` — [gosec](https://github.com/securego/gosec) security scanner directive
-- Go directive comments matching `//[a-z0-9]+:[a-z0-9]` (e.g. `//nolint:linter`, `//go:generate`, `//revive:disable:rule`)
+- Go directive comments matching `//[a-z0-9]+:[a-z0-9]` (e.g. `//nolint:linter`, `//go:generate`, `//revive:disable:rule`), as well as comments starting with `//line `, `//extern `, and `//export `
 
 Configuration example:
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -263,7 +263,8 @@ You need to add both `"mypragma:"` and `"+optional"` in the configuration
 The following comment prefixes are allowed by default:
 
 - `//#nosec` — [gosec](https://github.com/securego/gosec) security scanner directive
-- Go directive comments matching `//[a-z0-9]+:[a-z0-9]` (e.g. `//nolint:linter`, `//go:generate`, `//revive:disable:rule`), as well as comments starting with `//line `, `//extern `, and `//export `
+- Go directive comments matching `//[a-z0-9]+:[a-z0-9]` (e.g. `//nolint:linter`, `//go:generate`, `//revive:disable:rule`),
+as well as comments starting with `//line `, `//extern `, and `//export `
 
 Configuration example:
 

--- a/rule/comment_spacings.go
+++ b/rule/comment_spacings.go
@@ -7,8 +7,13 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
+// defaultAllowList is a set of comment prefixes that are allowed to not have a space after the comment delimiter.
+var defaultAllowList = []string{
+	"//#nosec",
+}
+
 // CommentSpacingsRule checks whether there is a space between
-// the comment symbol // and the start of the comment text.
+// the comment symbol `//` and the start of the comment text.
 type CommentSpacingsRule struct {
 	allowList []string
 }
@@ -17,7 +22,7 @@ type CommentSpacingsRule struct {
 //
 // Configuration implements the [lint.ConfigurableRule] interface.
 func (r *CommentSpacingsRule) Configure(arguments lint.Arguments) error {
-	r.allowList = []string{}
+	r.allowList = defaultAllowList
 	for _, arg := range arguments {
 		allow, ok := arg.(string) // Alt. non panicking version
 		if !ok {

--- a/rule/comment_spacings_test.go
+++ b/rule/comment_spacings_test.go
@@ -1,0 +1,73 @@
+package rule
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+)
+
+func TestCommentSpacingsRule_Configure(t *testing.T) {
+	tests := []struct {
+		name          string
+		arguments     lint.Arguments
+		wantErr       error
+		wantAllowList []string
+	}{
+		{
+			name:      "no arguments uses default allow list",
+			arguments: lint.Arguments{},
+			wantErr:   nil,
+			wantAllowList: []string{
+				"//#nosec",
+			},
+		},
+		{
+			name:      "valid arguments appended to default allow list",
+			arguments: lint.Arguments{"mypragma:", "+optional"},
+			wantErr:   nil,
+			wantAllowList: []string{
+				"//#nosec",
+				"//mypragma:",
+				"//+optional",
+			},
+		},
+		{
+			name:      "invalid argument type",
+			arguments: lint.Arguments{123},
+			wantErr:   errors.New("invalid argument 123 for comment-spacings; expected string but got int"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r CommentSpacingsRule
+
+			err := r.Configure(tt.arguments)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("unexpected error: got = nil, want = %v", tt.wantErr)
+					return
+				}
+				if err.Error() != tt.wantErr.Error() {
+					t.Errorf("unexpected error: got = %v, want = %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: got = %v, want = nil", err)
+				return
+			}
+			if len(r.allowList) != len(tt.wantAllowList) {
+				t.Errorf("unexpected allowList length: got = %d, want = %d", len(r.allowList), len(tt.wantAllowList))
+				return
+			}
+			for i, entry := range tt.wantAllowList {
+				if r.allowList[i] != entry {
+					t.Errorf("unexpected allowList[%d]: got = %q, want = %q", i, r.allowList[i], entry)
+				}
+			}
+		})
+	}
+}

--- a/test/comment_spacings_test.go
+++ b/test/comment_spacings_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestCommentSpacings(t *testing.T) {
-	testRule(t, "comment_spacings", &rule.CommentSpacingsRule{}, &lint.RuleConfig{
+	testRule(t, "comment_spacings", &rule.CommentSpacingsRule{}, &lint.RuleConfig{})
+	testRule(t, "comment_spacings_custom_directive", &rule.CommentSpacingsRule{}, &lint.RuleConfig{
 		Arguments: lint.Arguments{"myOwnDirective:", "+optional"},
-	},
-	)
+	})
 }

--- a/testdata/comment_spacings.go
+++ b/testdata/comment_spacings.go
@@ -1,5 +1,10 @@
 package commentspacings
 
+import (
+	"fmt"
+	"os"
+)
+
 //revive:disable:cyclomatic
 type some struct{}
 
@@ -16,12 +21,10 @@ type hello struct {
 	random `json:random`
 }
 
-// MATCH:21 /no space between comment delimiter and comment text/
+// MATCH:26 /no space between comment delimiter and comment text/
 
 //This comment does not respect the spacing rule!
 var a string
-
-//myOwnDirective: do something
 
 /*
 Should be valid
@@ -29,7 +32,7 @@ Should be valid
 
 //	Tabs between comment delimiter and comment text should be fine
 
-// MATCH:34 /no space between comment delimiter and comment text/
+// MATCH:37 /no space between comment delimiter and comment text/
 
 /*Not valid
  */
@@ -43,15 +46,20 @@ Should be valid
 //nolint:staticcheck // nolint should be in the default list of acceptable comments.
 var b string
 
-type c struct {
-	//+optional
-	d *int `json:"d,omitempty"`
-}
-
 //extern open
 //export MyFunction
 
 //nolint:gochecknoglobals
 
 //this is a regular command that's incorrectly formatted //nolint:foobar // because one two three
-// MATCH:56 /no space between comment delimiter and comment text/
+// MATCH:54 /no space between comment delimiter and comment text/
+
+func _(outputPath string) {
+	//gosec:disable G703
+	f, err := os.Create(outputPath) //#nosec G703 - path is validated above
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+}

--- a/testdata/comment_spacings_custom_directive.go
+++ b/testdata/comment_spacings_custom_directive.go
@@ -1,0 +1,23 @@
+package commentspacings
+
+import (
+	"fmt"
+	"os"
+)
+
+//myOwnDirective: do something // should be valid
+
+type c struct {
+	//+optional
+	d *int `json:"d,omitempty"`
+}
+
+func _(outputPath string) {
+	//gosec:disable G703
+	f, err := os.Create(outputPath) //#nosec G703 - path is validated above
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+}


### PR DESCRIPTION
Extend the comment-spacings rule to ignore `//#nosec` comments by default.

https://github.com/securego/gosec/blob/5f4eec95fa28ce5dc6cf555de8c242cb57545f01/cmd/gosecutil/tools.go#L79