### PR TITLE
docs: document Go versions for rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ List of all [available rules](./RULES_DESCRIPTIONS.md).
 | [`max-public-structs`](./RULES_DESCRIPTIONS.md#max-public-structs)  |  int (defaults to 5)  | The maximum number of public structs in a file.                  |    no    |  no   |
 | [`modifies-parameter`](./RULES_DESCRIPTIONS.md#modifies-parameter)  |  n/a   | Warns on assignments to function parameters                      |    no    |  no   |
 | [`modifies-value-receiver`](./RULES_DESCRIPTIONS.md#modifies-value-receiver) |  n/a   | Warns on assignments to value-passed method receivers        |    no    |  yes  |
+| [`multiline-if-init`](./RULES_DESCRIPTIONS.md#multiline-if-init)    |  n/a   | Flags `if` statements whose init clause spans multiple lines    |    no    |  no   |
 | [`nested-structs`](./RULES_DESCRIPTIONS.md#nested-structs)          |  n/a   |  Warns on structs within structs |    no    |  no   |
 | [`optimize-operands-order`](./RULES_DESCRIPTIONS.md#optimize-operands-order)          |  n/a   |  Checks inefficient conditional expressions |    no    |  no   |
 | [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |  n/a   | Package commenting conventions.                                  |   yes    |  no   |

--- a/README.md
+++ b/README.md
@@ -510,112 +510,112 @@ You can use the following exclude patterns
 
 List of all [available rules](./RULES_DESCRIPTIONS.md).
 
-| Name                  | Config | Description                                                      | `golint` | Typed |
-| --------------------- | :----: | :--------------------------------------------------------------- | :------: | :---: |
-| [`add-constant`](./RULES_DESCRIPTIONS.md#add-constant)        |  map   | Suggests using constant for magic numbers and string literals    |    no    |  no   |
-| [`argument-limit`](./RULES_DESCRIPTIONS.md#argument-limit)      |  int (defaults to 8)  | Specifies the maximum number of arguments a function can receive |    no    |  no   |
-| [`atomic`](./RULES_DESCRIPTIONS.md#atomic)              |  n/a   | Check for common mistaken usages of the `sync/atomic` package    |    no    |  no   |
-| [`banned-characters`](./RULES_DESCRIPTIONS.md#banned-characters)          |  []string (defaults to []string{})   |  Checks banned characters in identifiers |    no    |  no   |
-| [`bare-return`](./RULES_DESCRIPTIONS.md#bare-return) | n/a  | Warns on bare returns   |    no    |  no   |
-| [`blank-imports`](./RULES_DESCRIPTIONS.md#blank-imports)       |  n/a   | Disallows blank imports                                          |   yes    |  no   |
-| [`bool-literal-in-expr`](./RULES_DESCRIPTIONS.md#bool-literal-in-expr)|  n/a   | Suggests removing Boolean literals from logic expressions        |    no    |  no   |
-| [`call-to-gc`](./RULES_DESCRIPTIONS.md#call-to-gc)   | n/a    | Warns on explicit call to the garbage collector    |    no    |  no   |
-| [`cognitive-complexity`](./RULES_DESCRIPTIONS.md#cognitive-complexity)          |  int (defaults to 7) | Sets restriction for maximum Cognitive complexity.              |    no    |  no   |
-| [`comment-spacings`](./RULES_DESCRIPTIONS.md#comment-spacings)          |  []string   |  Warns on malformed comments |    no    |  no   |
-| [`comments-density`](./RULES_DESCRIPTIONS.md#comments-density) |  int (defaults to 0)  | Enforces a minimum comment / code relation |    no    |  no   |
-| [`confusing-naming`](./RULES_DESCRIPTIONS.md#confusing-naming)    |  n/a   | Warns on methods with names that differ only by capitalization   |    no    |  no   |
-| [`confusing-results`](./RULES_DESCRIPTIONS.md#confusing-results)   |  n/a   | Suggests to name potentially confusing function results          |    no    |  no   |
-| [`constant-logical-expr`](./RULES_DESCRIPTIONS.md#constant-logical-expr)   |  n/a   | Warns on constant logical expressions                        |    no    |  no   |
-| [`context-as-argument`](./RULES_DESCRIPTIONS.md#context-as-argument) |  n/a   | `context.Context` should be the first argument of a function.    |   yes    |  no   |
-| [`context-keys-type`](./RULES_DESCRIPTIONS.md#context-keys-type)   |  n/a   | Disallows the usage of basic types in `context.WithValue`.       |   yes    |  yes  |
-| [`cyclomatic`](./RULES_DESCRIPTIONS.md#cyclomatic)          |  int (defaults to 10)   | Sets restriction for maximum Cyclomatic complexity.              |    no    |  no   |
-| [`datarace`](./RULES_DESCRIPTIONS.md#datarace)          |  n/a   |  Spots potential dataraces |    no    |  no   |
-| [`deep-exit`](./RULES_DESCRIPTIONS.md#deep-exit)           |  n/a   | Looks for program exits in funcs other than `main()` or `init()` |    no    |  no   |
-| [`defer`](./RULES_DESCRIPTIONS.md#defer)          |  map   |  Warns on some [defer gotchas](https://blog.learngoprogramming.com/5-gotchas-of-defer-in-go-golang-part-iii-36a1ab3d6ef1)       |    no    |  no   |
-| [`dot-imports`](./RULES_DESCRIPTIONS.md#dot-imports)         |  n/a   | Forbids `.` imports.                                             |   yes    |  no   |
-| [`duplicated-imports`](./RULES_DESCRIPTIONS.md#duplicated-imports) | n/a  | Looks for packages that are imported two or more times   |    no    |  no   |
-| [`early-return`](./RULES_DESCRIPTIONS.md#early-return)          | []string   | Spots if-then-else statements where the predicate may be inverted to reduce nesting |    no    |  no   |
-| [`empty-block`](./RULES_DESCRIPTIONS.md#empty-block)         |  n/a   | Warns on empty code blocks                                       |    no    |  no   |
-| [`empty-lines`](./RULES_DESCRIPTIONS.md#empty-lines)   | n/a | Warns when there are heading or trailing newlines in a block              |    no    |  no   |
-| [`epoch-naming`](./RULES_DESCRIPTIONS.md#epoch-naming)      |  n/a   | Enforces naming conventions for epoch time variables       |    no    |  yes   |
-| [`enforce-map-style`](./RULES_DESCRIPTIONS.md#enforce-map-style) |  string (defaults to "any")  |  Enforces consistent usage of `make(map[type]type)` or `map[type]type{}` for map initialization. Does not affect `make(map[type]type, size)` constructions. |    no    |  no   |
-| [`enforce-repeated-arg-type-style`](./RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style) |  string (defaults to "any")  |  Enforces consistent style for repeated argument and/or return value types. |    no    |  no   |
-| [`enforce-slice-style`](./RULES_DESCRIPTIONS.md#enforce-slice-style) |  string (defaults to "any")  |  Enforces consistent usage of `make([]type, 0)` or `[]type{}` for slice initialization. Does not affect `make(map[type]type, non_zero_len, or_non_zero_cap)` constructions. |    no    |  no   |
-| [`enforce-switch-style`](./RULES_DESCRIPTIONS.md#enforce-switch-style) |  []string (defaults to enforce occurrence and position) |  Enforces consistent usage of `default` on `switch` statements. |    no    |  no   |
-| [`error-naming`](./RULES_DESCRIPTIONS.md#error-naming)        |  n/a   | Naming of error variables.                                       |   yes    |  no   |
-| [`error-return`](./RULES_DESCRIPTIONS.md#error-return)        |  n/a   | The error return parameter should be last.                       |   yes    |  no   |
-| [`error-strings`](./RULES_DESCRIPTIONS.md#error-strings)       |  []string   | Conventions around error strings.                                |   yes    |  no   |
-| [`errorf`](./RULES_DESCRIPTIONS.md#errorf)              |  n/a   | Should replace `errors.New(fmt.Sprintf())` with `fmt.Errorf()`   |   yes    |  yes  |
-| [`exported`](./RULES_DESCRIPTIONS.md#exported)            |  []string   | Naming and commenting conventions on exported symbols.           |   yes    |  no   |
-| [`file-header`](./RULES_DESCRIPTIONS.md#file-header)         | string (defaults to none)| Header which each file should have.                              |    no    |  no   |
-| [`file-length-limit`](./RULES_DESCRIPTIONS.md#file-length-limit) | map (optional)| Enforces a maximum number of lines per file |    no    |  no   |
-| [`filename-format`](./RULES_DESCRIPTIONS.md#filename-format) | regular expression (optional) | Enforces the formatting of filenames |   no    |  no   |
-| [`flag-parameter`](./RULES_DESCRIPTIONS.md#flag-parameter)      |  n/a   | Warns on boolean parameters that create a control coupling       |    no    |  no   |
-| [`forbidden-call-in-wg-go`](./RULES_DESCRIPTIONS.md#forbidden-call-in-wg-go)  |  n/a   | Warns on forbidden calls inside calls to wg.Go |    no    |  no   |
-| [`function-length`](./RULES_DESCRIPTIONS.md#function-length)          |  int, int (defaults to 50 statements, 75 lines)   |  Warns on functions exceeding the statements or lines max |    no    |  no   |
-| [`function-result-limit`](./RULES_DESCRIPTIONS.md#function-result-limit) |  int (defaults to 3)| Specifies the maximum number of results a function can return    |    no    |  no   |
-| [`get-return`](./RULES_DESCRIPTIONS.md#get-return)          |  n/a   | Warns on getters that do not yield any result                    |    no    |  no   |
-| [`identical-branches`](./RULES_DESCRIPTIONS.md#identical-branches)          |  n/a   | Spots if-then-else statements with identical `then` and `else` branches       |    no    |  no   |
-| [`identical-ifelseif-branches`](./RULES_DESCRIPTIONS.md#identical-ifelseif-branches)          |  n/a   | Spots `if ... else if` chains with identical branches.       |    no    |  no   |
-| [`identical-ifelseif-conditions`](./RULES_DESCRIPTIONS.md#identical-ifelseif-conditions)          |  n/a   | Spots identical conditions in  `if ... else if` chains.       |    no    |  no   |
-| [`identical-switch-branches`](./RULES_DESCRIPTIONS.md#identical-switch-branches)          |  n/a   | Spots `switch` with identical branches.       |    no    |  no   |
-| [`identical-switch-conditions`](./RULES_DESCRIPTIONS.md#identical-switch-conditions)          |  n/a   | Spots identical conditions in case clauses of `switch` statements.       |    no    |  no   |
-| [`if-return`](./RULES_DESCRIPTIONS.md#if-return)           |  n/a   | Redundant if when returning an error.                            |   no    |  no   |
-| [`import-alias-naming`](./RULES_DESCRIPTIONS.md#import-alias-naming)         | string or map[string]string (defaults to allow regex pattern `^[a-z][a-z0-9]{0,}$`) | Conventions around the naming of import aliases.                              |    no    |  no   |
-| [`import-shadowing`](./RULES_DESCRIPTIONS.md#import-shadowing)   | n/a    | Spots identifiers that shadow an import    |    no    |  no   |
-| [`imports-blocklist`](./RULES_DESCRIPTIONS.md#imports-blocklist)   | []string | Disallows importing the specified packages                     |    no    |  no   |
-| [`increment-decrement`](./RULES_DESCRIPTIONS.md#increment-decrement) |  n/a   | Use `i++` and `i--` instead of `i += 1` and `i -= 1`.            |   yes    |  no   |
-| [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |  []string   | Prevents redundant else statements.                              |   yes    |  no   |
-| [`inefficient-map-lookup`](./RULES_DESCRIPTIONS.md#inefficient-map-lookup)   |  n/a  | Spots iterative searches for a key in a map           |   no    |  yes   |
-| [`line-length-limit`](./RULES_DESCRIPTIONS.md#line-length-limit)   | int (defaults to 80) | Specifies the maximum number of characters in a line             |    no    |  no   |
-| [`marshal-receiver`](./RULES_DESCRIPTIONS.md#marshal-receiver) |  n/a   | Checks receiver type consistency for common marshal/unmarshal methods. |    no    |  no   |
-| [`max-control-nesting`](./RULES_DESCRIPTIONS.md#max-control-nesting) |  int (defaults to 5)  | Sets restriction for maximum nesting of control structures. |    no    |  no   |
-| [`max-public-structs`](./RULES_DESCRIPTIONS.md#max-public-structs)  |  int (defaults to 5)  | The maximum number of public structs in a file.                  |    no    |  no   |
-| [`modifies-parameter`](./RULES_DESCRIPTIONS.md#modifies-parameter)  |  n/a   | Warns on assignments to function parameters                      |    no    |  no   |
-| [`modifies-value-receiver`](./RULES_DESCRIPTIONS.md#modifies-value-receiver) |  n/a   | Warns on assignments to value-passed method receivers        |    no    |  yes  |
-| [`multiline-if-init`](./RULES_DESCRIPTIONS.md#multiline-if-init)    |  n/a   | Flags `if` statements whose init clause spans multiple lines    |    no    |  no   |
-| [`nested-structs`](./RULES_DESCRIPTIONS.md#nested-structs)          |  n/a   |  Warns on structs within structs |    no    |  no   |
-| [`optimize-operands-order`](./RULES_DESCRIPTIONS.md#optimize-operands-order)          |  n/a   |  Checks inefficient conditional expressions |    no    |  no   |
-| [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |  n/a   | Package commenting conventions.                                  |   yes    |  no   |
-| [`package-naming`](./RULES_DESCRIPTIONS.md#package-naming)    |  map   | Checks that package names follow Go conventions and best practices |   no    |  no   |
-| [`package-directory-mismatch`](./RULES_DESCRIPTIONS.md#package-directory-mismatch)    | string | Checks that package name matches containing directory name     |   no    |  no   |
-| [`range-val-address`](./RULES_DESCRIPTIONS.md#range-val-address)|  n/a   | Warns if address of range value is used dangerously |    no    |  yes   |
-| [`range-val-in-closure`](./RULES_DESCRIPTIONS.md#range-val-in-closure)|  n/a   | Warns if range value is used in a closure dispatched as goroutine|    no    |  no   |
-| [`range`](./RULES_DESCRIPTIONS.md#range)               |  n/a   | Prevents redundant variables when iterating over a collection.   |   yes    |  no   |
-| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  map (optional)   | Conventions around the naming of receivers.                      |   yes    |  no   |
-| [`redefines-builtin-id`](./RULES_DESCRIPTIONS.md#redefines-builtin-id)|  n/a   | Warns on redefinitions of builtin identifiers                    |    no    |  no   |
-| [`redundant-build-tag`](./RULES_DESCRIPTIONS.md#redundant-build-tag) | n/a   | Warns about redundant `// +build` comment lines |   no    |  no   |
-| [`redundant-import-alias`](./RULES_DESCRIPTIONS.md#redundant-import-alias)          |  n/a   |  Warns on import aliases matching the imported package name |    no    |  no   |
-| [`redundant-test-main-exit`](./RULES_DESCRIPTIONS.md#redundant-test-main-exit) |  n/a   | Suggests removing `Exit` call in `TestMain` function for test files |    no    |  no   |
-| [`string-format`](./RULES_DESCRIPTIONS.md#string-format)          |  map   | Warns on specific string literals that fail one or more user-configured regular expressions            |    no    |  no   |
-| [`string-of-int`](./RULES_DESCRIPTIONS.md#string-of-int)          |  n/a   | Warns on suspicious casts from int to string            |    no    |  yes   |
-| [`struct-tag`](./RULES_DESCRIPTIONS.md#struct-tag)          |  []string   | Checks common struct tags like `json`, `xml`, `yaml`               |    no    |  no   |
-| [`superfluous-else`](./RULES_DESCRIPTIONS.md#superfluous-else)    |  []string   | Prevents redundant else statements (extends [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)) |    no    |  no   |
-| [`time-date`](./RULES_DESCRIPTIONS.md#time-date)         |  n/a   | Reports bad usage of `time.Date`.                 |   no    |  no   |
-| [`time-equal`](./RULES_DESCRIPTIONS.md#time-equal)         |  n/a   | Suggests to use `time.Time.Equal` instead of `==` and `!=` for equality check time.                 |   no    |  yes  |
-| [`time-naming`](./RULES_DESCRIPTIONS.md#time-naming)         |  n/a   | Conventions around the naming of time variables.                 |   yes    |  yes  |
-| [`unchecked-type-assertion`](./RULES_DESCRIPTIONS.md#unchecked-type-assertion)         |  n/a   | Disallows type assertions without checking the result.                 |   no    |  no   |
-| [`unconditional-recursion`](./RULES_DESCRIPTIONS.md#unconditional-recursion)          |  n/a   | Warns on function calls that will lead to (direct) infinite recursion |    no    |  no   |
-| [`unexported-naming`](./RULES_DESCRIPTIONS.md#unexported-naming)          |  n/a   |  Warns on wrongly named un-exported symbols       |    no    |  no   |
-| [`unexported-return`](./RULES_DESCRIPTIONS.md#unexported-return)   |  n/a   | Warns when a public return is from unexported type.              |   yes    |  yes  |
-| [`unhandled-error`](./RULES_DESCRIPTIONS.md#unhandled-error)   | []string   | Warns on unhandled errors returned by function calls    |    no    |  yes   |
-| [`unnecessary-if`](./RULES_DESCRIPTIONS.md#unnecessary-if)    |  n/a   | Identifies `if-else` statements that can be replaced by simpler statements  |    no    |  no   |
-| [`unnecessary-format`](./RULES_DESCRIPTIONS.md#unnecessary-format)    |  n/a   | Identifies calls to formatting functions where the format string does not contain any formatting verbs          |    no    |  no   |
-| [`unnecessary-stmt`](./RULES_DESCRIPTIONS.md#unnecessary-stmt)    |  n/a   | Suggests removing or simplifying unnecessary statements          |    no    |  no   |
-| [`unreachable-code`](./RULES_DESCRIPTIONS.md#unreachable-code)    |  n/a   | Warns on unreachable code                                        |    no    |  no   |
-| [`unsecure-url-scheme`](./RULES_DESCRIPTIONS.md#unsecure-url-scheme)          |  n/a   |  Checks for usage of potentially unsecure URL schemes. |    no    |  no   |
-| [`unused-parameter`](./RULES_DESCRIPTIONS.md#unused-parameter)    |  n/a   | Suggests to rename or remove unused function parameters          |    no    |  no   |
-| [`unused-receiver`](./RULES_DESCRIPTIONS.md#unused-receiver)   | n/a    | Suggests to rename or remove unused method receivers    |    no    |  no   |
-| [`use-any`](./RULES_DESCRIPTIONS.md#use-any)          |  n/a   |  Proposes to replace `interface{}` with its alias `any` |    no    |  no   |
-| [`use-errors-new`](./RULES_DESCRIPTIONS.md#use-errors-new) | n/a   | Spots calls to `fmt.Errorf` that can be replaced by `errors.New` |   no    |  no   |
-| [`use-fmt-print`](./RULES_DESCRIPTIONS.md#use-fmt-print) | n/a   | Proposes to replace calls to built-in `print` and `println` with their equivalents from `fmt`. |   no    |  no   |
-| [`use-slices-sort`](./RULES_DESCRIPTIONS.md#use-slices-sort) | n/a   | Proposes to replace calls to `sort.Ints`, `sort.Strings` and the like with their equivalents from `slices` package. |   no    |  no   |
-| [`use-waitgroup-go`](./RULES_DESCRIPTIONS.md#use-waitgroup-go)          |  n/a   |  Proposes to replace `wg.Add ... go {... wg.Done ...}` idiom with `wg.Go` |    no    |  no   |
-| [`useless-break`](./RULES_DESCRIPTIONS.md#useless-break)          |  n/a   |  Warns on useless `break` statements in case clauses |    no    |  no   |
-| [`useless-fallthrough`](./RULES_DESCRIPTIONS.md#useless-fallthrough)  |  n/a   |  Warns on useless `fallthrough` statements in case clauses |    no    |  no   |
-| [`var-declaration`](./RULES_DESCRIPTIONS.md#var-declaration)     |  n/a   | Reduces redundancies around variable declaration.                |   yes    |  yes  |
-| [`var-naming`](./RULES_DESCRIPTIONS.md#var-naming)          |  allowlist & blocklist of initialisms   | Naming rules.                                                    |   yes    |  no   |
-| [`waitgroup-by-value`](./RULES_DESCRIPTIONS.md#waitgroup-by-value)  |  n/a   | Warns on functions taking sync.WaitGroup as a by-value parameter |    no    |  no   |
+| Name                  | Config | Description                                                      | Go version | `golint` | Typed |
+| --------------------- | :----: | :--------------------------------------------------------------- | :--------: | :------: | :---: |
+| [`add-constant`](./RULES_DESCRIPTIONS.md#add-constant)        |  map   | Suggests using constant for magic numbers and string literals    | 1.0 |    no    |  no   |
+| [`argument-limit`](./RULES_DESCRIPTIONS.md#argument-limit)      |  int (defaults to 8)  | Specifies the maximum number of arguments a function can receive | 1.0 |    no    |  no   |
+| [`atomic`](./RULES_DESCRIPTIONS.md#atomic)              |  n/a   | Check for common mistaken usages of the `sync/atomic` package    | 1.0 |    no    |  no   |
+| [`banned-characters`](./RULES_DESCRIPTIONS.md#banned-characters)          |  []string (defaults to []string{})   |  Checks banned characters in identifiers | 1.0 |    no    |  no   |
+| [`bare-return`](./RULES_DESCRIPTIONS.md#bare-return) | n/a  | Warns on bare returns   | 1.0 |    no    |  no   |
+| [`blank-imports`](./RULES_DESCRIPTIONS.md#blank-imports)       |  n/a   | Disallows blank imports                                          | 1.0 |   yes    |  no   |
+| [`bool-literal-in-expr`](./RULES_DESCRIPTIONS.md#bool-literal-in-expr)|  n/a   | Suggests removing Boolean literals from logic expressions        | 1.0 |    no    |  no   |
+| [`call-to-gc`](./RULES_DESCRIPTIONS.md#call-to-gc)   | n/a    | Warns on explicit call to the garbage collector    | 1.0 |    no    |  no   |
+| [`cognitive-complexity`](./RULES_DESCRIPTIONS.md#cognitive-complexity)          |  int (defaults to 7) | Sets restriction for maximum Cognitive complexity.              | 1.0 |    no    |  no   |
+| [`comment-spacings`](./RULES_DESCRIPTIONS.md#comment-spacings)          |  []string   |  Warns on malformed comments | 1.0 |    no    |  no   |
+| [`comments-density`](./RULES_DESCRIPTIONS.md#comments-density) |  int (defaults to 0)  | Enforces a minimum comment / code relation | 1.0 |    no    |  no   |
+| [`confusing-naming`](./RULES_DESCRIPTIONS.md#confusing-naming)    |  n/a   | Warns on methods with names that differ only by capitalization   | 1.0 |    no    |  no   |
+| [`confusing-results`](./RULES_DESCRIPTIONS.md#confusing-results)   |  n/a   | Suggests to name potentially confusing function results          | 1.0 |    no    |  no   |
+| [`constant-logical-expr`](./RULES_DESCRIPTIONS.md#constant-logical-expr)   |  n/a   | Warns on constant logical expressions                        | 1.0 |    no    |  no   |
+| [`context-as-argument`](./RULES_DESCRIPTIONS.md#context-as-argument) |  n/a   | `context.Context` should be the first argument of a function.    | 1.0 |   yes    |  no   |
+| [`context-keys-type`](./RULES_DESCRIPTIONS.md#context-keys-type)   |  n/a   | Disallows the usage of basic types in `context.WithValue`.       | 1.0 |   yes    |  yes  |
+| [`cyclomatic`](./RULES_DESCRIPTIONS.md#cyclomatic)          |  int (defaults to 10)   | Sets restriction for maximum Cyclomatic complexity.              | 1.0 |    no    |  no   |
+| [`datarace`](./RULES_DESCRIPTIONS.md#datarace)          |  n/a   |  Spots potential dataraces | 1.0 |    no    |  no   |
+| [`deep-exit`](./RULES_DESCRIPTIONS.md#deep-exit)           |  n/a   | Looks for program exits in funcs other than `main()` or `init()` | 1.0 |    no    |  no   |
+| [`defer`](./RULES_DESCRIPTIONS.md#defer)          |  map   |  Warns on some [defer gotchas](https://blog.learngoprogramming.com/5-gotchas-of-defer-in-go-golang-part-iii-36a1ab3d6ef1)       | 1.0 |    no    |  no   |
+| [`dot-imports`](./RULES_DESCRIPTIONS.md#dot-imports)         |  n/a   | Forbids `.` imports.                                             | 1.0 |   yes    |  no   |
+| [`duplicated-imports`](./RULES_DESCRIPTIONS.md#duplicated-imports) | n/a  | Looks for packages that are imported two or more times   | 1.0 |    no    |  no   |
+| [`early-return`](./RULES_DESCRIPTIONS.md#early-return)          | []string   | Spots if-then-else statements where the predicate may be inverted to reduce nesting | 1.0 |    no    |  no   |
+| [`empty-block`](./RULES_DESCRIPTIONS.md#empty-block)         |  n/a   | Warns on empty code blocks                                       | 1.0 |    no    |  no   |
+| [`empty-lines`](./RULES_DESCRIPTIONS.md#empty-lines)   | n/a | Warns when there are heading or trailing newlines in a block              | 1.0 |    no    |  no   |
+| [`epoch-naming`](./RULES_DESCRIPTIONS.md#epoch-naming)      |  n/a   | Enforces naming conventions for epoch time variables       | 1.0 |    no    |  yes   |
+| [`enforce-map-style`](./RULES_DESCRIPTIONS.md#enforce-map-style) |  string (defaults to "any")  |  Enforces consistent usage of `make(map[type]type)` or `map[type]type{}` for map initialization. Does not affect `make(map[type]type, size)` constructions. | 1.0 |    no    |  no   |
+| [`enforce-repeated-arg-type-style`](./RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style) |  string (defaults to "any")  |  Enforces consistent style for repeated argument and/or return value types. | 1.0 |    no    |  no   |
+| [`enforce-slice-style`](./RULES_DESCRIPTIONS.md#enforce-slice-style) |  string (defaults to "any")  |  Enforces consistent usage of `make([]type, 0)` or `[]type{}` for slice initialization. Does not affect `make(map[type]type, non_zero_len, or_non_zero_cap)` constructions. | 1.0 |    no    |  no   |
+| [`enforce-switch-style`](./RULES_DESCRIPTIONS.md#enforce-switch-style) |  []string (defaults to enforce occurrence and position) |  Enforces consistent usage of `default` on `switch` statements. | 1.0 |    no    |  no   |
+| [`error-naming`](./RULES_DESCRIPTIONS.md#error-naming)        |  n/a   | Naming of error variables.                                       | 1.0 |   yes    |  no   |
+| [`error-return`](./RULES_DESCRIPTIONS.md#error-return)        |  n/a   | The error return parameter should be last.                       | 1.0 |   yes    |  no   |
+| [`error-strings`](./RULES_DESCRIPTIONS.md#error-strings)       |  []string   | Conventions around error strings.                                | 1.0 |   yes    |  no   |
+| [`errorf`](./RULES_DESCRIPTIONS.md#errorf)              |  n/a   | Should replace `errors.New(fmt.Sprintf())` with `fmt.Errorf()`   | 1.0 |   yes    |  yes  |
+| [`exported`](./RULES_DESCRIPTIONS.md#exported)            |  []string   | Naming and commenting conventions on exported symbols.           | 1.0 |   yes    |  no   |
+| [`file-header`](./RULES_DESCRIPTIONS.md#file-header)         | string (defaults to none)| Header which each file should have.                              | 1.0 |    no    |  no   |
+| [`file-length-limit`](./RULES_DESCRIPTIONS.md#file-length-limit) | map (optional)| Enforces a maximum number of lines per file | 1.0 |    no    |  no   |
+| [`filename-format`](./RULES_DESCRIPTIONS.md#filename-format) | regular expression (optional) | Enforces the formatting of filenames | 1.0 |   no    |  no   |
+| [`flag-parameter`](./RULES_DESCRIPTIONS.md#flag-parameter)      |  n/a   | Warns on boolean parameters that create a control coupling       | 1.0 |    no    |  no   |
+| [`forbidden-call-in-wg-go`](./RULES_DESCRIPTIONS.md#forbidden-call-in-wg-go)  |  n/a   | Warns on forbidden calls inside calls to wg.Go | >= 1.25 |    no    |  no   |
+| [`function-length`](./RULES_DESCRIPTIONS.md#function-length)          |  int, int (defaults to 50 statements, 75 lines)   |  Warns on functions exceeding the statements or lines max | 1.0 |    no    |  no   |
+| [`function-result-limit`](./RULES_DESCRIPTIONS.md#function-result-limit) |  int (defaults to 3)| Specifies the maximum number of results a function can return    | 1.0 |    no    |  no   |
+| [`get-return`](./RULES_DESCRIPTIONS.md#get-return)          |  n/a   | Warns on getters that do not yield any result                    | 1.0 |    no    |  no   |
+| [`identical-branches`](./RULES_DESCRIPTIONS.md#identical-branches)          |  n/a   | Spots if-then-else statements with identical `then` and `else` branches       | 1.0 |    no    |  no   |
+| [`identical-ifelseif-branches`](./RULES_DESCRIPTIONS.md#identical-ifelseif-branches)          |  n/a   | Spots `if ... else if` chains with identical branches.       | 1.0 |    no    |  no   |
+| [`identical-ifelseif-conditions`](./RULES_DESCRIPTIONS.md#identical-ifelseif-conditions)          |  n/a   | Spots identical conditions in  `if ... else if` chains.       | 1.0 |    no    |  no   |
+| [`identical-switch-branches`](./RULES_DESCRIPTIONS.md#identical-switch-branches)          |  n/a   | Spots `switch` with identical branches.       | 1.0 |    no    |  no   |
+| [`identical-switch-conditions`](./RULES_DESCRIPTIONS.md#identical-switch-conditions)          |  n/a   | Spots identical conditions in case clauses of `switch` statements.       | 1.0 |    no    |  no   |
+| [`if-return`](./RULES_DESCRIPTIONS.md#if-return)           |  n/a   | Redundant if when returning an error.                            | 1.0 |   no    |  no   |
+| [`import-alias-naming`](./RULES_DESCRIPTIONS.md#import-alias-naming)         | string or map[string]string (defaults to allow regex pattern `^[a-z][a-z0-9]{0,}$`) | Conventions around the naming of import aliases.                              | 1.0 |    no    |  no   |
+| [`import-shadowing`](./RULES_DESCRIPTIONS.md#import-shadowing)   | n/a    | Spots identifiers that shadow an import    | 1.0 |    no    |  no   |
+| [`imports-blocklist`](./RULES_DESCRIPTIONS.md#imports-blocklist)   | []string | Disallows importing the specified packages                     | 1.0 |    no    |  no   |
+| [`increment-decrement`](./RULES_DESCRIPTIONS.md#increment-decrement) |  n/a   | Use `i++` and `i--` instead of `i += 1` and `i -= 1`.            | 1.0 |   yes    |  no   |
+| [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |  []string   | Prevents redundant else statements.                              | 1.0 |   yes    |  no   |
+| [`inefficient-map-lookup`](./RULES_DESCRIPTIONS.md#inefficient-map-lookup)   |  n/a  | Spots iterative searches for a key in a map           | 1.0 |   no    |  yes   |
+| [`line-length-limit`](./RULES_DESCRIPTIONS.md#line-length-limit)   | int (defaults to 80) | Specifies the maximum number of characters in a line             | 1.0 |    no    |  no   |
+| [`marshal-receiver`](./RULES_DESCRIPTIONS.md#marshal-receiver) |  n/a   | Checks receiver type consistency for common marshal/unmarshal methods. | 1.0 |    no    |  no   |
+| [`max-control-nesting`](./RULES_DESCRIPTIONS.md#max-control-nesting) |  int (defaults to 5)  | Sets restriction for maximum nesting of control structures. | 1.0 |    no    |  no   |
+| [`max-public-structs`](./RULES_DESCRIPTIONS.md#max-public-structs)  |  int (defaults to 5)  | The maximum number of public structs in a file.                  | 1.0 |    no    |  no   |
+| [`modifies-parameter`](./RULES_DESCRIPTIONS.md#modifies-parameter)  |  n/a   | Warns on assignments to function parameters                      | 1.0 |    no    |  no   |
+| [`modifies-value-receiver`](./RULES_DESCRIPTIONS.md#modifies-value-receiver) |  n/a   | Warns on assignments to value-passed method receivers        | 1.0 |    no    |  yes  |
+| [`multiline-if-init`](./RULES_DESCRIPTIONS.md#multiline-if-init)    |  n/a   | Flags `if` statements whose init clause spans multiple lines    | 1.0 |    no    |  no   |
+| [`nested-structs`](./RULES_DESCRIPTIONS.md#nested-structs)          |  n/a   |  Warns on structs within structs | 1.0 |    no    |  no   |
+| [`optimize-operands-order`](./RULES_DESCRIPTIONS.md#optimize-operands-order)          |  n/a   |  Checks inefficient conditional expressions | 1.0 |    no    |  no   |
+| [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |  n/a   | Package commenting conventions.                                  | 1.0 |   yes    |  no   |
+| [`package-naming`](./RULES_DESCRIPTIONS.md#package-naming)    |  map   | Checks that package names follow Go conventions and best practices | 1.0 |   no    |  no   |
+| [`package-directory-mismatch`](./RULES_DESCRIPTIONS.md#package-directory-mismatch)    | string | Checks that package name matches containing directory name     | 1.0 |   no    |  no   |
+| [`range-val-address`](./RULES_DESCRIPTIONS.md#range-val-address)|  n/a   | Warns if address of range value is used dangerously | < 1.22 |    no    |  yes   |
+| [`range-val-in-closure`](./RULES_DESCRIPTIONS.md#range-val-in-closure)|  n/a   | Warns if range value is used in a closure dispatched as goroutine| < 1.22 |    no    |  no   |
+| [`range`](./RULES_DESCRIPTIONS.md#range)               |  n/a   | Prevents redundant variables when iterating over a collection.   | 1.0 |   yes    |  no   |
+| [`receiver-naming`](./RULES_DESCRIPTIONS.md#receiver-naming)     |  map (optional)   | Conventions around the naming of receivers.                      | 1.0 |   yes    |  no   |
+| [`redefines-builtin-id`](./RULES_DESCRIPTIONS.md#redefines-builtin-id)|  n/a   | Warns on redefinitions of builtin identifiers                    | 1.0 |    no    |  no   |
+| [`redundant-build-tag`](./RULES_DESCRIPTIONS.md#redundant-build-tag) | n/a   | Warns about redundant `// +build` comment lines | >= 1.17 |   no    |  no   |
+| [`redundant-import-alias`](./RULES_DESCRIPTIONS.md#redundant-import-alias)          |  n/a   |  Warns on import aliases matching the imported package name | 1.0 |    no    |  no   |
+| [`redundant-test-main-exit`](./RULES_DESCRIPTIONS.md#redundant-test-main-exit) |  n/a   | Suggests removing `Exit` call in `TestMain` function for test files | >= 1.15 |    no    |  no   |
+| [`string-format`](./RULES_DESCRIPTIONS.md#string-format)          |  map   | Warns on specific string literals that fail one or more user-configured regular expressions            | 1.0 |    no    |  no   |
+| [`string-of-int`](./RULES_DESCRIPTIONS.md#string-of-int)          |  n/a   | Warns on suspicious casts from int to string            | 1.0 |    no    |  yes   |
+| [`struct-tag`](./RULES_DESCRIPTIONS.md#struct-tag)          |  []string   | Checks common struct tags like `json`, `xml`, `yaml`               | 1.0 |    no    |  no   |
+| [`superfluous-else`](./RULES_DESCRIPTIONS.md#superfluous-else)    |  []string   | Prevents redundant else statements (extends [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)) | 1.0 |    no    |  no   |
+| [`time-date`](./RULES_DESCRIPTIONS.md#time-date)         |  n/a   | Reports bad usage of `time.Date`.                 | 1.0 |   no    |  no   |
+| [`time-equal`](./RULES_DESCRIPTIONS.md#time-equal)         |  n/a   | Suggests to use `time.Time.Equal` instead of `==` and `!=` for equality check time.                 | 1.0 |   no    |  yes  |
+| [`time-naming`](./RULES_DESCRIPTIONS.md#time-naming)         |  n/a   | Conventions around the naming of time variables.                 | 1.0 |   yes    |  yes  |
+| [`unchecked-type-assertion`](./RULES_DESCRIPTIONS.md#unchecked-type-assertion)         |  n/a   | Disallows type assertions without checking the result.                 | 1.0 |   no    |  no   |
+| [`unconditional-recursion`](./RULES_DESCRIPTIONS.md#unconditional-recursion)          |  n/a   | Warns on function calls that will lead to (direct) infinite recursion | 1.0 |    no    |  no   |
+| [`unexported-naming`](./RULES_DESCRIPTIONS.md#unexported-naming)          |  n/a   |  Warns on wrongly named un-exported symbols       | 1.0 |    no    |  no   |
+| [`unexported-return`](./RULES_DESCRIPTIONS.md#unexported-return)   |  n/a   | Warns when a public return is from unexported type.              | 1.0 |   yes    |  yes  |
+| [`unhandled-error`](./RULES_DESCRIPTIONS.md#unhandled-error)   | []string   | Warns on unhandled errors returned by function calls    | 1.0 |    no    |  yes   |
+| [`unnecessary-if`](./RULES_DESCRIPTIONS.md#unnecessary-if)    |  n/a   | Identifies `if-else` statements that can be replaced by simpler statements  | 1.0 |    no    |  no   |
+| [`unnecessary-format`](./RULES_DESCRIPTIONS.md#unnecessary-format)    |  n/a   | Identifies calls to formatting functions where the format string does not contain any formatting verbs          | 1.0 |    no    |  no   |
+| [`unnecessary-stmt`](./RULES_DESCRIPTIONS.md#unnecessary-stmt)    |  n/a   | Suggests removing or simplifying unnecessary statements          | 1.0 |    no    |  no   |
+| [`unreachable-code`](./RULES_DESCRIPTIONS.md#unreachable-code)    |  n/a   | Warns on unreachable code                                        | 1.0 |    no    |  no   |
+| [`unsecure-url-scheme`](./RULES_DESCRIPTIONS.md#unsecure-url-scheme)          |  n/a   |  Checks for usage of potentially unsecure URL schemes. | 1.0 |    no    |  no   |
+| [`unused-parameter`](./RULES_DESCRIPTIONS.md#unused-parameter)    |  n/a   | Suggests to rename or remove unused function parameters          | 1.0 |    no    |  no   |
+| [`unused-receiver`](./RULES_DESCRIPTIONS.md#unused-receiver)   | n/a    | Suggests to rename or remove unused method receivers    | 1.0 |    no    |  no   |
+| [`use-any`](./RULES_DESCRIPTIONS.md#use-any)          |  n/a   |  Proposes to replace `interface{}` with its alias `any` | >= 1.18 |    no    |  no   |
+| [`use-errors-new`](./RULES_DESCRIPTIONS.md#use-errors-new) | n/a   | Spots calls to `fmt.Errorf` that can be replaced by `errors.New` | < 1.26 |   no    |  no   |
+| [`use-fmt-print`](./RULES_DESCRIPTIONS.md#use-fmt-print) | n/a   | Proposes to replace calls to built-in `print` and `println` with their equivalents from `fmt`. | 1.0 |   no    |  no   |
+| [`use-slices-sort`](./RULES_DESCRIPTIONS.md#use-slices-sort) | n/a   | Proposes to replace calls to `sort.Ints`, `sort.Strings` and the like with their equivalents from `slices` package. | >= 1.21 |   no    |  no   |
+| [`use-waitgroup-go`](./RULES_DESCRIPTIONS.md#use-waitgroup-go)          |  n/a   |  Proposes to replace `wg.Add ... go {... wg.Done ...}` idiom with `wg.Go` | >= 1.25 |    no    |  no   |
+| [`useless-break`](./RULES_DESCRIPTIONS.md#useless-break)          |  n/a   |  Warns on useless `break` statements in case clauses | 1.0 |    no    |  no   |
+| [`useless-fallthrough`](./RULES_DESCRIPTIONS.md#useless-fallthrough)  |  n/a   |  Warns on useless `fallthrough` statements in case clauses | 1.0 |    no    |  no   |
+| [`var-declaration`](./RULES_DESCRIPTIONS.md#var-declaration)     |  n/a   | Reduces redundancies around variable declaration.                | 1.0 |   yes    |  yes  |
+| [`var-naming`](./RULES_DESCRIPTIONS.md#var-naming)          |  allowlist & blocklist of initialisms   | Naming rules.                                                    | 1.0 |   yes    |  no   |
+| [`waitgroup-by-value`](./RULES_DESCRIPTIONS.md#waitgroup-by-value)  |  n/a   | Warns on functions taking sync.WaitGroup as a by-value parameter | 1.0 |    no    |  no   |
 
  The rules ported from `golint` are left unchanged and indicated in the "golint" column.
 

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -120,6 +120,8 @@ and `lowercase` (e.g., `maxlitcount`, `allowstrs`, `skipcomments`) formats are s
 
 ## add-constant
 
+_Go version_: 1.0.
+
 _Description_: Suggests using constant for [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)#Unnamed_numerical_constants)
 and string literals.
 
@@ -142,6 +144,8 @@ arguments = [
 
 ## argument-limit
 
+_Go version_: 1.0.
+
 _Description_: Warns when a function receives more parameters than the maximum set by the rule's configuration.
 Enforcing a maximum number of parameters helps to keep the code readable and maintainable.
 
@@ -156,11 +160,15 @@ arguments = [4]
 
 ## atomic
 
+_Go version_: 1.0.
+
 _Description_: Check for commonly mistaken usages of the `sync/atomic` package.
 
 _Configuration_: N/A
 
 ## banned-characters
+
+_Go version_: 1.0.
 
 _Description_: Checks given banned characters in identifiers (func, var, const). Comments are not checked.
 
@@ -174,6 +182,8 @@ arguments = ["Ω", "Σ", "σ"]
 ```
 
 ## bare-return
+
+_Go version_: 1.0.
 
 _Description_: Warns on bare (a.k.a. naked) returns.
 
@@ -203,6 +213,8 @@ _Configuration_: N/A
 
 ## blank-imports
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 _Description_: Blank import should be only in a main or test package, or have a comment justifying it.
@@ -210,6 +222,8 @@ _Description_: Blank import should be only in a main or test package, or have a 
 _Configuration_: N/A
 
 ## bool-literal-in-expr
+
+_Go version_: 1.0.
 
 _Description_: Using Boolean literals (`true`, `false`) in logic expressions may make the code less readable.
 This rule suggests removing Boolean literals from logic expressions.
@@ -244,6 +258,8 @@ _Configuration_: N/A
 
 ## call-to-gc
 
+_Go version_: 1.0.
+
 _Description_: Explicitly invoking the garbage collector is, except for specific uses in benchmarking, very dubious.
 
 The garbage collector can be configured through environment variables as [described here](https://pkg.go.dev/runtime).
@@ -251,6 +267,8 @@ The garbage collector can be configured through environment variables as [descri
 _Configuration_: N/A
 
 ## cognitive-complexity
+
+_Go version_: 1.0.
 
 _Description_: [Cognitive complexity](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) is a measure of how hard code is to understand.
 While cyclomatic complexity is good to measure "testability" of the code,
@@ -267,6 +285,8 @@ arguments = [7]
 ```
 
 ## comment-spacings
+
+_Go version_: 1.0.
 
 _Description_: Warns on malformed comments.
 Spots comments of the form:
@@ -299,6 +319,8 @@ arguments = ["mypragma:", "+optional"]
 
 ## comments-density
 
+_Go version_: 1.0.
+
 _Description_: Spots files not respecting a minimum value for the [_comments lines density_](https://docs.sonarsource.com/sonarqube/latest/user-guide/metric-definitions/)
 metric = _comment lines / (lines of code + comment lines) * 100_
 
@@ -313,11 +335,15 @@ arguments = [15]
 
 ## confusing-naming
 
+_Go version_: 1.0.
+
 _Description_: Methods or fields of `struct` that have names different only by capitalization could be confusing.
 
 _Configuration_: N/A
 
 ## confusing-results
+
+_Go version_: 1.0.
 
 _Description_: Function or methods that return multiple, no named, values of the same type could induce error.
 
@@ -341,11 +367,15 @@ _Configuration_: N/A
 
 ## constant-logical-expr
 
+_Go version_: 1.0.
+
 _Description_: The rule spots logical expressions that evaluate always to the same value.
 
 _Configuration_: N/A
 
 ## context-as-argument
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -367,6 +397,8 @@ arguments = [
 
 ## context-keys-type
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 **_Typed_**
@@ -376,6 +408,8 @@ _Description_: Basic types should not be used as a key in `context.WithValue`.
 _Configuration_: N/A
 
 ## cyclomatic
+
+_Go version_: 1.0.
 
 _Description_: [Cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) is a measure of code complexity.
 Enforcing a maximum complexity per function helps to keep code readable and maintainable.
@@ -391,6 +425,8 @@ arguments = [3]
 
 ## datarace
 
+_Go version_: 1.0; behavior changes in 1.22.
+
 _Description_: This rule spots potential dataraces caused by goroutines capturing (by-reference) particular identifiers of the function from
 which goroutines are created.
 The rule is able to spot two of such cases: go-routines capturing named return values, and capturing `for-range` values.
@@ -399,12 +435,16 @@ _Configuration_: N/A
 
 ## deep-exit
 
+_Go version_: 1.0.
+
 _Description_: Packages exposing functions that can stop program execution by exiting are hard to reuse.
 This rule looks for program exits in functions other than `main()` or `init()`.
 
 _Configuration_: N/A
 
 ## defer
+
+_Go version_: 1.0.
 
 _Description_: This rule warns on some common mistakes when using `defer` statement. It currently alerts on the following situations:
 
@@ -435,6 +475,8 @@ arguments = [["call-chain", "loop"]]
 
 ## dot-imports
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 _Description_: Importing with `.` makes the programs much harder to understand because it is unclear whether names belong to the current package or
@@ -460,11 +502,15 @@ arguments = [
 
 ## duplicated-imports
 
+_Go version_: 1.0.
+
 _Description_: It is possible to unintentionally import the same package twice. This rule looks for packages that are imported two or more times.
 
 _Configuration_: N/A
 
 ## early-return
+
+_Go version_: 1.0.
 
 _Description_: In Go it is idiomatic to minimize nesting statements, a typical example is to avoid if-then-else constructions.
 This rule spots constructions like
@@ -527,6 +573,8 @@ arguments = ["preserve-scope", "allow-jump"]
 ```
 
 ## empty-block
+
+_Go version_: 1.0.
 
 _Description_: Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
 
@@ -597,12 +645,16 @@ For more details, see:
 
 ## empty-lines
 
+_Go version_: 1.0.
+
 _Description_: Sometimes `gofmt` is not enough to enforce a common formatting of a code-base;
 this rule warns when there are heading or trailing newlines in code blocks.
 
 _Configuration_: N/A
 
 ## epoch-naming
+
+_Go version_: 1.0.
 
 **_Typed_**
 
@@ -646,6 +698,8 @@ _Configuration_: N/A
 
 ## enforce-map-style
 
+_Go version_: 1.0.
+
 _Description_: This rule enforces consistent usage of `make(map[type]type)` or `map[type]type{}` for map initialization.
 It does not affect `make(map[type]type, size)` constructions as well as `map[type]type{k1: v1}`.
 
@@ -663,6 +717,8 @@ arguments = ["make"]
 ```
 
 ## enforce-repeated-arg-type-style
+
+_Go version_: 1.0.
 
 _Description_: This rule is designed to maintain consistency in the declaration of repeated argument and return value types in Go functions.
 It supports three styles: 'any', 'short', and 'full'.
@@ -700,6 +756,8 @@ arguments = [{ func-arg-style = "full", func-ret-val-style = "short" }]
 
 ## enforce-slice-style
 
+_Go version_: 1.0.
+
 _Description_: This rule enforces consistent usage of `make([]type, 0)`, `[]type{}`, or `var []type` for slice initialization.
 It does not affect `make([]type, non_zero_len, or_non_zero_cap)` constructions as well as `[]type{v1}`.
 Nil slices are always permitted.
@@ -719,6 +777,8 @@ arguments = ["make"]
 ```
 
 ## enforce-switch-style
+
+_Go version_: 1.0.
 
 _Description_: This rule enforces consistent usage of `default` on `switch` statements.
 It can check for `default` case clause occurrence and/or position in the list of case clauses.
@@ -754,6 +814,8 @@ Notice that a configuration including both options will effectively deactivate t
 
 ## error-naming
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 _Description_: By convention, for the sake of readability, variables of type `error` must be named with the prefix `err`.
@@ -785,6 +847,8 @@ _Configuration_: N/A
 
 ## error-return
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 _Description_: By convention, for the sake of readability, the errors should be last in the list of returned values by a function.
@@ -811,6 +875,8 @@ _Configuration_: N/A
 
 ## error-strings
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 _Description_: By convention, for better readability, error messages should not be capitalized or end with punctuation or a newline.
@@ -831,6 +897,8 @@ arguments = ["xerrors.Errorf"]
 
 ## errorf
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 **_Typed_**
@@ -841,6 +909,8 @@ This rule spots that kind of simplification opportunities.
 _Configuration_: N/A
 
 ## exported
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -877,6 +947,8 @@ arguments = [
 
 ## file-header
 
+_Go version_: 1.0.
+
 _Description_: This rule helps to enforce a common header for all source files in a project by spotting those files that do not have the specified header.
 
 _Configuration_: (string) the header to look for in source files.
@@ -889,6 +961,8 @@ arguments = ["This is the text that must appear at the top of source files."]
 ```
 
 ## file-length-limit
+
+_Go version_: 1.0.
 
 _Description_: This rule enforces a maximum number of lines per file, in order to aid in maintainability and reduce complexity.
 
@@ -907,6 +981,8 @@ arguments = [{ max = 100, skip-comments = true, skip-blank-lines = true }]
 
 ## filename-format
 
+_Go version_: 1.0.
+
 _Description_: Enforces conventions on source file names. By default, the rule enforces filenames of the form `^[_A-Za-z0-9][_A-Za-z0-9-]*\.go$`.
 Optionally, the rule can be configured to enforce other forms.
 
@@ -921,6 +997,8 @@ arguments = ["^[_a-z][_a-z0-9]*\\.go$"]
 
 ## flag-parameter
 
+_Go version_: 1.0.
+
 _Description_: If a function controls the flow of another by passing it information on what to do, both functions are said to be [control-coupled](https://en.wikipedia.org/wiki/Coupling_(computer_programming)#Procedural_programming).
 Coupling among functions must be minimized for better maintainability of the code.
 This rule warns on boolean parameters that create a control coupling.
@@ -928,6 +1006,8 @@ This rule warns on boolean parameters that create a control coupling.
 _Configuration_: N/A
 
 ## forbidden-call-in-wg-go
+
+_Go version_: >= 1.25.
 
 _Description_: Since Go 1.25, it is possible to create goroutines with the method `waitgroup.Go`.
 The `Go` method calls a function in a new goroutine and adds (`Add`) that task to the WaitGroup.
@@ -984,6 +1064,8 @@ _Configuration_: N/A
 
 ## function-length
 
+_Go version_: 1.0.
+
 _Description_: Functions too long (with many statements and/or lines) can be hard to understand.
 
 _Configuration_: (int, int) the maximum allowed statements and lines.
@@ -1000,6 +1082,8 @@ Will check for functions exceeding 10 statements and will not check the number o
 
 ## function-result-limit
 
+_Go version_: 1.0.
+
 _Description_: Specifies the maximum number of results a function can return.
 Functions returning too many results can be hard to understand/use.
 
@@ -1014,6 +1098,8 @@ arguments = [3]
 
 ## get-return
 
+_Go version_: 1.0.
+
 _Description_: Warns on getters that do not yield any result.
 Typically, functions with names prefixed with _Get_ are supposed to return a value.
 
@@ -1021,11 +1107,15 @@ _Configuration_: N/A
 
 ## identical-branches
 
+_Go version_: 1.0.
+
 _Description_: An `if-then-else` conditional with identical implementations in both branches is an error.
 
 _Configuration_: N/A
 
 ## identical-ifelseif-branches
+
+_Go version_: 1.0.
 
 _Description_: An `if ... else if` chain with identical branches makes maintenance harder
 and might be a source of bugs. Duplicated branches should be consolidated in one.
@@ -1034,6 +1124,8 @@ _Configuration_: N/A
 
 ## identical-ifelseif-conditions
 
+_Go version_: 1.0.
+
 _Description_: An `if ... else if` chain with identical conditions can lead to
 unreachable code and is a potential source of bugs while making the code harder to read and maintain.
 
@@ -1041,11 +1133,15 @@ _Configuration_: N/A
 
 ## identical-switch-branches
 
+_Go version_: 1.0.
+
 _Description_: A `switch` with identical branches makes maintenance harder
 and might be a source of bugs. Duplicated branches should be consolidated
 in one case clause.
 
 ## identical-switch-conditions
+
+_Go version_: 1.0.
 
 _Description_: A `switch` statement with cases with the same condition can lead to
 unreachable code and is a potential source of bugs while making the code harder to read and maintain.
@@ -1053,6 +1149,8 @@ unreachable code and is a potential source of bugs while making the code harder 
 _Configuration_: N/A
 
 ## if-return
+
+_Go version_: 1.0.
 
 _Description_: Checking if an error is _nil_ to just after return the error or nil is redundant.
 
@@ -1080,6 +1178,8 @@ func do() error {
 _Configuration_: N/A
 
 ## import-alias-naming
+
+_Go version_: 1.0.
 
 _Description_: Aligns with Go's naming conventions, as outlined in the official
 [blog post](https://go.dev/blog/package-names). It enforces clear and lowercase import alias names, echoing
@@ -1113,6 +1213,8 @@ arguments = [{ allow-regex = "^[a-z][a-z0-9]{0,}$", deny-regex = '^v\d+$' }]
 
 ## import-shadowing
 
+_Go version_: 1.0.
+
 _Description_: In Go it is possible to declare identifiers (packages, structs,
 interfaces, parameters, receivers, variables, constants...) that conflict with the
 name of an imported package. This rule spots identifiers that shadow an import.
@@ -1123,6 +1225,8 @@ which allows identifiers like `v1`. This is a deliberate trade-off to keep the r
 _Configuration_: N/A
 
 ## imports-blocklist
+
+_Go version_: 1.0.
 
 _Description_: Warns when importing block-listed packages.
 
@@ -1136,6 +1240,8 @@ arguments = ["crypto/md5", "crypto/sha1", "crypto/**/pkix"]
 ```
 
 ## increment-decrement
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -1161,6 +1267,8 @@ count--
 _Configuration_: N/A
 
 ## indent-error-flow
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -1208,6 +1316,8 @@ arguments = ["preserve-scope"]
 
 ## inefficient-map-lookup
 
+_Go version_: 1.0.
+
 **_Typed_**
 
 _Description_: This rule identifies code that iteratively searches for a key in a map.
@@ -1254,6 +1364,8 @@ _Configuration_: N/A
 
 ## line-length-limit
 
+_Go version_: 1.0.
+
 _Description_: Warns in the presence of code lines longer than a configured maximum.
 
 _Configuration_: (int) maximum line length in characters. Default: `80`.
@@ -1266,6 +1378,8 @@ arguments = [80]
 ```
 
 ## marshal-receiver
+
+_Go version_: 1.0.
 
 _Description_: Checks receiver type consistency for common marshal/unmarshal methods.
 The rule inspects only methods whose names exactly match: `MarshalJSON`, `MarshalText`, `MarshalYAML`, `UnmarshalJSON`, `UnmarshalText`, and `UnmarshalYAML`.
@@ -1341,6 +1455,8 @@ _Configuration_: N/A
 
 ## max-control-nesting
 
+_Go version_: 1.0.
+
 _Description_: Warns if nesting level of control structures (`if-then-else`, `for`, `switch`) exceeds a given maximum.
 
 _Configuration_: (int) maximum accepted nesting level of control structures. Default: `5`.
@@ -1353,6 +1469,8 @@ arguments = [3]
 ```
 
 ## max-public-structs
+
+_Go version_: 1.0.
 
 _Description_: Packages declaring too many public structs can be hard to understand/use,
 and could be a symptom of bad design.
@@ -1370,6 +1488,8 @@ arguments = [3]
 
 ## modifies-parameter
 
+_Go version_: 1.0.
+
 _Description_: A function that modifies its parameters can be hard to understand.
 It can also be misleading if the arguments are passed by value by the caller.
 This rule warns when a function modifies one or more of its parameters or when
@@ -1378,6 +1498,8 @@ parameters are passed to functions that modify them (e.g. `slices.Delete`).
 _Configuration_: N/A
 
 ## modifies-value-receiver
+
+_Go version_: 1.0.
 
 **_Typed_**
 
@@ -1388,6 +1510,8 @@ This rule warns when a method modifies its receiver.
 _Configuration_: N/A
 
 ## multiline-if-init
+
+_Go version_: 1.0.
 
 _Description_: Flags `if` statements whose init clause spans multiple lines.
 The if-init idiom exists for tight one-liners.
@@ -1430,11 +1554,15 @@ _Configuration_: N/A
 
 ## nested-structs
 
+_Go version_: 1.0.
+
 _Description_: Packages declaring structs that contain other inline struct definitions can be hard to understand/read for other developers.
 
 _Configuration_: N/A
 
 ## optimize-operands-order
+
+_Go version_: 1.0.
 
 _Description_: Conditional expressions can be written to take advantage of short circuit evaluation and speed up its average evaluation time
 by forcing the evaluation of less time-consuming terms before more costly ones.
@@ -1458,6 +1586,8 @@ if !config.IgnoreGeneratedHeader && isGenerated(content) {
 
 ## package-comments
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 _Description_: Packages should have comments. This rule warns on undocumented packages and when packages comments are detached to the `package` keyword.
@@ -1467,6 +1597,8 @@ More [information here](https://go.dev/wiki/CodeReviewComments#package-comments)
 _Configuration_: N/A
 
 ## package-naming
+
+_Go version_: 1.0.
 
 _Description_: This rule checks that package names follow [Go conventions](https://go.dev/blog/package-names) and best practices.
 It helps prevent using bad package names and enforces consistent naming patterns.
@@ -1538,6 +1670,8 @@ arguments = [{ check-collision-with-all-std = true }]
 
 ## package-directory-mismatch
 
+_Go version_: 1.0.
+
 _Description_: It is considered a good practice to name a package after the directory containing it.
 This rule warns when the package name declared in the file does not match the name of the directory containing the file.
 
@@ -1580,6 +1714,8 @@ arguments = [{ ignore-directories = [] }]
 
 ## range-val-address
 
+_Go version_: < 1.22.
+
 **_Typed_**
 
 _Description_: Range variables in a loop are reused at each iteration.
@@ -1591,6 +1727,8 @@ _Note_: This rule is irrelevant for Go 1.22+.
 
 ## range-val-in-closure
 
+_Go version_: < 1.22.
+
 _Description_: Range variables in a loop are reused at each iteration; therefore a goroutine created in a loop will point to the range variable
 with from the upper scope. This way, the goroutine could use the variable with an undesired value.
 This rule warns when a range value (or index) is used inside a closure.
@@ -1600,6 +1738,8 @@ _Configuration_: N/A
 _Note_: This rule is irrelevant for Go 1.22+.
 
 ## range
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -1626,6 +1766,8 @@ for i := range items {
 _Configuration_: N/A
 
 ## receiver-naming
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -1673,6 +1815,8 @@ arguments = [{ max-length = 2 }]
 
 ## redefines-builtin-id
 
+_Go version_: 1.0; behavior changes in 1.21.
+
 _Description_: Constant names like `false`, `true`, `nil`, function names like `append`, `make`,
 and basic type names like `bool`, and `byte` are not reserved words of the language; therefore the can be redefined.
 Even if possible, redefining these built in names can lead to bugs very difficult to detect.
@@ -1680,6 +1824,8 @@ Even if possible, redefining these built in names can lead to bugs very difficul
 _Configuration_: N/A
 
 ## redundant-build-tag
+
+_Go version_: >= 1.17; behavior changes in 1.21.
 
 _Description_: This rule warns about redundant [build tag comments](https://pkg.go.dev/cmd/go@go1.17.0#hdr-Build_constraints).
 It detects unnecessary `// +build` comments when `//go:build` is present.
@@ -1729,11 +1875,15 @@ _Note_: This rule is irrelevant for Go 1.16-.
 
 ## redundant-import-alias
 
+_Go version_: 1.0.
+
 _Description_: This rule warns on redundant import aliases. This happens when the alias used on the import statement matches the imported package name.
 
 _Configuration_: N/A
 
 ## redundant-test-main-exit
+
+_Go version_: >= 1.15.
 
 _Description_: This rule warns about redundant `Exit` calls in the `TestMain` function,
 as the Go test runner automatically handles program termination starting from Go 1.15.
@@ -1743,6 +1893,8 @@ _Configuration_: N/A
 _Note_: This rule is irrelevant for Go 1.14-.
 
 ## string-format
+
+_Go version_: 1.0.
 
 _Description_: This rule allows you to configure a list of regular expressions that string literals in certain function calls are checked against.
 This is geared towards user facing applications where string literals are often used for messages that will be presented to users,
@@ -1797,6 +1949,8 @@ arguments = [
 
 ## string-of-int
 
+_Go version_: 1.0.
+
 **_Typed_**
 
 _Description_: Explicit type conversion `string(i)` where `i` has an integer type other than `rune` might behave not as expected by the developer
@@ -1805,6 +1959,8 @@ _Description_: Explicit type conversion `string(i)` where `i` has an integer typ
 _Configuration_: N/A
 
 ## struct-tag
+
+_Go version_: 1.0; behavior changes in 1.24.
 
 _Description_: The rule spots errors in struct tags.
 This is useful because struct tags are not checked at compile time.
@@ -1852,6 +2008,8 @@ arguments = ["!validate", "bson,outline,gnu"]
 
 ## superfluous-else
 
+_Go version_: 1.0.
+
 _Description_: To improve the readability of code, it is recommended to reduce the indentation as much as possible.
 This rule highlights redundant _else-blocks_ that can be eliminated when the preceding `if`-block deviates control flow,
 for example ending with a `break`, `continue`, `goto`, `panic` or `os.Exit` call (the `return` case is handled by [indent-error-flow](#indent-error-flow)).
@@ -1894,6 +2052,8 @@ arguments = ["preserve-scope"]
 ```
 
 ## time-date
+
+_Go version_: 1.0.
 
 _Description_: Reports bad usage of `time.Date`.
 
@@ -1968,6 +2128,8 @@ var _ = time.Date(2023, 01, 02, 03, 04, 00, 0, time.UTC)
 
 ## time-equal
 
+_Go version_: 1.0.
+
 **_Typed_**
 
 _Description_: This rule warns when using `==` and `!=` for equality checks on `time.Time` and suggests using the `time.Time.Equal` method.
@@ -1976,6 +2138,8 @@ For more information, see [this link](https://pkg.go.dev/time#Time).
 _Configuration_: N/A
 
 ## time-naming
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -1987,6 +2151,8 @@ this rule highlights those cases.
 _Configuration_: N/A
 
 ## unchecked-type-assertion
+
+_Go version_: 1.0.
 
 _Description_: This rule checks whether a type assertion result is checked (the `ok` value), preventing unexpected `panic`s.
 
@@ -2009,6 +2175,8 @@ arguments = [{ accept-ignored-assertion-result = true }]
 
 ## unconditional-recursion
 
+_Go version_: 1.0.
+
 _Description_: Unconditional recursive calls will produce infinite recursion, thus program stack overflow.
 This rule detects and warns about unconditional (direct) recursive calls.
 
@@ -2016,11 +2184,15 @@ _Configuration_: N/A
 
 ## unexported-naming
 
+_Go version_: 1.0.
+
 _Description_: this rule warns on wrongly named un-exported symbols, i.e. un-exported symbols whose name start with a capital letter.
 
 _Configuration_: N/A
 
 ## unexported-return
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -2031,6 +2203,8 @@ _Description_: This rule warns when an exported function or method returns a val
 _Configuration_: N/A
 
 ## unhandled-error
+
+_Go version_: 1.0.
 
 **_Typed_**
 
@@ -2052,6 +2226,8 @@ arguments = [
 ```
 
 ## unnecessary-if
+
+_Go version_: 1.0.
 
 _Description_: Detects unnecessary `if-else` statements that return or assign a boolean value
 based on a condition and suggests a simplified, direct return or assignment.
@@ -2086,12 +2262,16 @@ _Configuration_: N/A
 
 ## unnecessary-format
 
+_Go version_: 1.0.
+
 _Description_: This rule identifies calls to formatting functions where the format string does not contain any formatting verbs
 and recommends switching to the non-formatting, more efficient alternative.
 
 _Configuration_: N/A
 
 ## unnecessary-stmt
+
+_Go version_: 1.0.
 
 _Description_: This rule suggests to remove redundant statements like a `break` at the end of a case block, for improving the code's readability.
 
@@ -2119,6 +2299,8 @@ case "active":
 _Configuration_: N/A
 
 ## unreachable-code
+
+_Go version_: 1.0.
 
 _Description_: This rule spots and proposes to remove [unreachable code](https://en.wikipedia.org/wiki/Unreachable_code).
 
@@ -2150,6 +2332,8 @@ _Configuration_: N/A
 
 ## unsecure-url-scheme
 
+_Go version_: 1.0.
+
 _Description_: Checks for usage of potentially unsecure URL schemes (`http`, `ws`) in string literals.
 Using unencrypted URL schemes can expose sensitive data during transmission and
 make applications vulnerable to man-in-the-middle attacks.
@@ -2160,6 +2344,8 @@ _Configuration_: N/A
 The rule will not warn on local URLs (`localhost`, `127.0.0.1`).
 
 ## unused-parameter
+
+_Go version_: 1.0.
 
 _Description_: This rule warns on unused parameters. Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
 
@@ -2181,6 +2367,8 @@ arguments = [{ allow-regex = "^_" }]
 
 ## unused-receiver
 
+_Go version_: 1.0.
+
 _Description_: This rule warns on unused method receivers. Methods with unused receivers can be a symptom of an unfinished refactoring or a bug.
 
 _Configuration_:
@@ -2200,6 +2388,8 @@ arguments = [{ allow-regex = "^_" }]
 ```
 
 ## use-any
+
+_Go version_: >= 1.18.
 
 _Description_: This rule proposes to replace instances of `interface{}` with its alias [`any`](https://pkg.go.dev/builtin@go1.18.0#any).
 
@@ -2231,6 +2421,8 @@ _Note_: This rule is irrelevant for Go 1.17-.
 
 ## use-errors-new
 
+_Go version_: < 1.26.
+
 _Description_: This rule identifies calls to `fmt.Errorf` that can be safely replaced by, the more efficient, `errors.New`.
 This applies when the format string has no formatting verbs (no additional arguments are passed).
 
@@ -2259,6 +2451,8 @@ For unformatted strings, `fmt.Errorf("x")` generally [matches](https://go.dev/do
 
 ## use-fmt-print
 
+_Go version_: 1.0.
+
 _Description_: This rule proposes to replace calls to built-in `print` and `println` with their equivalents from `fmt` standard package.
 
 `print` and `println` built-in functions are not recommended for use-cases other than
@@ -2267,6 +2461,8 @@ _Description_: This rule proposes to replace calls to built-in `print` and `prin
 _Configuration_: N/A
 
 ## use-slices-sort
+
+_Go version_: >= 1.21.
 
 _Description_: Since Go 1.21 the `slices` package proposes methods that are faster and easier to use
 than their equivalents in `sort` package.
@@ -2299,6 +2495,8 @@ _Configuration_: N/A
 _Note_: This rule is irrelevant for Go 1.20-.
 
 ## use-waitgroup-go
+
+_Go version_: >= 1.25.
 
 _Description_: Since Go 1.25 the `sync` package proposes the [`WaitGroup.Go`](https://pkg.go.dev/sync#WaitGroup.Go) method.
 This method is a shorter and safer replacement for the idiom `wg.Add ... go { ... wg.Done ... }`.
@@ -2355,6 +2553,8 @@ _Note_: This rule is irrelevant for Go 1.24-.
 
 ## useless-break
 
+_Go version_: 1.0.
+
 _Description_: This rule warns on useless `break` statements in case clauses of switch and select statements. Go,
 unlike other programming languages like C, only executes statements of the selected case while ignoring the subsequent case clauses.
 Therefore, inserting a `break` at the end of a case clause has no effect.
@@ -2391,6 +2591,8 @@ for {
 _Configuration_: N/A
 
 ## useless-fallthrough
+
+_Go version_: 1.0.
 
 _Description_: This rule warns on useless `fallthrough` statements in case clauses of switch statements.
 A `fallthrough` is considered _useless_ if it's the single statement of a case clause block.
@@ -2430,6 +2632,8 @@ _Configuration_: N/A
 
 ## var-declaration
 
+_Go version_: 1.0.
+
 **_Ported from golint_**
 
 **_Typed_**
@@ -2439,6 +2643,8 @@ _Description_: This rule proposes simplifications of variable declarations.
 _Configuration_: N/A
 
 ## var-naming
+
+_Go version_: 1.0.
 
 **_Ported from golint_**
 
@@ -2474,6 +2680,8 @@ arguments = [["ID"], ["VM"], [{ upper-case-const = true }]]
 ```
 
 ## waitgroup-by-value
+
+_Go version_: 1.0.
 
 _Description_: Function parameters that are passed by value, are in fact a copy of the original argument.
 Passing a copy of a `sync.WaitGroup` is usually not what the developer wants to do.

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1009,7 +1009,7 @@ _Configuration_: N/A
 
 _Go version_: >= 1.25.
 
-_Description_: Since Go 1.25, it is possible to create goroutines with the method `waitgroup.Go`.
+_Description_: Since Go 1.25, it is possible to create goroutines with the method `WaitGroup.Go`.
 The `Go` method calls a function in a new goroutine and adds (`Add`) that task to the WaitGroup.
 When the function returns, the task is removed (`Done`) from the WaitGroup.
 


### PR DESCRIPTION
The available-rules table currently does not show which target Go versions each rule applies to. This makes version-gated rules difficult to identify without reading their implementations or individual descriptions.

Closes #1311
