### PR TITLE
feat/initialisms-as-words

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1996,17 +1996,16 @@ _Configuration_: N/A
 
 **_Ported from golint_**
 
-_Description_: This rule warns when [initialism](https://go.dev/wiki/CodeReviewComments#initialisms), [variable](https://go.dev/wiki/CodeReviewComments#variable-names)
+_Description_: This rule warns when
+[initialism](https://go.dev/wiki/CodeReviewComments#initialisms)
+or [variable](https://go.dev/wiki/CodeReviewComments#variable-names)
 naming conventions are not followed.
 It ignores functions starting with `Example`, `Test`, `Benchmark`, and `Fuzz` in test files, preserving `golint` original behavior.
 
 _Configuration_: This rule accepts two slices of strings and one optional slice containing a single map with named parameters.
 (This is because TOML does not support "slice of any," and we maintain backward compatibility with the previous configuration version).
-The first slice is an allowlist, and the second one is a blocklist of initialisms.
-You can add a boolean parameter `skip-initialism-name-checks` to control how names
-of functions, variables, consts, and structs handle known initialisms (e.g., JSON, HTTP, etc.) when written in `camelCase`.
-When `skip-initialism-name-checks` is set to true, the rule allows names like `readJson`, `HttpMethod` etc.
-In the map, you can add a boolean `upper-case-const` parameter to allow `UPPER_CASE` for `const`.
+The first slice is an allowlist of initialisms, the second one is a blocklist of initialisms,
+and the third, optional one holds a map with named parameters for configuring the rule.
 
 By default, the rule behaves exactly as the alternative in `golint` for non-package identifiers;
 `golint`-equivalent package-name warnings now require enabling the [`package-naming`](#package-naming) rule.
@@ -2014,6 +2013,41 @@ The legacy package-related options `skip-package-name-checks`, `extra-bad-packag
 and are now treated as no-ops by `var-naming` (they are ignored, apart from an optional warning when logging is enabled).
 Package-name checks should be configured via the [`package-naming`](#package-naming) rule instead,
 and these options should be removed from `var-naming` configurations to avoid confusion.
+
+_Configuration_ (0): (`[]string`) an allowlist of initialisms.
+It loosens capitalization rules,
+allowing all-uppercase, all-lowercase, and initial-uppercase forms
+for the listed initialisms (e.g., `ID`, `id` and `Id`).
+
+_Configuration_ (1): (`[]string`) a blocklist of initialisms.
+It prevents listed initialisms from appearing in mixed case;
+they must be all uppercase or all lowercase (e.g., `ID` or `id` but not `Id`).
+The blocklist lets you extend the built-in list of initialisms
+with additional initialisms.
+To ignore the built-in list and only use the blocklist,
+add the `initialismsAsWords` option.
+
+_Configuration_ (2): (`[]map[string]any`) a slice containing one map
+of named parameters,
+recognized in camelCaseStyle, kebab-case-style, or alllowercasestyle.
+
+`initialismsAsWords`: A boolean parameter to treat initialisms as normal words
+for uppercase and lowercase rules.
+When `initialismsAsWords` is set to true, the rule forbids names like
+`readJSON`, `HTTPMethod`, `ID`, etc. and requires names like
+`readJson`, `HttpMethod`, `httpMethod`, `Id`, `id`, etc.
+The built-in list of initialisms is ignored.
+The allowlist and blocklist continue to function as described above.
+
+`skipInitialismNameChecks`: A boolean parameter to control how names
+of functions, variables, consts, and structs handle known initialisms
+(e.g., JSON, HTTP, etc.) when written in `camelCase`.
+When `skipInitialismNameChecks` is set to true,
+the rule allows names like
+`readJson`, `readJSON`, `httpMethod`, `HttpMethod`, `HTTPMethod`, etc.
+It disables the allowlist, the blocklist, and all built-in initialisms.
+
+`upperCaseConst`: A boolean parameter to allow `UPPER_CASE` for `const`.
 
 Configuration examples:
 

--- a/internal/rule/name.go
+++ b/internal/rule/name.go
@@ -52,7 +52,7 @@ var commonInitialisms = map[string]bool{
 }
 
 // Name returns a different name of struct, var, const, or function if it should be different.
-func Name(name string, allowlist, blocklist []string, skipInitialismNameChecks bool) (should string) {
+func Name(name string, allowlist, blocklist []string, skipInitialismNameChecks bool, initialismsAsWords bool) (should string) {
 	// Fast path for simple cases: "_" and all lowercase.
 	if name == "_" {
 		return name
@@ -95,6 +95,13 @@ func Name(name string, allowlist, blocklist []string, skipInitialismNameChecks b
 		case unicode.IsLower(runes[i]) && !unicode.IsLower(runes[i+1]):
 			// lower->non-lower
 			eow = true
+		case initialismsAsWords && w < i-1 && !unicode.IsLower(runes[i]) && unicode.IsLower(runes[i+1]):
+			// non-lower->lower after more than one letter of non-lower
+			if i > 0 && !unicode.IsLower(runes[i-1]) {
+				// previous letter was the end of an uppercase initialism
+				i--
+				eow = true
+			}
 		}
 		i++
 		if !eow {
@@ -117,6 +124,8 @@ func Name(name string, allowlist, blocklist []string, skipInitialismNameChecks b
 			// Keep consistent case, which is lowercase only at the start.
 			if w == 0 && unicode.IsLower(runes[w]) {
 				u = strings.ToLower(u)
+			} else if initialismsAsWords && len(u) > 1 && !extraInits[u] {
+				u = u[:1] + strings.ToLower(u[1:])
 			}
 			// Keep lowercase s for IDs
 			if u == "IDS" {
@@ -128,6 +137,14 @@ func Name(name string, allowlist, blocklist []string, skipInitialismNameChecks b
 		} else if w > 0 && strings.ToLower(word) == word {
 			// already all lowercase, and not the first word, so uppercase the first character.
 			runes[w] = unicode.ToUpper(runes[w])
+		} else if initialismsAsWords && strings.ToUpper(word) == word {
+			// If the word is all uppercase, but not in the known initialisms,
+			// it's either an incorrect all-caps word or an unknown initialism.
+			// Uppercase the first character and lowercase the rest.
+			if len(word) > 1 {
+				u = u[:1] + strings.ToLower(u[1:])
+				copy(runes[w:], []rune(u))
+			}
 		}
 		w = i
 	}

--- a/internal/rule/name.go
+++ b/internal/rule/name.go
@@ -52,7 +52,7 @@ var commonInitialisms = map[string]bool{
 }
 
 // Name returns a different name of struct, var, const, or function if it should be different.
-func Name(name string, allowlist, blocklist []string, skipInitialismNameChecks bool, initialismsAsWords bool) (should string) {
+func Name(name string, allowlist, blocklist []string, skipInitialismNameChecks, initialismsAsWords bool) (should string) {
 	// Fast path for simple cases: "_" and all lowercase.
 	if name == "_" {
 		return name
@@ -137,7 +137,7 @@ func Name(name string, allowlist, blocklist []string, skipInitialismNameChecks b
 		} else if w > 0 && strings.ToLower(word) == word {
 			// already all lowercase, and not the first word, so uppercase the first character.
 			runes[w] = unicode.ToUpper(runes[w])
-		} else if initialismsAsWords && strings.ToUpper(word) == word {
+		} else if initialismsAsWords && u == word && !ignoreInitWarnings[u] {
 			// If the word is all uppercase, but not in the known initialisms,
 			// it's either an incorrect all-caps word or an unknown initialism.
 			// Uppercase the first character and lowercase the rest.

--- a/internal/rule/name_test.go
+++ b/internal/rule/name_test.go
@@ -12,6 +12,7 @@ func TestName(t *testing.T) {
 		allowlist                []string
 		blocklist                []string
 		skipInitialismNameChecks bool
+		initialismsAsWords       bool
 		want                     string
 	}{
 		{
@@ -184,12 +185,226 @@ func TestName(t *testing.T) {
 			skipInitialismNameChecks: true,
 			want:                     "fooIdCustomHttpJson",
 		},
+
+		{
+			name:               "foo_bar",
+			want:               "fooBar",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "foo_bar_baz",
+			want:               "fooBarBaz",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "Foo_bar",
+			want:               "FooBar",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "foo_WiFi",
+			want:               "fooWiFi",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "id",
+			want:               "id",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "Id",
+			want:               "Id",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "foo_id",
+			want:               "fooId",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "fooId",
+			want:               "fooId",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "fooUid",
+			want:               "fooUid",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "idFoo",
+			want:               "idFoo",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "uidFoo",
+			want:               "uidFoo",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "midIdDle",
+			want:               "midIdDle",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "APIProxy",
+			want:               "ApiProxy",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "ApiProxy",
+			want:               "ApiProxy",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "apiProxy",
+			want:               "apiProxy",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "_Leading",
+			want:               "_Leading",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "___Leading",
+			want:               "_Leading",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "trailing_",
+			want:               "trailing",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "trailing___",
+			want:               "trailing",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "a_b",
+			want:               "aB",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "a__b",
+			want:               "aB",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "a___b",
+			want:               "aB",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "Rpc1150",
+			want:               "Rpc1150",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "rpc1150",
+			want:               "rpc1150",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "case3_1",
+			want:               "case3_1",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "case3__1",
+			want:               "case3_1",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "IEEE802_16bit",
+			want:               "Ieee802_16bit",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "IEEE802_16Bit",
+			want:               "Ieee802_16Bit",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "IDS",
+			want:               "Ids",
+			initialismsAsWords: true,
+		},
+		// Test skipInitialismChecks functionality
+		{
+			name:                     "getJson",
+			skipInitialismNameChecks: true,
+			initialismsAsWords:       true,
+			want:                     "getJson",
+		},
+		{
+			name:                     "userId",
+			skipInitialismNameChecks: true,
+			initialismsAsWords:       true,
+			want:                     "userId",
+		},
+		{
+			name:                     "myHttpClient",
+			skipInitialismNameChecks: true,
+			initialismsAsWords:       true,
+			want:                     "myHttpClient",
+		},
+		// Test allowlist functionality
+		{
+			name:               "fooId",
+			allowlist:          []string{"ID"},
+			initialismsAsWords: true,
+			want:               "fooId",
+		},
+		{
+			name:               "fooApi",
+			allowlist:          []string{"API"},
+			initialismsAsWords: true,
+			want:               "fooApi",
+		},
+		{
+			name:               "fooHttp",
+			allowlist:          []string{"HTTP"},
+			initialismsAsWords: true,
+			want:               "fooHttp",
+		},
+		// Test blocklist functionality
+		{
+			name:               "fooCustom",
+			blocklist:          []string{"CUSTOM"},
+			initialismsAsWords: true,
+			want:               "fooCUSTOM",
+		},
+		{
+			name:               "mySpecial",
+			blocklist:          []string{"SPECIAL"},
+			initialismsAsWords: true,
+			want:               "mySPECIAL",
+		},
+		// Test combination of allowlist and blocklist
+		{
+			name:               "fooIdCustom",
+			allowlist:          []string{"ID"},
+			blocklist:          []string{"CUSTOM"},
+			initialismsAsWords: true,
+			want:               "fooIdCUSTOM",
+		},
+		// Test combination of allowlist, blocklist and skipInitialismChecks
+		{
+			name:                     "fooIdCustomHttpJson",
+			allowlist:                []string{"ID"},
+			blocklist:                []string{"CUSTOM"},
+			skipInitialismNameChecks: true,
+			initialismsAsWords:       true,
+			want:                     "fooIdCustomHttpJson",
+		},
 	}
 	for _, test := range tests {
-		got := rule.Name(test.name, test.allowlist, test.blocklist, test.skipInitialismNameChecks)
+		got := rule.Name(test.name, test.allowlist, test.blocklist, test.skipInitialismNameChecks, test.initialismsAsWords)
 		if got != test.want {
-			t.Errorf("name(%q, allowlist=%v, blocklist=%v, skipInitialismNameChecks=%v) = %q, want %q",
-				test.name, test.allowlist, test.blocklist, test.skipInitialismNameChecks, got, test.want)
+			t.Errorf("name(%q, allowlist=%v, blocklist=%v, skipInitialismNameChecks=%v, initialismsAsWords=%v) = %q, want %q",
+				test.name, test.allowlist, test.blocklist, test.skipInitialismNameChecks, test.initialismsAsWords, got, test.want)
 		}
 	}
 }

--- a/internal/rule/name_test.go
+++ b/internal/rule/name_test.go
@@ -40,6 +40,10 @@ func TestName(t *testing.T) {
 			want: "ID",
 		},
 		{
+			name: "ID",
+			want: "ID",
+		},
+		{
 			name: "foo_id",
 			want: "fooID",
 		},
@@ -134,6 +138,26 @@ func TestName(t *testing.T) {
 			want:                     "getJson",
 		},
 		{
+			name:                     "getJSON",
+			skipInitialismNameChecks: true,
+			want:                     "getJSON",
+		},
+		{
+			name:                     "httpMethod",
+			skipInitialismNameChecks: true,
+			want:                     "httpMethod",
+		},
+		{
+			name:                     "HttpMethod",
+			skipInitialismNameChecks: true,
+			want:                     "HttpMethod",
+		},
+		{
+			name:                     "HTTPMethod",
+			skipInitialismNameChecks: true,
+			want:                     "HTTPMethod",
+		},
+		{
 			name:                     "userId",
 			skipInitialismNameChecks: true,
 			want:                     "userId",
@@ -213,6 +237,11 @@ func TestName(t *testing.T) {
 		},
 		{
 			name:               "Id",
+			want:               "Id",
+			initialismsAsWords: true,
+		},
+		{
+			name:               "ID",
 			want:               "Id",
 			initialismsAsWords: true,
 		},
@@ -333,10 +362,34 @@ func TestName(t *testing.T) {
 		},
 		// Test skipInitialismChecks functionality
 		{
+			name:                     "getJSON",
+			skipInitialismNameChecks: true,
+			initialismsAsWords:       true,
+			want:                     "getJson",
+		},
+		{
 			name:                     "getJson",
 			skipInitialismNameChecks: true,
 			initialismsAsWords:       true,
 			want:                     "getJson",
+		},
+		{
+			name:                     "httpMethod",
+			skipInitialismNameChecks: true,
+			initialismsAsWords:       true,
+			want:                     "httpMethod",
+		},
+		{
+			name:                     "HttpMethod",
+			skipInitialismNameChecks: true,
+			initialismsAsWords:       true,
+			want:                     "HttpMethod",
+		},
+		{
+			name:                     "HTTPMethod",
+			skipInitialismNameChecks: true,
+			initialismsAsWords:       true,
+			want:                     "HttpMethod",
 		},
 		{
 			name:                     "userId",
@@ -358,10 +411,22 @@ func TestName(t *testing.T) {
 			want:               "fooId",
 		},
 		{
+			name:               "fooID",
+			allowlist:          []string{"ID"},
+			initialismsAsWords: true,
+			want:               "fooID",
+		},
+		{
 			name:               "fooApi",
 			allowlist:          []string{"API"},
 			initialismsAsWords: true,
 			want:               "fooApi",
+		},
+		{
+			name:               "fooAPI",
+			allowlist:          []string{"API"},
+			initialismsAsWords: true,
+			want:               "fooAPI",
 		},
 		{
 			name:               "fooHttp",

--- a/lint/name.go
+++ b/lint/name.go
@@ -6,5 +6,5 @@ import "github.com/mgechev/revive/internal/rule"
 //
 // Deprecated: Do not use this function, it will be removed in the next major release.
 func Name(name string, allowlist, blocklist []string) string {
-	return rule.Name(name, allowlist, blocklist, false)
+	return rule.Name(name, allowlist, blocklist, false, false)
 }

--- a/rule/var_naming.go
+++ b/rule/var_naming.go
@@ -23,6 +23,7 @@ type VarNamingRule struct {
 	blockList []string
 
 	allowUpperCaseConst      bool // if true - allows to use UPPER_SOME_NAMES for constants
+	initialismsAsWords       bool // if true - enforce initial capitals like Http
 	skipInitialismNameChecks bool // if true - disable enforcing capitals for common initialisms
 }
 
@@ -64,6 +65,8 @@ func (r *VarNamingRule) Configure(arguments lint.Arguments) error {
 			switch {
 			case isRuleOption(k, "skipInitialismNameChecks"):
 				r.skipInitialismNameChecks = fmt.Sprint(v) == "true"
+			case isRuleOption(k, "initialismsAsWords"):
+				r.initialismsAsWords = fmt.Sprint(v) == "true"
 			case isRuleOption(k, "upperCaseConst"):
 				r.allowUpperCaseConst = fmt.Sprint(v) == "true"
 			case isRuleOption(k, "skipPackageNameChecks"):
@@ -104,6 +107,7 @@ func (r *VarNamingRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure 
 		allowList:            r.allowList,
 		blockList:            r.blockList,
 		skipInitialismChecks: r.skipInitialismNameChecks,
+		initialismsAsWords:   r.initialismsAsWords,
 		upperCaseConst:       r.allowUpperCaseConst,
 	}
 
@@ -124,6 +128,7 @@ type lintNames struct {
 	allowList            []string
 	blockList            []string
 	skipInitialismChecks bool
+	initialismsAsWords   bool
 	upperCaseConst       bool
 }
 
@@ -163,7 +168,7 @@ func (w *lintNames) check(id *ast.Ident, thing string) {
 		return
 	}
 
-	should := rule.Name(id.Name, w.allowList, w.blockList, w.skipInitialismChecks)
+	should := rule.Name(id.Name, w.allowList, w.blockList, w.skipInitialismChecks, w.initialismsAsWords)
 	if id.Name == should {
 		return
 	}

--- a/rule/var_naming_test.go
+++ b/rule/var_naming_test.go
@@ -15,6 +15,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 		wantAllowList                []string
 		wantBlockList                []string
 		wantSkipInitialismNameChecks bool
+		wantInitialismsAsWords       bool
 		wantAllowUpperCaseConst      bool
 	}{
 		{
@@ -24,6 +25,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 			wantAllowList:                nil,
 			wantBlockList:                nil,
 			wantSkipInitialismNameChecks: false,
+			wantInitialismsAsWords:       false,
 			wantAllowUpperCaseConst:      false,
 		},
 		{
@@ -33,6 +35,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 				[]any{"VM"},
 				[]any{map[string]any{
 					"skipInitialismNameChecks": true,
+					"initialismsAsWords":       true,
 					"upperCaseConst":           true,
 				}},
 			},
@@ -40,6 +43,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 			wantAllowList:                []string{"ID"},
 			wantBlockList:                []string{"VM"},
 			wantSkipInitialismNameChecks: true,
+			wantInitialismsAsWords:       true,
 			wantAllowUpperCaseConst:      true,
 		},
 		{
@@ -49,6 +53,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 				[]any{"VM"},
 				[]any{map[string]any{
 					"skipinitialismnamechecks": true,
+					"initialismsaswords":       true,
 					"uppercaseconst":           true,
 				}},
 			},
@@ -56,6 +61,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 			wantAllowList:                []string{"ID"},
 			wantBlockList:                []string{"VM"},
 			wantSkipInitialismNameChecks: true,
+			wantInitialismsAsWords:       true,
 			wantAllowUpperCaseConst:      true,
 		},
 		{
@@ -65,6 +71,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 				[]any{"VM"},
 				[]any{map[string]any{
 					"skip-initialism-name-checks": true,
+					"initialisms-as-words":        true,
 					"upper-case-const":            true,
 				}},
 			},
@@ -72,6 +79,7 @@ func TestVarNamingRule_Configure(t *testing.T) {
 			wantAllowList:                []string{"ID"},
 			wantBlockList:                []string{"VM"},
 			wantSkipInitialismNameChecks: true,
+			wantInitialismsAsWords:       true,
 			wantAllowUpperCaseConst:      true,
 		},
 		{
@@ -130,6 +138,9 @@ func TestVarNamingRule_Configure(t *testing.T) {
 			}
 			if rule.skipInitialismNameChecks != tt.wantSkipInitialismNameChecks {
 				t.Errorf("unexpected skipInitialismNameChecks: got = %v, want %v", rule.skipInitialismNameChecks, tt.wantSkipInitialismNameChecks)
+			}
+			if rule.initialismsAsWords != tt.wantInitialismsAsWords {
+				t.Errorf("unexpected initialismsAsWords: got = %v, want %v", rule.initialismsAsWords, tt.wantInitialismsAsWords)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #1736

Adds to the `var-naming` rule: `initialismsAsWords`: A boolean parameter to treat initialisms as normal words for uppercase and lowercase rules. When `initialismsAsWords` is set to true, the rule forbids names like `readJSON`, `HTTPMethod`, `ID`, etc. and requires names like `readJson`, `HttpMethod`, `httpMethod`, `Id`, `id`, etc.

When `true`, the built-in list of initialisms is ignored. The allowlist and blocklist continue to function, allowing targeted ignores and progressive enforcement of initialism spelling rules. Unlike `skipInitialismChecks` or the `allowlist`, this flag will enforce consistent capitalization.

I also added tests, and documentation about what the other options of `var-naming` do.