### PR TITLE
chore: update renovate: monthly, disable indirect

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,16 @@
     {
       "matchManagers": ["gomod"],
       "matchFileNames": ["go.mod"],
-      "matchDepTypes": ["indirect"],
+      "matchDepTypes": ["direct"],
       "groupName": "gomod",
-      "extends": ["schedule:weekly"],
+      "extends": ["schedule:monthly"],
       "enabled": true
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchFileNames": ["go.mod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
     },
     {
       "matchManagers": ["gomod"],
@@ -23,7 +29,7 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "github actions",
-      "extends": ["schedule:weekly"],
+      "extends": ["schedule:monthly"],
       "enabled": true
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
     },
     {
       "matchManagers": ["gomod"],
-      "matchFileNames": ["go.mod"],
+      "matchFileNames": ["go.mod", "tools/go.mod"],
       "matchDepTypes": ["indirect"],
       "enabled": false
     },


### PR DESCRIPTION
Update the renovate config:

- explicitly enable upgrading direct deps
- disable upgrading indirect deps
- schedule monthly

Closes #1742