### PR TITLE
docs: add MegaLinter to the linter aggregators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ Please notice that if no particular configuration is provided, `revive` will beh
 (the [Available Rules table](#available-rules) details what are the `golint` rules).
 When a configuration is provided, only rules in the configuration are enabled.
 
+#### MegaLinter
+
+[MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI, runs `revive` on Go projects out of the box.
+See its [revive documentation page](https://megalinter.io/latest/descriptors/go_revive/) for configuration details.
+
 ### Command Line Flags
 
 `revive` accepts the following command line parameters:


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI that ships revive out of the box for Go projects.

Since the README already has a "Linter aggregators" section (currently just golangci-lint), I figured a short mention could help revive users who run it through MegaLinter find the relevant docs: https://megalinter.io/latest/descriptors/go_revive/

Happy to tweak the wording or placement if you prefer. Thanks for revive!