### PR TITLE
add-constant: ignore empty string literals

### DIFF
--- a/rule/add_constant.go
+++ b/rule/add_constant.go
@@ -166,7 +166,11 @@ func (w *lintAddConstantRule) checkStrLit(n *ast.BasicLit) {
 	mustCheck := count > ignoreMarker
 	if mustCheck {
 		w.strLits[n.Value] = count + 1
-		if n.Value != "``" && w.strLits[n.Value] > w.strLitLimit {
+		val, _ := strconv.Unquote(n.Value)
+		if val == "" {
+			return
+		}
+		if w.strLits[n.Value] > w.strLitLimit {
 			w.onFailure(lint.Failure{
 				Confidence: 1,
 				Node:       n,

--- a/rule/add_constant.go
+++ b/rule/add_constant.go
@@ -166,7 +166,7 @@ func (w *lintAddConstantRule) checkStrLit(n *ast.BasicLit) {
 	mustCheck := count > ignoreMarker
 	if mustCheck {
 		w.strLits[n.Value] = count + 1
-		if w.strLits[n.Value] > w.strLitLimit {
+		if n.Value != "``" && w.strLits[n.Value] > w.strLitLimit {
 			w.onFailure(lint.Failure{
 				Confidence: 1,
 				Node:       n,

--- a/testdata/add_constant.go
+++ b/testdata/add_constant.go
@@ -102,3 +102,12 @@ func tagsInStructLiteralsShouldBeOK() {
 
 	_, _, _, _, _, _, _ = a, b, c, d, e, f, g
 }
+
+func _() {
+	_ = ""
+	_ = ""
+	_ = ""
+	_ = ``
+	_ = ``
+	_ = ``
+}

--- a/testdata/add_constant.go
+++ b/testdata/add_constant.go
@@ -102,12 +102,3 @@ func tagsInStructLiteralsShouldBeOK() {
 
 	_, _, _, _, _, _, _ = a, b, c, d, e, f, g
 }
-
-func _() {
-	_ = ""
-	_ = ""
-	_ = ""
-	_ = ``
-	_ = ``
-	_ = ``
-}

--- a/testdata/add_constant_default.go
+++ b/testdata/add_constant_default.go
@@ -9,4 +9,11 @@ func foo() {
 	e = "match" // MATCH /string literal "match" appears, at least, 3 times, create a named constant for it/
 
 	f = 5 // MATCH /avoid magic numbers like '5', create a named constant for it/
+
+	_ = ""
+	_ = ""
+	_ = ""
+	_ = ``
+	_ = ``
+	_ = ``
 }


### PR DESCRIPTION
This PR extends the `add-constant` rule to ignore the empty string `` by default.