### PR TITLE
fix: stamp release binaries with version, commit, date and builder

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/mgechev/revive/cli.version={{.Version}}
+      - -X github.com/mgechev/revive/cli.version={{.Tag}}
       - -X github.com/mgechev/revive/cli.commit={{.Commit}}
       - -X github.com/mgechev/revive/cli.date={{.Date}}
       - -X github.com/mgechev/revive/cli.builtBy=GoReleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,12 @@ builds:
   -
     env:
       - CGO_ENABLED=0
-      - BUILDER=GoReleaser
+    ldflags:
+      - -s -w
+      - -X github.com/mgechev/revive/cli.version={{.Version}}
+      - -X github.com/mgechev/revive/cli.commit={{.Commit}}
+      - -X github.com/mgechev/revive/cli.date={{.Date}}
+      - -X github.com/mgechev/revive/cli.builtBy=GoReleaser
     goos:
       - linux
       - darwin


### PR DESCRIPTION
Fixes #787.

`cli/main.go` expects its version metadata in package-level variables — `cli.version`, `cli.commit`, `cli.date`, `cli.builtBy` — but `.goreleaser.yml` has no `ldflags` section, so releases get GoReleaser's default stamping of `main.version` et al., which lands in the wrong package and leaves the variables at their defaults. The `BUILDER=GoReleaser` build env declared there is not read by anything; it is removed.

One honest note: the symptom has drifted since the issue was filed. Go now embeds VCS build info, so an unstamped binary reports a pseudo-version rather than the `(devel)` from 2023:

```
$ revive -version        # built exactly as releases are built today
version 0.0.0-20260727054359-0ac11a611ddf+dirty
```

With the ldflags from this change (same `-X` paths, sample values):

```
Version:	1.99.0-test
Commit:		deadbeef
Built		2026-08-07T00:00:00Z by GoReleaser
```

`-s -w` is kept explicitly because overriding `ldflags` replaces GoReleaser's defaults rather than extending them.

AI-assisted (LLM used for drafting); the runs above are mine.
