### PR TITLE
chore: set minimumReleaseAge in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
This PR adds two top-level options to `renovate.json`:

- `minimumReleaseAge` - Renovate won't raise a PR until a release is at least 7 days old.
- `internalChecksFilter` ensures the age check is actually enforced.
