### PR TITLE
docs: update go instructions for modern go patterns

### DIFF
--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -16,7 +16,8 @@ and [Google's Go Style Guide](https://google.github.io/styleguide/go/).
 - Always determine the project's Go version from the `go` directive in `go.mod` before suggesting changes.
 - Do **not** propose rewrites that replace modern standard-library features (Go 1.21+) with hand-rolled equivalents.
 - Do **not** flag, downgrade, or "polyfill" the following modern features when the `go.mod` permits them:
-  - Go 1.21: built-ins `min`, `max`, `clear`; stdlib packages `slices`, `maps`, `cmp`; structured logging `log/slog`; `errors.Join`.
+  - Go 1.20: `errors.Join`.
+  - Go 1.21: built-ins `min`, `max`, `clear`; stdlib packages `slices`, `maps`, `cmp`; structured logging `log/slog`.
   - Go 1.22: range-over-integer (`for i := range n`); per-iteration loop variable scoping; `math/rand/v2`; enhanced `http.ServeMux` patterns; `cmp.Or`.
   - Go 1.23: range-over-function iterators (`iter.Seq`, `iter.Seq2`); `unique` package; `slices.Sorted`, `slices.Collect`, etc.
   - Go 1.24: generic type aliases; `omitzero` JSON tag; `weak` package; `testing.B.Loop`; `os.Root`.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -409,8 +409,8 @@ for it := range ch { /* ... */ }
 Do:
 
 ```go
-func Items(source []T) iter.Seq[Item] {
-    return func(yield func(Item) bool) {
+func Items[T any](source []T) iter.Seq[T] {
+    return func(yield func(T) bool) {
         for _, it := range source {
             if !yield(it) {
                 return
@@ -445,13 +445,13 @@ type Config struct {
 Don't (re-declaring instead of aliasing):
 
 ```go
-type StringSet struct{ inner sets.Set[string] }
+type Vec[T any] []T
 ```
 
 Do:
 
 ```go
-type Set[T comparable] = sets.Set[T]
+type VecAlias[T any] = []T
 ```
 
 ### `testing/synctest` for time-dependent tests (Go 1.25)

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -11,6 +11,19 @@ These instructions are based on [Effective Go](https://go.dev/doc/effective_go),
 [Go Test Code Comments](https://go.dev/wiki/TestComments),
 and [Google's Go Style Guide](https://google.github.io/styleguide/go/).
 
+## Go Version Awareness
+
+- Always determine the project's Go version from the `go` directive in `go.mod` before suggesting changes.
+- Do **not** propose rewrites that replace modern standard-library features (Go 1.21+) with hand-rolled equivalents.
+- Do **not** flag, downgrade, or "polyfill" the following modern features when the `go.mod` permits them:
+  - Go 1.21: built-ins `min`, `max`, `clear`; stdlib packages `slices`, `maps`, `cmp`; structured logging `log/slog`; `errors.Join`.
+  - Go 1.22: range-over-integer (`for i := range n`); per-iteration loop variable scoping; `math/rand/v2`; enhanced `http.ServeMux` patterns; `cmp.Or`.
+  - Go 1.23: range-over-function iterators (`iter.Seq`, `iter.Seq2`); `unique` package; `slices.Sorted`, `slices.Collect`, etc.
+  - Go 1.24: generic type aliases; `omitzero` JSON tag; `weak` package; `testing.B.Loop`; `os.Root`.
+  - Go 1.25: `testing/synctest`; `runtime.AddCleanup`; container-aware `GOMAXPROCS`; `encoding/json/v2` (experimental).
+- When proposing code that requires a feature newer than `go.mod` allows, call this out explicitly rather than silently using it.
+- Prefer the newest idiomatic form available for the project's Go version; only suggest the older pattern when the feature is genuinely unavailable.
+
 ## General Instructions
 
 - Write simple, clear, and idiomatic Go code
@@ -233,6 +246,274 @@ and [Google's Go Style Guide](https://google.github.io/styleguide/go/).
 - Write meaningful commit messages
 - Review diffs before committing
 
+## Modern Go Features (Go 1.21+) — Do / Don't
+
+Use these examples when the `go.mod` version permits the feature. Do not suggest reverting any of the "Do" forms below to the "Don't" forms.
+
+### Built-in `min`, `max`, `clear` (Go 1.21)
+
+Don't:
+
+```go
+func maxInt(a, b int) int {
+    if a > b {
+        return a
+    }
+    return b
+}
+n := maxInt(x, y)
+
+for k := range m {
+    delete(m, k)
+}
+```
+
+Do:
+
+```go
+n := max(x, y)
+clear(m)
+```
+
+### `slices` and `maps` packages (Go 1.21)
+
+Don't:
+
+```go
+func contains(haystack []string, needle string) bool {
+    for _, s := range haystack {
+        if s == needle {
+            return true
+        }
+    }
+    return false
+}
+
+sort.Slice(xs, func(i, j int) bool { return xs[i] < xs[j] })
+```
+
+Do:
+
+```go
+if slices.Contains(haystack, needle) { /* ... */ }
+slices.Sort(xs)
+keys := slices.Sorted(maps.Keys(m)) // Go 1.23
+```
+
+### `errors.Join` (Go 1.20+) and `%w` wrapping
+
+Don't:
+
+```go
+type multiErr struct{ errs []error }
+func (m *multiErr) Error() string { /* manual join */ }
+```
+
+Do:
+
+```go
+return errors.Join(err1, err2, err3)
+```
+
+### `log/slog` for structured logging (Go 1.21)
+
+Don't:
+
+```go
+log.Printf("user %s failed login from %s: %v", user, ip, err)
+```
+
+Do:
+
+```go
+slog.Error("login failed",
+    "user", user,
+    "ip", ip,
+    "err", err,
+)
+```
+
+### Range-over-integer (Go 1.22)
+
+Don't:
+
+```go
+for i := 0; i < n; i++ {
+    work()
+}
+```
+
+Do:
+
+```go
+for range n {
+    work()
+}
+```
+
+### Loop variable scoping (Go 1.22)
+
+Don't (no longer necessary):
+
+```go
+for _, v := range items {
+    v := v // shadow to capture per iteration
+    go func() { handle(v) }()
+}
+```
+
+Do:
+
+```go
+for _, v := range items {
+    go func() { handle(v) }() // each iteration has its own v since Go 1.22
+}
+```
+
+### `cmp.Or` for fallback chains (Go 1.22)
+
+Don't:
+
+```go
+name := userName
+if name == "" {
+    name = envName
+}
+if name == "" {
+    name = "anonymous"
+}
+```
+
+Do:
+
+```go
+name := cmp.Or(userName, envName, "anonymous")
+```
+
+### Range-over-function iterators (Go 1.23)
+
+Don't:
+
+```go
+ch := make(chan Item)
+go func() {
+    defer close(ch)
+    for _, it := range source {
+        ch <- it
+    }
+}()
+for it := range ch { /* ... */ }
+```
+
+Do:
+
+```go
+func Items(source []T) iter.Seq[Item] {
+    return func(yield func(Item) bool) {
+        for _, it := range source {
+            if !yield(it) {
+                return
+            }
+        }
+    }
+}
+
+for it := range Items(source) { /* ... */ }
+```
+
+### `omitzero` JSON tag (Go 1.24)
+
+Don't (pointer just to make `omitempty` skip the zero struct):
+
+```go
+type Config struct {
+    Window *Window `json:"window,omitempty"`
+}
+```
+
+Do:
+
+```go
+type Config struct {
+    Window Window `json:"window,omitzero"`
+}
+```
+
+### Generic type aliases (Go 1.24)
+
+Don't (re-declaring instead of aliasing):
+
+```go
+type StringSet struct{ inner sets.Set[string] }
+```
+
+Do:
+
+```go
+type Set[T comparable] = sets.Set[T]
+```
+
+### `testing/synctest` for time-dependent tests (Go 1.25)
+
+Don't:
+
+```go
+func TestDebounce(t *testing.T) {
+    d := NewDebouncer(100 * time.Millisecond)
+    d.Trigger()
+    time.Sleep(150 * time.Millisecond) // real wall-clock wait
+    // assert fired
+}
+```
+
+Do:
+
+```go
+func TestDebounce(t *testing.T) {
+    synctest.Run(func() {
+        d := NewDebouncer(100 * time.Millisecond)
+        d.Trigger()
+        time.Sleep(150 * time.Millisecond) // synthetic time, instant
+        // assert fired
+    })
+}
+```
+
+### `testing.B.Loop` for benchmarks (Go 1.24)
+
+Don't:
+
+```go
+func BenchmarkParse(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        Parse(input)
+    }
+}
+```
+
+Do:
+
+```go
+func BenchmarkParse(b *testing.B) {
+    for b.Loop() {
+        Parse(input)
+    }
+}
+```
+
+### Container-aware `GOMAXPROCS` (Go 1.25)
+
+Don't:
+
+```go
+// Manually clamp to cgroup CPU quota at startup.
+runtime.GOMAXPROCS(detectCgroupCPUs())
+```
+
+Do:
+
+Rely on the default — since Go 1.25 the runtime reads the cgroup CPU quota on Linux automatically. Only override when you have a measured reason.
+
 ## Common Pitfalls to Avoid
 
 - Not checking errors
@@ -245,3 +526,6 @@ and [Google's Go Style Guide](https://google.github.io/styleguide/go/).
 - Using global variables unnecessarily
 - Over-using empty interfaces (`interface{}` or `any`)
 - Not considering the zero value of types
+- Suggesting hand-rolled replacements for standard-library features the project's Go version already provides (see "Modern Go Features" above)
+- Re-introducing pre-Go-1.22 loop-variable shadowing (`v := v`) when the module targets Go 1.22 or later
+- Replacing `log/slog` with `log.Printf`-style unstructured logging


### PR DESCRIPTION
This pull request updates the Go code review instructions to ensure recommendations are always aligned with the project's Go version, and to strongly encourage the use of modern Go features when available. It introduces explicit guidance and examples for using new standard library features, and adds new "do/don't" sections for idiomatic usage. The goal is to prevent unnecessary rewrites or regressions to older patterns when the codebase supports newer Go versions.

Key changes include:

### Go Version Awareness and Guidance

- Added a new section instructing reviewers and tools to always check the `go.mod` version before suggesting changes, and to avoid recommending hand-rolled or downgraded alternatives to modern standard library features when the Go version supports them. This section also lists specific features by Go version and provides rules for proposing code that uses features newer than the project's Go version.

### Modern Go Features: Examples and Best Practices

- Introduced a comprehensive "Modern Go Features (Go 1.21+) — Do / Don't" section, with clear before/after code examples for features such as built-in `min`/`max`/`clear`, `slices` and `maps` packages, `errors.Join`, `log/slog`, range-over-integer, loop variable scoping, `cmp.Or`, range-over-function iterators, `omitzero` JSON tag, generic type aliases, `testing/synctest`, `testing.B.Loop`, and container-aware `GOMAXPROCS`. This section instructs not to suggest reverting to older patterns when the modern feature is available.

### Pitfall List Updates

- Expanded the "Common Pitfalls to Avoid" section to explicitly call out suggesting hand-rolled replacements for standard library features, re-introducing unnecessary loop-variable shadowing in Go 1.22+, and replacing structured logging with unstructured logging, reinforcing the new guidance throughout the document.