### PR TITLE
redundant-build-tag: add a case with redundant go1.X

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1411,9 +1411,47 @@ _Configuration_: N/A
 
 ## redundant-build-tag
 
-_Description_: This rule warns about redundant [build tag comments](https://pkg.go.dev/cmd/go@go1.17.0#hdr-Build_constraints) `// +build`
-when `//go:build` is present.
+_Description_: This rule warns about redundant [build tag comments](https://pkg.go.dev/cmd/go@go1.17.0#hdr-Build_constraints).
+It detects unnecessary `// +build` comments when `//go:build` is present.
 `gofmt` in Go 1.17+ automatically adds the `//go:build` constraint, making the `// +build` comment unnecessary.
+Also, the rule spots redundant build tags `//go:build go1.X` when the package version is greater than or equal to `go1.X`.
+
+### Examples (redundant-build-tag)
+
+1. Redundant `// +build` comment:
+
+Before (violation):
+
+```go
+//go:build go1.17
+// +build go1.17
+
+package example
+```
+
+After (fixed):
+
+```go
+//go:build go1.17
+
+package example
+```
+
+2. Redundant build tag when the package version is Go 1.21 or later:
+
+Before (violation):
+
+```go
+//go:build go1.20
+
+package example
+```
+
+After (fixed):
+
+```go
+package example
+```
 
 _Configuration_: N/A
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1418,7 +1418,7 @@ Also, the rule spots redundant build tags `//go:build go1.X` when the package ve
 
 ### Examples (redundant-build-tag)
 
-1. Redundant `// +build` comment:
+Redundant `// +build` comment:
 
 Before (violation):
 
@@ -1437,7 +1437,7 @@ After (fixed):
 package example
 ```
 
-2. Redundant build tag when the package version is Go 1.21 or later:
+Redundant build tag when the package version is Go 1.21 or later:
 
 Before (violation):
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1414,7 +1414,7 @@ _Configuration_: N/A
 _Description_: This rule warns about redundant [build tag comments](https://pkg.go.dev/cmd/go@go1.17.0#hdr-Build_constraints).
 It detects unnecessary `// +build` comments when `//go:build` is present.
 `gofmt` in Go 1.17+ automatically adds the `//go:build` constraint, making the `// +build` comment unnecessary.
-Also, the rule spots redundant build tags `//go:build go1.X` when the package version is greater than or equal to `go1.X`.
+Also, the rule spots redundant build tags `//go:build go1.X` when the package's Go language version is greater than or equal to `go1.X`.
 
 ### Examples (redundant-build-tag)
 
@@ -1437,7 +1437,7 @@ After (fixed):
 package example
 ```
 
-Redundant build tag when the package version is Go 1.21 or later:
+Redundant build tag when the module Go version is Go 1.21 or later:
 
 Before (violation):
 

--- a/lint/package.go
+++ b/lint/package.go
@@ -227,6 +227,14 @@ func (p *Package) IsAtLeastGoVersion(v *goversion.Version) bool {
 	return p.goVersion.GreaterThanOrEqual(v)
 }
 
+// GoVersion returns the Go version for this package.
+func (p *Package) GoVersion() *goversion.Version {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.goVersion
+}
+
 func getSortableMethodFlagForFunction(fn *ast.FuncDecl) sortableMethodsFlags {
 	switch {
 	case astutils.FuncSignatureIs(fn, "Len", []string{}, []string{"int"}):

--- a/rule/redundant_build_tag.go
+++ b/rule/redundant_build_tag.go
@@ -21,7 +21,7 @@ func (*RedundantBuildTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 			if ver, ok := strings.CutPrefix(comment.Text, "//go:build "); ok {
 				hasGoBuild = true
 
-				// Starting from the Go 1.21, the go version in go.mod is a hard requirement.
+				// Starting with Go 1.21, the go version in go.mod is a hard requirement.
 				// Ignore this check for Go 1.20 and earlier.
 				if file.Pkg.IsAtLeastGoVersion(lint.Go121) && version.IsValid(ver) {
 					fileVersion := file.Pkg.GoVersion().String()

--- a/rule/redundant_build_tag.go
+++ b/rule/redundant_build_tag.go
@@ -1,6 +1,8 @@
 package rule
 
 import (
+	"fmt"
+	"go/version"
 	"strings"
 
 	"github.com/mgechev/revive/lint"
@@ -16,8 +18,23 @@ func (*RedundantBuildTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 	for _, group := range file.AST.Comments {
 		hasGoBuild := false
 		for _, comment := range group.List {
-			if strings.HasPrefix(comment.Text, "//go:build ") {
+			if ver, ok := strings.CutPrefix(comment.Text, "//go:build "); ok {
 				hasGoBuild = true
+
+				// Starting from the Go 1.21, the go version in go.mod is a hard requirement.
+				// Ignore this check for Go 1.20 and earlier.
+				if file.Pkg.IsAtLeastGoVersion(lint.Go121) && version.IsValid(ver) {
+					fileVersion := file.Pkg.GoVersion().String()
+					if version.Compare("go"+fileVersion, ver) >= 0 {
+						return []lint.Failure{{
+							Category:   lint.FailureCategoryStyle,
+							Confidence: 1,
+							Node:       comment,
+							Failure:    fmt.Sprintf(`The build tag "%s" is redundant for Go %s and can be removed`, comment.Text, fileVersion),
+						}}
+					}
+				}
+
 				continue
 			}
 

--- a/rule/redundant_build_tag.go
+++ b/rule/redundant_build_tag.go
@@ -25,19 +25,18 @@ func (*RedundantBuildTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 			if ver, ok := strings.CutPrefix(comment.Text, "//go:build "); ok {
 				hasGoBuild = true
 
-				// Starting with Go 1.21, the go version in go.mod is a hard requirement.
-				// Ignore this check for Go 1.20 and earlier.
-				if file.Pkg.IsAtLeastGoVersion(lint.Go121) && version.IsValid(ver) {
-					segments := file.Pkg.GoVersion().Segments()
-					fileVersion := fmt.Sprintf("%d.%d", segments[0], segments[1])
-					if version.Compare("go"+fileVersion, ver) >= 0 {
-						return []lint.Failure{{
-							Category:   lint.FailureCategoryStyle,
-							Confidence: 1,
-							Node:       comment,
-							Failure:    fmt.Sprintf("The build tag %q is redundant for Go %s and can be removed", comment.Text, fileVersion),
-						}}
-					}
+				// goVersion is the module's language version, e.g. "go1.21".
+				goVersion := version.Lang("go" + file.Pkg.GoVersion().String())
+				// Starting with Go 1.21 the go version in go.mod is a hard requirement,
+				// so a `//go:build go1.X` constraint it already satisfies is redundant.
+				// Skip this check for Go 1.20 and earlier.
+				if file.Pkg.IsAtLeastGoVersion(lint.Go121) && version.IsValid(ver) && version.Compare(goVersion, ver) >= 0 {
+					return []lint.Failure{{
+						Category:   lint.FailureCategoryStyle,
+						Confidence: 1,
+						Node:       comment,
+						Failure:    fmt.Sprintf("The build tag %q is redundant for Go %s and can be removed", comment.Text, strings.TrimPrefix(goVersion, "go")),
+					}}
 				}
 
 				continue

--- a/rule/redundant_build_tag.go
+++ b/rule/redundant_build_tag.go
@@ -11,8 +11,12 @@ import (
 // RedundantBuildTagRule lints the presence of redundant build tags.
 type RedundantBuildTagRule struct{}
 
-// Apply triggers if an old build tag `// +build` is found after a new one `//go:build`.
-// `//go:build` comments are automatically added by gofmt when Go 1.17+ is used.
+// Apply triggers on two kinds of redundant build tags:
+//   - an old `// +build` tag found after a new `//go:build` tag, since `//go:build`
+//     comments are automatically added by gofmt when Go 1.17+ is used;
+//   - a `//go:build go1.X` version constraint that is already guaranteed by the
+//     go version in go.mod (Go 1.21+, where the go directive is a hard requirement).
+//
 // See https://pkg.go.dev/cmd/go#hdr-Build_constraints
 func (*RedundantBuildTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	for _, group := range file.AST.Comments {
@@ -24,13 +28,14 @@ func (*RedundantBuildTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 				// Starting with Go 1.21, the go version in go.mod is a hard requirement.
 				// Ignore this check for Go 1.20 and earlier.
 				if file.Pkg.IsAtLeastGoVersion(lint.Go121) && version.IsValid(ver) {
-					fileVersion := file.Pkg.GoVersion().String()
+					segments := file.Pkg.GoVersion().Segments()
+					fileVersion := fmt.Sprintf("%d.%d", segments[0], segments[1])
 					if version.Compare("go"+fileVersion, ver) >= 0 {
 						return []lint.Failure{{
 							Category:   lint.FailureCategoryStyle,
 							Confidence: 1,
 							Node:       comment,
-							Failure:    fmt.Sprintf(`The build tag %q is redundant for Go %s and can be removed`, comment.Text, fileVersion),
+							Failure:    fmt.Sprintf("The build tag %q is redundant for Go %s and can be removed", comment.Text, fileVersion),
 						}}
 					}
 				}
@@ -38,12 +43,13 @@ func (*RedundantBuildTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 				continue
 			}
 
-			if hasGoBuild && strings.HasPrefix(comment.Text, "// +build ") {
+			const oldGoBuildPrefix = "// +build"
+			if hasGoBuild && strings.HasPrefix(comment.Text, oldGoBuildPrefix) {
 				return []lint.Failure{{
 					Category:   lint.FailureCategoryStyle,
 					Confidence: 1,
 					Node:       comment,
-					Failure:    `The build tag "// +build" is redundant since Go 1.17 and can be removed`,
+					Failure:    fmt.Sprintf("The build tag %q is redundant since Go 1.17 and can be removed", oldGoBuildPrefix),
 				}}
 			}
 		}

--- a/rule/redundant_build_tag.go
+++ b/rule/redundant_build_tag.go
@@ -30,7 +30,7 @@ func (*RedundantBuildTagRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 							Category:   lint.FailureCategoryStyle,
 							Confidence: 1,
 							Node:       comment,
-							Failure:    fmt.Sprintf(`The build tag "%s" is redundant for Go %s and can be removed`, comment.Text, fileVersion),
+							Failure:    fmt.Sprintf(`The build tag %q is redundant for Go %s and can be removed`, comment.Text, fileVersion),
 						}}
 					}
 				}

--- a/test/redundant_build_tag_test.go
+++ b/test/redundant_build_tag_test.go
@@ -18,3 +18,9 @@ func TestRedundantBuildTagRuleNoFailure(t *testing.T) {
 func TestRedundantBuildTagRuleGo116(t *testing.T) {
 	testRule(t, "redundant_build_tag_go116", &rule.RedundantBuildTagRule{}, &lint.RuleConfig{})
 }
+
+func TestRedundantBuildTagRuleGo121(t *testing.T) {
+	testRule(t, "go1.21/redundant_build_tag", &rule.RedundantBuildTagRule{}, &lint.RuleConfig{})
+	testRule(t, "go1.21/redundant_build_tag_go120", &rule.RedundantBuildTagRule{}, &lint.RuleConfig{})
+	testRule(t, "go1.21/redundant_build_tag_go122", &rule.RedundantBuildTagRule{}, &lint.RuleConfig{})
+}

--- a/testdata/go1.21/redundant_build_tag.go
+++ b/testdata/go1.21/redundant_build_tag.go
@@ -1,5 +1,5 @@
 //go:build go1.21
 
-// MATCH:1 /The build tag "//go:build go1.21" is redundant for Go 1.21.0 and can be removed/
+// MATCH:1 /The build tag "//go:build go1.21" is redundant for Go 1.21 and can be removed/
 
 package fixtures

--- a/testdata/go1.21/redundant_build_tag.go
+++ b/testdata/go1.21/redundant_build_tag.go
@@ -1,0 +1,5 @@
+//go:build go1.21
+
+// MATCH:1 /The build tag "//go:build go1.21" is redundant for Go 1.21.0 and can be removed/
+
+package fixtures

--- a/testdata/go1.21/redundant_build_tag_go120.go
+++ b/testdata/go1.21/redundant_build_tag_go120.go
@@ -1,0 +1,5 @@
+//go:build go1.20
+
+// MATCH:1 /The build tag "//go:build go1.20" is redundant for Go 1.21.0 and can be removed/
+
+package fixtures

--- a/testdata/go1.21/redundant_build_tag_go120.go
+++ b/testdata/go1.21/redundant_build_tag_go120.go
@@ -1,5 +1,5 @@
 //go:build go1.20
 
-// MATCH:1 /The build tag "//go:build go1.20" is redundant for Go 1.21.0 and can be removed/
+// MATCH:1 /The build tag "//go:build go1.20" is redundant for Go 1.21 and can be removed/
 
 package fixtures

--- a/testdata/go1.21/redundant_build_tag_go122.go
+++ b/testdata/go1.21/redundant_build_tag_go122.go
@@ -1,0 +1,3 @@
+//go:build go1.22
+
+package fixtures


### PR DESCRIPTION
This PR extends the `redundant-build-tag` rule to detect unnecessary `//go:build go1.X` comments.

I found this in the https://github.com/prometheus/exporter-toolkit repo: the package version is [Go 1.25.0](https://github.com/prometheus/exporter-toolkit/blob/master/go.mod#L3) and the comment [`//go:build go1.14`](https://github.com/prometheus/exporter-toolkit/blob/d55bf30bb3b87a8e2eee385ff513a40f23be5ffe/web/tls_config_test.go#L14) is unnecessary. 