### PR TITLE
docs: add before/after examples to a batch of rule descriptions

### DIFF
--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1880,8 +1880,8 @@ arguments = ["!validate", "bson,outline,gnu"]
 ## superfluous-else
 
 _Description_: To improve the readability of code, it is recommended to reduce the indentation as much as possible.
-This rule highlights redundant _else-blocks_ that can be eliminated when the preceding `if`-block ends with a
-`break`, `continue` or `goto` statement (the `return` case is handled by [indent-error-flow](#indent-error-flow)).
+This rule highlights redundant _else-blocks_ that can be eliminated when the preceding `if`-block deviates control flow,
+for example ending with a `break`, `continue`, `goto`, `panic` or `os.Exit` call (the `return` case is handled by [indent-error-flow](#indent-error-flow)).
 
 ### Examples (superfluous-else)
 
@@ -2274,7 +2274,7 @@ return fmt.Errorf("connection refused")
 After (fixed):
 
 ```go
-import "fmt"
+import "errors"
 
 return errors.New("connection refused")
 ```

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -765,6 +765,8 @@ Unexported error variables should start with `err`, exported ones with `Err`.
 Before (violation):
 
 ```go
+import "errors"
+
 var invalidInput = errors.New("invalid input")
 
 var TimeoutError = errors.New("connection timed out")
@@ -773,6 +775,8 @@ var TimeoutError = errors.New("connection timed out")
 After (fixed):
 
 ```go
+import "errors"
+
 var errInvalidInput = errors.New("invalid input")
 
 var ErrTimeout = errors.New("connection timed out")
@@ -2146,6 +2150,8 @@ _Description_: This rule spots and proposes to remove [unreachable code](https:/
 Before (violation):
 
 ```go
+import "log"
+
 func compute() int {
 	return doWork()
 	log.Println("done")
@@ -2155,6 +2161,7 @@ func compute() int {
 After (fixed):
 
 ```go
+import "log"
 func compute() int {
 	log.Println("starting")
 	return doWork()
@@ -2223,6 +2230,8 @@ _Description_: This rule proposes to replace instances of `interface{}` with its
 Before (violation):
 
 ```go
+import "fmt"
+
 func PrintValue(v interface{}) {
 	fmt.Println(v)
 }
@@ -2231,6 +2240,8 @@ func PrintValue(v interface{}) {
 After (fixed):
 
 ```go
+import "fmt"
+
 func PrintValue(v any) {
 	fmt.Println(v)
 }
@@ -2250,12 +2261,16 @@ This applies when the format string has no formatting verbs (no additional argum
 Before (violation):
 
 ```go
+import "fmt"
+
 return fmt.Errorf("connection refused")
 ```
 
 After (fixed):
 
 ```go
+import "fmt"
+
 return errors.New("connection refused")
 ```
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1175,6 +1175,8 @@ More [information here](https://go.dev/wiki/CodeReviewComments#indent-error-flow
 Before (violation):
 
 ```go
+import "log"
+
 if err != nil {
 	return err
 } else {
@@ -1185,6 +1187,8 @@ if err != nil {
 After (fixed):
 
 ```go
+import "log"
+
 if err != nil {
 	return err
 }
@@ -1236,14 +1240,14 @@ aValue := false
 
 // Inefficient map lookup
 for k := range aMap {
-  if k == aValue {
-    // do something
-  }
+	if k == aValue {
+		// do something
+	}
 }
 
 // Simpler and more efficient version
 if _, ok := aMap[aValue]; ok {
-  // do something
+	// do something
 }
 ```
 
@@ -2162,6 +2166,7 @@ After (fixed):
 
 ```go
 import "log"
+
 func compute() int {
 	log.Println("starting")
 	return doWork()

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -178,6 +178,28 @@ arguments = ["Ω", "Σ", "σ"]
 
 _Description_: Warns on bare (a.k.a. naked) returns.
 
+### Examples (bare-return)
+
+Before (violation):
+
+```go
+func split(sum int) (x, y int) {
+	x = sum * 4 / 9
+	y = sum - x
+	return
+}
+```
+
+After (fixed):
+
+```go
+func split(sum int) (x, y int) {
+	x = sum * 4 / 9
+	y = sum - x
+	return x, y
+}
+```
+
 _Configuration_: N/A
 
 ## blank-imports
@@ -468,6 +490,30 @@ if !cond {
 // do something
 ```
 
+### Examples (early-return)
+
+Before (violation):
+
+```go
+if hasAccess {
+	grantResource()
+	logAccess()
+} else {
+	return errNoAccess
+}
+```
+
+After (fixed):
+
+```go
+if !hasAccess {
+	return errNoAccess
+}
+
+grantResource()
+logAccess()
+```
+
 _Configuration_: ([]string) rule flags. Available flags are:
 
 - `preserve-scope`: do not suggest refactorings that would increase variable scope
@@ -712,6 +758,25 @@ Notice that a configuration including both options will effectively deactivate t
 **_Ported from golint_**
 
 _Description_: By convention, for the sake of readability, variables of type `error` must be named with the prefix `err`.
+Unexported error variables should start with `err`, exported ones with `Err`.
+
+### Examples (error-naming)
+
+Before (violation):
+
+```go
+var invalidInput = errors.New("invalid input")
+
+var TimeoutError = errors.New("connection timed out")
+```
+
+After (fixed):
+
+```go
+var errInvalidInput = errors.New("invalid input")
+
+var ErrTimeout = errors.New("connection timed out")
+```
 
 _Configuration_: N/A
 
@@ -720,6 +785,24 @@ _Configuration_: N/A
 **_Ported from golint_**
 
 _Description_: By convention, for the sake of readability, the errors should be last in the list of returned values by a function.
+
+### Examples (error-return)
+
+Before (violation):
+
+```go
+func readConfig(path string) (error, *Config) {
+	// ...
+}
+```
+
+After (fixed):
+
+```go
+func readConfig(path string) (*Config, error) {
+	// ...
+}
+```
 
 _Configuration_: N/A
 
@@ -970,6 +1053,27 @@ _Configuration_: N/A
 
 _Description_: Checking if an error is _nil_ to just after return the error or nil is redundant.
 
+### Examples (if-return)
+
+Before (violation):
+
+```go
+func do() error {
+	if err := validate(); err != nil {
+		return err
+	}
+	return nil
+}
+```
+
+After (fixed):
+
+```go
+func do() error {
+	return validate()
+}
+```
+
 _Configuration_: N/A
 
 ## import-alias-naming
@@ -1035,6 +1139,22 @@ arguments = ["crypto/md5", "crypto/sha1", "crypto/**/pkix"]
 _Description_: By convention, for better readability, incrementing an integer variable by 1 is recommended to be done using the `++` operator.
 This rule spots expressions like `i += 1` and `i -= 1` and proposes to change them into `i++` and `i--`.
 
+### Examples (increment-decrement)
+
+Before (violation):
+
+```go
+i += 1
+count -= 1
+```
+
+After (fixed):
+
+```go
+i++
+count--
+```
+
 _Configuration_: N/A
 
 ## indent-error-flow
@@ -1045,6 +1165,28 @@ _Description_: To improve the readability of code, it is recommended to reduce t
 This rule highlights redundant _else-blocks_ that can be eliminated from the code.
 
 More [information here](https://go.dev/wiki/CodeReviewComments#indent-error-flow).
+
+### Examples (indent-error-flow)
+
+Before (violation):
+
+```go
+if err != nil {
+	return err
+} else {
+	log.Println("no error")
+}
+```
+
+After (fixed):
+
+```go
+if err != nil {
+	return err
+}
+
+log.Println("no error")
+```
 
 _Configuration_: ([]string) rule flags. Available flags are:
 
@@ -1456,6 +1598,24 @@ _Note_: This rule is irrelevant for Go 1.22+.
 
 _Description_: This rule suggests a shorter way of writing ranges that do not use the second value.
 
+### Examples (range)
+
+Before (violation):
+
+```go
+for i, _ := range items {
+	process(i)
+}
+```
+
+After (fixed):
+
+```go
+for i := range items {
+	process(i)
+}
+```
+
 _Configuration_: N/A
 
 ## receiver-naming
@@ -1465,6 +1625,33 @@ _Configuration_: N/A
 _Description_: By convention, receiver names in a method should reflect their identity.
 For example, if the receiver is of type `Parts`, `p` is an adequate name for it.
 Contrary to other languages, it is not idiomatic to name receivers as `this` or `self`.
+All methods of a type should also use the same receiver name.
+
+### Examples (receiver-naming)
+
+Before (violation):
+
+```go
+func (p *Parts) Add(part Part) {
+	// ...
+}
+
+func (parts *Parts) Clear() {
+	// ...
+}
+```
+
+After (fixed):
+
+```go
+func (p *Parts) Add(part Part) {
+	// ...
+}
+
+func (p *Parts) Clear() {
+	// ...
+}
+```
 
 _Configuration_: (optional) list of key-value-pair-map (`[]map[string]any`).
 
@@ -1685,7 +1872,34 @@ arguments = ["!validate", "bson,outline,gnu"]
 ## superfluous-else
 
 _Description_: To improve the readability of code, it is recommended to reduce the indentation as much as possible.
-This rule highlights redundant _else-blocks_ that can be eliminated from the code.
+This rule highlights redundant _else-blocks_ that can be eliminated when the preceding `if`-block ends with a
+`break`, `continue` or `goto` statement (the `return` case is handled by [indent-error-flow](#indent-error-flow)).
+
+### Examples (superfluous-else)
+
+Before (violation):
+
+```go
+for _, v := range values {
+	if v < 0 {
+		continue
+	} else {
+		sum += v
+	}
+}
+```
+
+After (fixed):
+
+```go
+for _, v := range values {
+	if v < 0 {
+		continue
+	}
+
+	sum += v
+}
+```
 
 _Configuration_: ([]string) rule flags. Available flags are:
 
@@ -1900,11 +2114,52 @@ _Configuration_: N/A
 
 _Description_: This rule suggests to remove redundant statements like a `break` at the end of a case block, for improving the code's readability.
 
+### Examples (unnecessary-stmt)
+
+Before (violation):
+
+```go
+switch status {
+case "active":
+	handle()
+	break
+}
+```
+
+After (fixed):
+
+```go
+switch status {
+case "active":
+	handle()
+}
+```
+
 _Configuration_: N/A
 
 ## unreachable-code
 
 _Description_: This rule spots and proposes to remove [unreachable code](https://en.wikipedia.org/wiki/Unreachable_code).
+
+### Examples (unreachable-code)
+
+Before (violation):
+
+```go
+func compute() int {
+	return doWork()
+	log.Println("done")
+}
+```
+
+After (fixed):
+
+```go
+func compute() int {
+	log.Println("starting")
+	return doWork()
+}
+```
 
 _Configuration_: N/A
 
@@ -1963,6 +2218,24 @@ arguments = [{ allow-regex = "^_" }]
 
 _Description_: This rule proposes to replace instances of `interface{}` with its alias [`any`](https://pkg.go.dev/builtin@go1.18.0#any).
 
+### Examples (use-any)
+
+Before (violation):
+
+```go
+func PrintValue(v interface{}) {
+	fmt.Println(v)
+}
+```
+
+After (fixed):
+
+```go
+func PrintValue(v any) {
+	fmt.Println(v)
+}
+```
+
 _Configuration_: N/A
 
 _Note_: This rule is irrelevant for Go 1.17-.
@@ -1970,6 +2243,21 @@ _Note_: This rule is irrelevant for Go 1.17-.
 ## use-errors-new
 
 _Description_: This rule identifies calls to `fmt.Errorf` that can be safely replaced by, the more efficient, `errors.New`.
+This applies when the format string has no formatting verbs (no additional arguments are passed).
+
+### Examples (use-errors-new)
+
+Before (violation):
+
+```go
+return fmt.Errorf("connection refused")
+```
+
+After (fixed):
+
+```go
+return errors.New("connection refused")
+```
 
 _Configuration_: N/A
 
@@ -2081,6 +2369,31 @@ Therefore, inserting a `break` at the end of a case clause has no effect.
 Because `break` statements are rarely used in case clauses, when switch or select statements are inside a for-loop,
 the programmer might wrongly assume that a `break` in a case clause will take the control out of the loop.
 The rule emits a specific warning for such cases.
+
+### Examples (useless-break)
+
+Before (violation):
+
+```go
+for {
+	switch state {
+	case done:
+		cleanup()
+		break
+	}
+}
+```
+
+After (fixed):
+
+```go
+for {
+	switch state {
+	case done:
+		cleanup()
+	}
+}
+```
 
 _Configuration_: N/A
 


### PR DESCRIPTION
Refs #1498.

Adds Before/After Go code blocks to a first batch of 15 rules in `RULES_DESCRIPTIONS.md`, following the `use-any` format from the issue and the file's existing `### Examples (rule-name)` convention: bare-return, early-return, error-naming, error-return, if-return, increment-decrement, indent-error-flow, range, receiver-naming, superfluous-else, unnecessary-stmt, unreachable-code, use-any, use-errors-new, useless-break.

Each example was cross-checked against the rule's implementation in `rule/*.go` so it accurately shows what the rule flags/fixes. This is a first batch — the issue spans all ~70 rules, so this references rather than closes #1498.

I left out the optional "real-world use-case links", since fabricating PR URLs would be unverifiable (the existing Examples blocks omit them too).

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Each snippet was verified against `rule/*.go`; markdownlint (the repo's CI config) is clean and the assembled snippets pass gofmt + go build.*