### PR TITLE
feature: new rule `redundant-canonical-import`

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ List of all [available rules](./RULES_DESCRIPTIONS.md).
 | [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  map (optional)   | Conventions around the naming of receivers.                      |   yes    |  no   |
 | [`redefines-builtin-id`](./RULES_DESCRIPTIONS.md#redefines-builtin-id)|  n/a   | Warns on redefinitions of builtin identifiers                    |    no    |  no   |
 | [`redundant-build-tag`](./RULES_DESCRIPTIONS.md#redundant-build-tag) | n/a   | Warns about redundant `// +build` comment lines |   no    |  no   |
+| [`redundant-canonical-import`](./RULES_DESCRIPTIONS.md#redundant-canonical-import)          |  n/a   |  Warns on redundant canonical import path comments |    no    |  no   |
 | [`redundant-import-alias`](./RULES_DESCRIPTIONS.md#redundant-import-alias)          |  n/a   |  Warns on import aliases matching the imported package name |    no    |  no   |
 | [`redundant-test-main-exit`](./RULES_DESCRIPTIONS.md#redundant-test-main-exit) |  n/a   | Suggests removing `Exit` call in `TestMain` function for test files |    no    |  no   |
 | [`string-format`](./RULES_DESCRIPTIONS.md#string-format)          |  map   | Warns on specific string literals that fail one or more user-configured regular expressions            |    no    |  no   |

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1438,7 +1438,7 @@ Before (violation):
 package pdf // import "rsc.io/pdf"
 ```
 
-After (fixed)
+After (fixed):
 
 ```go
 package pdf

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1424,7 +1424,9 @@ _Note_: This rule is irrelevant for Go 1.16-.
 
 _Description_: This rule warns on [canonical import path comments](https://go.dev/doc/go1.4#canonicalimports)
 (e.g. `package pdf // import "rsc.io/pdf"`).
-In module mode the Go toolchain ignores these comments entirely — the `module` directive in `go.mod` is the single source of truth. So they are redundant and can be removed.
+In module mode the Go toolchain [ignores these comments entirely](https://pkg.go.dev/cmd/go@go1.11.0#hdr-Import_path_checking)
+the `module` directive in `go.mod` is the single source of truth.
+So they are redundant and can be removed.
 
 _Note_: This rule only reports for Go 1.11+.
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -77,6 +77,7 @@ List of all available rules.
 - [receiver-naming](#receiver-naming)
 - [redefines-builtin-id](#redefines-builtin-id)
 - [redundant-build-tag](#redundant-build-tag)
+- [redundant-canonical-import](#redundant-canonical-import)
 - [redundant-import-alias](#redundant-import-alias)
 - [redundant-test-main-exit](#redundant-test-main-exit)
 - [string-format](#string-format)
@@ -1418,6 +1419,30 @@ when `//go:build` is present.
 _Configuration_: N/A
 
 _Note_: This rule is irrelevant for Go 1.16-.
+
+## redundant-canonical-import
+
+_Description_: This rule warns on [canonical import path comments](https://go.dev/doc/go1.4#canonicalimports)
+(e.g. `package pdf // import "rsc.io/pdf"`).
+In module mode the Go toolchain ignores these comments entirely — the `module` directive in `go.mod` is the single source of truth. So they are redundant and can be removed.
+
+_Note_: This rule only reports for Go 1.11+.
+
+### Examples (redundant-canonical-import)
+
+Before (violation):
+
+```go
+package pdf // import "rsc.io/pdf"
+```
+
+After (fixed)
+
+```go
+package pdf
+```
+
+_Configuration_: N/A
 
 ## redundant-import-alias
 

--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,7 @@ var allRules = append([]lint.Rule{
 	&rule.CommentSpacingsRule{},
 	&rule.IfReturnRule{},
 	&rule.RedundantImportAlias{},
+	&rule.RedundantCanonicalImport{},
 	&rule.ImportAliasNamingRule{},
 	&rule.EnforceMapStyleRule{},
 	&rule.EnforceRepeatedArgTypeStyleRule{},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -442,7 +442,7 @@ func TestGetLintingRules(t *testing.T) {
 		// len of defaultRules
 		defaultRulesCount = 23
 		// len of allRules: update this when adding new rules
-		allRulesCount = 103
+		allRulesCount = 104
 	)
 
 	tt := map[string]struct {

--- a/lint/package.go
+++ b/lint/package.go
@@ -34,6 +34,8 @@ var (
 	trueValue  = 1
 	falseValue = 2
 
+	// Go111 is a constant representing the Go version 1.11.
+	Go111 = goversion.Must(goversion.NewVersion("1.11"))
 	// Go115 is a constant representing the Go version 1.15.
 	Go115 = goversion.Must(goversion.NewVersion("1.15"))
 	// Go118 is a constant representing the Go version 1.18.

--- a/rule/redundant_canonical_import.go
+++ b/rule/redundant_canonical_import.go
@@ -1,0 +1,64 @@
+package rule
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// matches a canonical import comment body, e.g.: import "rsc.io/pdf" or import `rsc.io/pdf`
+var canonicalImportCommentRegexp = regexp.MustCompile("^import\\s+(?:\"[^\"]+\"|`[^`]+`)$")
+
+// RedundantCanonicalImport warns on canonical import path comments that are redundant in module mode (Go 1.11+).
+// See https://go.dev/doc/go1.4#canonicalimports.
+type RedundantCanonicalImport struct{}
+
+// Apply applies the rule to given file.
+func (*RedundantCanonicalImport) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	if !file.Pkg.IsAtLeastGoVersion(lint.Go111) {
+		return nil
+	}
+
+	packageLine := file.ToPosition(file.AST.Name.End()).Line
+
+	for _, cg := range file.AST.Comments {
+		for _, c := range cg.List {
+			if c.Pos() < file.AST.Name.End() {
+				continue // before the package name
+			}
+			if file.ToPosition(c.Pos()).Line > packageLine {
+				return nil // past the package clause line; comments are ordered by position
+			}
+
+			if !canonicalImportCommentRegexp.MatchString(commentBody(c.Text)) {
+				continue
+			}
+
+			return []lint.Failure{
+				{
+					Category:   lint.FailureCategoryImports,
+					Node:       c,
+					Confidence: 1,
+					Failure:    fmt.Sprintf("Canonical import comment `%s` is redundant and can be removed", c.Text),
+				},
+			}
+		}
+	}
+
+	return nil
+}
+
+// commentBody strips the comment markers from c.Text, handling both line and block comments.
+func commentBody(text string) string {
+	text = strings.TrimPrefix(text, "//")
+	text = strings.TrimPrefix(text, "/*")
+	text = strings.TrimSuffix(text, "*/")
+	return strings.TrimSpace(text)
+}
+
+// Name returns the rule name.
+func (*RedundantCanonicalImport) Name() string {
+	return "redundant-canonical-import"
+}

--- a/rule/redundant_canonical_import.go
+++ b/rule/redundant_canonical_import.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mgechev/revive/lint"
 )
 
-// matches a canonical import comment body, e.g.: import "rsc.io/pdf" or import `rsc.io/pdf`
+// canonicalImportCommentRegexp matches a canonical import comment body, e.g.: import "rsc.io/pdf" or import `rsc.io/pdf`.
 var canonicalImportCommentRegexp = regexp.MustCompile("^import\\s+(?:\"[^\"]+\"|`[^`]+`)$")
 
 // RedundantCanonicalImport warns on canonical import path comments that are redundant in module mode (Go 1.11+).

--- a/rule/redundant_canonical_import.go
+++ b/rule/redundant_canonical_import.go
@@ -2,6 +2,7 @@ package rule
 
 import (
 	"fmt"
+	"go/ast"
 	"regexp"
 	"strings"
 
@@ -25,8 +26,8 @@ func (*RedundantCanonicalImport) Apply(file *lint.File, _ lint.Arguments) []lint
 
 	for _, cg := range file.AST.Comments {
 		for _, c := range cg.List {
-			if c.Pos() < file.AST.Name.End() {
-				continue // before the package name
+			if isBeforePackageName(c, file) {
+				continue
 			}
 			if file.ToPosition(c.Pos()).Line > packageLine {
 				return nil // past the package clause line; comments are ordered by position
@@ -48,6 +49,11 @@ func (*RedundantCanonicalImport) Apply(file *lint.File, _ lint.Arguments) []lint
 	}
 
 	return nil
+}
+
+// isBeforePackageName reports whether the comment appears before the package name.
+func isBeforePackageName(c *ast.Comment, file *lint.File) bool {
+	return c.Pos() < file.AST.Name.End()
 }
 
 // commentBody strips the comment markers from c.Text, handling both line and block comments.

--- a/test/redundant_canonical_import_test.go
+++ b/test/redundant_canonical_import_test.go
@@ -1,0 +1,12 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestRedundantCanonicalImport(t *testing.T) {
+	testRule(t, "go1.11/redundant_canonical_import", &rule.RedundantCanonicalImport{})
+	testRule(t, "redundant_canonical_import", &rule.RedundantCanonicalImport{})
+}

--- a/test/redundant_canonical_import_test.go
+++ b/test/redundant_canonical_import_test.go
@@ -8,5 +8,8 @@ import (
 
 func TestRedundantCanonicalImport(t *testing.T) {
 	testRule(t, "go1.11/redundant_canonical_import", &rule.RedundantCanonicalImport{})
+	testRule(t, "go1.11/redundant_canonical_import_backtick", &rule.RedundantCanonicalImport{})
+	testRule(t, "go1.11/redundant_canonical_import_block", &rule.RedundantCanonicalImport{})
+	testRule(t, "go1.11/redundant_canonical_import_negative", &rule.RedundantCanonicalImport{})
 	testRule(t, "redundant_canonical_import", &rule.RedundantCanonicalImport{})
 }

--- a/testdata/go1.11/go.mod
+++ b/testdata/go1.11/go.mod
@@ -1,0 +1,3 @@
+module github.com/mgechev/revive/testdata
+
+go 1.11

--- a/testdata/go1.11/redundant_canonical_import.go
+++ b/testdata/go1.11/redundant_canonical_import.go
@@ -1,0 +1,5 @@
+package pdf // import "rsc.io/pdf"
+
+// MATCH:1 /Canonical import comment `// import "rsc.io/pdf"` is redundant since Go 1.11 and can be removed/
+
+var _ = 0

--- a/testdata/go1.11/redundant_canonical_import.go
+++ b/testdata/go1.11/redundant_canonical_import.go
@@ -1,5 +1,5 @@
 package pdf // import "rsc.io/pdf"
 
-// MATCH:1 /Canonical import comment `// import "rsc.io/pdf"` is redundant since Go 1.11 and can be removed/
+// MATCH:1 /Canonical import comment `// import "rsc.io/pdf"` is redundant and can be removed/
 
 var _ = 0

--- a/testdata/go1.11/redundant_canonical_import_backtick.go
+++ b/testdata/go1.11/redundant_canonical_import_backtick.go
@@ -1,5 +1,5 @@
 package pdf // import `rsc.io/pdf`
 
-// MATCH:1 /Canonical import comment `// import `rsc.io/pdf`` is redundant since Go 1.11 and can be removed/
+// MATCH:1 /Canonical import comment `// import `rsc.io/pdf`` is redundant and can be removed/
 
 var _ = 0

--- a/testdata/go1.11/redundant_canonical_import_backtick.go
+++ b/testdata/go1.11/redundant_canonical_import_backtick.go
@@ -1,0 +1,5 @@
+package pdf // import `rsc.io/pdf`
+
+// MATCH:1 /Canonical import comment `// import `rsc.io/pdf`` is redundant since Go 1.11 and can be removed/
+
+var _ = 0

--- a/testdata/go1.11/redundant_canonical_import_block.go
+++ b/testdata/go1.11/redundant_canonical_import_block.go
@@ -1,3 +1,5 @@
-package pdf /* import "rsc.io/pdf" */ // MATCH /Canonical import comment `/* import "rsc.io/pdf" */` is redundant since Go 1.11 and can be removed/
+package pdf /* import "rsc.io/pdf" */
+
+// MATCH:1 /Canonical import comment `/* import "rsc.io/pdf" */` is redundant and can be removed/
 
 var _ = 0

--- a/testdata/go1.11/redundant_canonical_import_block.go
+++ b/testdata/go1.11/redundant_canonical_import_block.go
@@ -1,0 +1,3 @@
+package pdf /* import "rsc.io/pdf" */ // MATCH /Canonical import comment `/* import "rsc.io/pdf" */` is redundant since Go 1.11 and can be removed/
+
+var _ = 0

--- a/testdata/go1.11/redundant_canonical_import_negative.go
+++ b/testdata/go1.11/redundant_canonical_import_negative.go
@@ -1,0 +1,5 @@
+// Package foo does things.
+package foo // some explanation, not an import comment
+
+// import "below/the/package" is not on the package clause line
+var _ = 0

--- a/testdata/redundant_canonical_import.go
+++ b/testdata/redundant_canonical_import.go
@@ -1,0 +1,4 @@
+// The rule is inactive before Go 1.11 (module mode), so no failure is expected here.
+package pdf // import "rsc.io/pdf"
+
+var _ = 0

--- a/untyped.toml
+++ b/untyped.toml
@@ -65,6 +65,7 @@
 [rule.receiver-naming]
 [rule.redefines-builtin-id]
 [rule.redundant-build-tag]
+[rule.redundant-canonical-import]
 [rule.redundant-import-alias]
 [rule.redundant-test-main-exit]
 [rule.string-format]


### PR DESCRIPTION
This rule warns on [canonical import path comments](https://go.dev/doc/go1.4#canonicalimports) (e.g. `package pdf // import "rsc.io/pdf"`). In module mode the Go toolchain ignores these comments entirely. So, these canonical import comments can be removed.

See https://pkg.go.dev/cmd/go@go1.11.0#hdr-Import_path_checking:
> Import path checking is also disabled when using modules. Import path comments are obsoleted by the go.mod file's module statement.

### Examples

- https://go.googlesource.com/oauth2/+/refs/tags/v0.36.0/github/github.go#6
  ```go
  package github // import "golang.org/x/oauth2/github"
  ```
- https://github.com/open-telemetry/opentelemetry-go/blob/c2cac8c3d170dbaefe43f6ae5dad650001c5ca54/log/logger.go#L4
  ```go
  package log // import "go.opentelemetry.io/otel/log"
  ```
- https://gitlab.com/cznic/sqlite/-/blob/697300ffaa56b03b79e490dc960f218794cb2a75/sqlite.go#L7
  ```go
  package sqlite // import "modernc.org/sqlite"
  ```