### PR TITLE
feature: new rule `multiline-if-init`

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1155,6 +1155,16 @@ This rule warns when a method modifies its receiver.
 
 _Configuration_: N/A
 
+## multiline-if-init
+
+_Description_: Flags `if` statements whose init clause spans multiple lines.
+The if-init idiom exists for tight one-liners. When the init wraps across
+lines, the reader has to visually parse a struct literal or call chain to
+find where the initialization ends and the condition begins. Extract the
+initialization to a separate statement instead.
+
+_Configuration_: N/A
+
 ## nested-structs
 
 _Description_: Packages declaring structs that contain other inline struct definitions can be hard to understand/read for other developers.

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -65,6 +65,7 @@ List of all available rules.
 - [max-public-structs](#max-public-structs)
 - [modifies-parameter](#modifies-parameter)
 - [modifies-value-receiver](#modifies-value-receiver)
+- [multiline-if-init](#multiline-if-init)
 - [nested-structs](#nested-structs)
 - [optimize-operands-order](#optimize-operands-order)
 - [package-comments](#package-comments)

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1158,10 +1158,41 @@ _Configuration_: N/A
 ## multiline-if-init
 
 _Description_: Flags `if` statements whose init clause spans multiple lines.
-The if-init idiom exists for tight one-liners. When the init wraps across
-lines, the reader has to visually parse a struct literal or call chain to
-find where the initialization ends and the condition begins. Extract the
-initialization to a separate statement instead.
+The if-init idiom exists for tight one-liners.
+When the init wraps across lines, the reader has to visually parse a struct literal or
+call chain to find where the initialization ends and the condition begins.
+Extract the initialization to a separate statement instead.
+
+### Examples (multiline-if-init)
+
+Before (violation):
+
+```go
+if r, err := rec(
+	ctx,
+	mgr.GetClient(),
+	mgr.GetFieldIndexer(),
+	mgr.GetEventRecorderFor(fmt.Sprintf("%s-%s-controller", name, options.ManagerName)),
+	opts...,
+); err != nil {
+	return err
+}
+```
+
+After (fixed):
+
+```go
+r, err := rec(
+	ctx,
+	mgr.GetClient(),
+	mgr.GetFieldIndexer(),
+	mgr.GetEventRecorderFor(fmt.Sprintf("%s-%s-controller", name, options.ManagerName)),
+	opts...,
+)
+if err != nil {
+	return err
+}
+```
 
 _Configuration_: N/A
 

--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ var allRules = append([]lint.Rule{
 	&rule.DataRaceRule{},
 	&rule.CommentSpacingsRule{},
 	&rule.IfReturnRule{},
+	&rule.MultilineIfInitRule{},
 	&rule.RedundantImportAlias{},
 	&rule.ImportAliasNamingRule{},
 	&rule.EnforceMapStyleRule{},

--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,6 @@ var allRules = append([]lint.Rule{
 	&rule.DataRaceRule{},
 	&rule.CommentSpacingsRule{},
 	&rule.IfReturnRule{},
-	&rule.MultilineIfInitRule{},
 	&rule.RedundantImportAlias{},
 	&rule.ImportAliasNamingRule{},
 	&rule.EnforceMapStyleRule{},
@@ -120,6 +119,7 @@ var allRules = append([]lint.Rule{
 	&rule.EpochNamingRule{},
 	&rule.UseSlicesSort{},
 	&rule.PackageNamingRule{},
+	&rule.MultilineIfInitRule{},
 }, defaultRules...)
 
 // allFormatters is a list of all available formatters to output the linting results.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -442,7 +442,7 @@ func TestGetLintingRules(t *testing.T) {
 		// len of defaultRules
 		defaultRulesCount = 23
 		// len of allRules: update this when adding new rules
-		allRulesCount = 102
+		allRulesCount = 103
 	)
 
 	tt := map[string]struct {

--- a/rule/multiline_if_init.go
+++ b/rule/multiline_if_init.go
@@ -6,10 +6,9 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// MultilineIfInitRule flags if statements whose init clause spans
-// multiple lines.  A multi-line init defeats the purpose of the
-// if-init idiom, which exists for tight one-liners.  When it wraps,
-// the reader has to visually parse a struct literal or call chain to
+// MultilineIfInitRule flags if statements whose init clause spans multiple lines.
+// A multi-line init defeats the purpose of the if-init idiom, which exists for tight one-liners.
+// When it wraps, the reader has to visually parse a struct literal or call chain to
 // find where the init ends and the condition begins.
 type MultilineIfInitRule struct{}
 
@@ -52,7 +51,7 @@ func (w lintMultilineIfInit) Visit(n ast.Node) ast.Visitor {
 			Confidence: 1,
 			Node:       ifStmt,
 			Category:   lint.FailureCategoryStyle,
-			Failure:    "if-init statement spans multiple lines; extract the initialization to a separate statement",
+			Failure:    "if-init statement should not span multiple lines",
 		})
 	}
 

--- a/rule/multiline_if_init.go
+++ b/rule/multiline_if_init.go
@@ -1,0 +1,60 @@
+package rule
+
+import (
+	"go/ast"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// MultilineIfInitRule flags if statements whose init clause spans
+// multiple lines.  A multi-line init defeats the purpose of the
+// if-init idiom, which exists for tight one-liners.  When it wraps,
+// the reader has to visually parse a struct literal or call chain to
+// find where the init ends and the condition begins.
+type MultilineIfInitRule struct{}
+
+// Apply applies the rule to given file.
+func (*MultilineIfInitRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	var failures []lint.Failure
+
+	onFailure := func(failure lint.Failure) {
+		failures = append(failures, failure)
+	}
+
+	ast.Walk(lintMultilineIfInit{
+		file:      file,
+		onFailure: onFailure,
+	}, file.AST)
+	return failures
+}
+
+// Name returns the rule name.
+func (*MultilineIfInitRule) Name() string {
+	return "multiline-if-init"
+}
+
+type lintMultilineIfInit struct {
+	file      *lint.File
+	onFailure func(lint.Failure)
+}
+
+func (w lintMultilineIfInit) Visit(n ast.Node) ast.Visitor {
+	ifStmt, ok := n.(*ast.IfStmt)
+	if !ok || ifStmt.Init == nil {
+		return w
+	}
+
+	initStart := w.file.ToPosition(ifStmt.Init.Pos())
+	initEnd := w.file.ToPosition(ifStmt.Init.End())
+
+	if initEnd.Line-initStart.Line > 0 {
+		w.onFailure(lint.Failure{
+			Confidence: 1,
+			Node:       ifStmt,
+			Category:   lint.FailureCategoryStyle,
+			Failure:    "if-init statement spans multiple lines; extract the initialization to a separate statement",
+		})
+	}
+
+	return w
+}

--- a/test/multiline_if_init_test.go
+++ b/test/multiline_if_init_test.go
@@ -1,0 +1,11 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestMultilineIfInit(t *testing.T) {
+	testRule(t, "multiline_if_init", &rule.MultilineIfInitRule{})
+}

--- a/testdata/multiline_if_init.go
+++ b/testdata/multiline_if_init.go
@@ -1,0 +1,73 @@
+// Test of multiline-if-init rule.
+
+// Package fixtures ...
+package fixtures
+
+import "time"
+
+type MempoolTx struct {
+	id      [32]byte
+	expires time.Time
+	tx      interface{}
+}
+
+func insert(tx *MempoolTx) error { return nil }
+
+// Single-line init: OK.
+func singleLine() {
+	if err := insert(nil); err != nil {
+		panic(err)
+	}
+}
+
+// Multi-return single-line init: OK.
+func multiReturnSingleLine() {
+	if x, err := 1, insert(nil); err != nil {
+		_ = x
+		panic(err)
+	}
+}
+
+// Multi-line init with struct literal.
+func multiLineStructLiteral() {
+	if err := insert(&MempoolTx{ // MATCH /if-init statement spans multiple lines; extract the initialization to a separate statement/
+		expires: time.Now().Add(time.Hour),
+	}); err != nil {
+		panic(err)
+	}
+}
+
+// Multi-line init with long call chain.
+func multiLineCallChain() {
+	if err := insert( // MATCH /if-init statement spans multiple lines; extract the initialization to a separate statement/
+		nil,
+	); err != nil {
+		panic(err)
+	}
+}
+
+// Nested: outer is single-line (OK), inner is multi-line.
+func nested() {
+	if err := insert(nil); err != nil {
+		if err2 := insert(&MempoolTx{ // MATCH /if-init statement spans multiple lines; extract the initialization to a separate statement/
+			expires: time.Now(),
+		}); err2 != nil {
+			panic(err2)
+		}
+	}
+}
+
+// No init clause: OK.
+func noInit() {
+	x := true
+	if x {
+		_ = x
+	}
+}
+
+// Init is a simple assignment (single line): OK.
+func simpleAssign() {
+	if x := 42; x > 0 {
+		_ = x
+	}
+}

--- a/testdata/multiline_if_init.go
+++ b/testdata/multiline_if_init.go
@@ -1,6 +1,3 @@
-// Test of multiline-if-init rule.
-
-// Package fixtures ...
 package fixtures
 
 import "time"
@@ -8,7 +5,7 @@ import "time"
 type MempoolTx struct {
 	id      [32]byte
 	expires time.Time
-	tx      interface{}
+	tx      any
 }
 
 func insert(tx *MempoolTx) error { return nil }
@@ -30,7 +27,7 @@ func multiReturnSingleLine() {
 
 // Multi-line init with struct literal.
 func multiLineStructLiteral() {
-	if err := insert(&MempoolTx{ // MATCH /if-init statement spans multiple lines; extract the initialization to a separate statement/
+	if err := insert(&MempoolTx{ // MATCH /if-init statement should not span multiple lines/
 		expires: time.Now().Add(time.Hour),
 	}); err != nil {
 		panic(err)
@@ -39,7 +36,7 @@ func multiLineStructLiteral() {
 
 // Multi-line init with long call chain.
 func multiLineCallChain() {
-	if err := insert( // MATCH /if-init statement spans multiple lines; extract the initialization to a separate statement/
+	if err := insert( // MATCH /if-init statement should not span multiple lines/
 		nil,
 	); err != nil {
 		panic(err)
@@ -49,7 +46,7 @@ func multiLineCallChain() {
 // Nested: outer is single-line (OK), inner is multi-line.
 func nested() {
 	if err := insert(nil); err != nil {
-		if err2 := insert(&MempoolTx{ // MATCH /if-init statement spans multiple lines; extract the initialization to a separate statement/
+		if err2 := insert(&MempoolTx{ // MATCH /if-init statement should not span multiple lines/
 			expires: time.Now(),
 		}); err2 != nil {
 			panic(err2)


### PR DESCRIPTION
## Motivation

The `if`-init idiom exists for tight one-liners:

```go
if err := foo(); err != nil {
    return err
}
```

When the init clause spans multiple lines — typically because it contains a struct literal or a wrapped call chain — the boundary between initialization and condition becomes ambiguous:

```go
if err := insert(&MempoolTx{
    id: tx.TxHash(), expires: time.Now().Add(time.Hour), tx: tx,
}); err != nil {
    t.Fatal(err)
}
```

The `});` line is syntactically valid but visually deceptive. Readers have to parse the struct literal to find where the init ends and the condition begins. The fix is mechanical — extract the init to a separate statement:

```go
err := insert(&MempoolTx{
    id: tx.TxHash(), expires: time.Now().Add(time.Hour), tx: tx,
})
if err != nil {
    t.Fatal(err)
}
```

This came up repeatedly in code review on a production Go project and we wanted a lint rule to catch it going forward.

## Implementation

The rule walks `ast.IfStmt` nodes. If `Init` is non-nil and its start line differs from its end line (via `token.Position`), the rule reports a failure. No type checking required.

## Checklist

- [x] Tests added (`test/multiline_if_init_test.go`)
- [x] Test fixture covers positive and negative cases (`testdata/multiline_if_init.go`)
- [x] Rule registered in `config/config.go` (opt-in, not in default set)
- [x] Documentation added to `RULES_DESCRIPTIONS.md`
- [x] Follows existing rule conventions (`Apply`/`Name` interface, `ast.Visitor` walker)
- [x] No configuration needed
- [x] No false positives on single-line multi-return inits like `if x, err := foo(); err != nil`

Closes #1714
