### PR TITLE
rule: add no-increment-decrement rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ List of all [available rules](./RULES_DESCRIPTIONS.md).
 | [`modifies-parameter`](./RULES_DESCRIPTIONS.md#modifies-parameter)  |  n/a   | Warns on assignments to function parameters                      |    no    |  no   |
 | [`modifies-value-receiver`](./RULES_DESCRIPTIONS.md#modifies-value-receiver) |  n/a   | Warns on assignments to value-passed method receivers        |    no    |  yes  |
 | [`nested-structs`](./RULES_DESCRIPTIONS.md#nested-structs)          |  n/a   |  Warns on structs within structs |    no    |  no   |
+| [`no-increment-decrement`](./RULES_DESCRIPTIONS.md#no-increment-decrement) |  n/a   | Use `i += 1` and `i -= 1` instead of `i++` and `i--`.            |    no    |  no   |
 | [`optimize-operands-order`](./RULES_DESCRIPTIONS.md#optimize-operands-order)          |  n/a   |  Checks inefficient conditional expressions |    no    |  no   |
 | [`package-comments`](./RULES_DESCRIPTIONS.md#package-comments)    |  n/a   | Package commenting conventions.                                  |   yes    |  no   |
 | [`package-naming`](./RULES_DESCRIPTIONS.md#package-naming)    |  map   | Checks that package names follow Go conventions and best practices |   no    |  no   |

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -68,6 +68,7 @@ List of all available rules.
 - [modifies-value-receiver](#modifies-value-receiver)
 - [multiline-if-init](#multiline-if-init)
 - [nested-structs](#nested-structs)
+- [no-increment-decrement](#no-increment-decrement)
 - [optimize-operands-order](#optimize-operands-order)
 - [package-comments](#package-comments)
 - [package-naming](#package-naming)
@@ -1431,6 +1432,40 @@ _Configuration_: N/A
 ## nested-structs
 
 _Description_: Packages declaring structs that contain other inline struct definitions can be hard to understand/read for other developers.
+
+_Configuration_: N/A
+
+## no-increment-decrement
+
+_Description_: This rule is the opposite of [increment-decrement](#increment-decrement).
+Some coding styles prefer the explicit `i += 1` and `i -= 1` forms over the `i++` and `i--` operators,
+which are absent from many other languages and, in practice, are seldom used outside of loop counters.
+This rule spots `i++` and `i--` statements and proposes to change them into `i += 1` and `i -= 1`.
+Increment and decrement statements used as the post statement of a `for` loop are ignored, as that is
+the idiomatic place for a loop counter.
+
+### Examples (no-increment-decrement)
+
+Before (violation):
+
+```go
+i++
+count--
+```
+
+After (fixed):
+
+```go
+i += 1
+count -= 1
+```
+
+Loop counters are not flagged:
+
+```go
+for i := 0; i < n; i++ {
+}
+```
 
 _Configuration_: N/A
 

--- a/config/config.go
+++ b/config/config.go
@@ -124,6 +124,7 @@ var allRules = append([]lint.Rule{
 	&rule.PackageNamingRule{},
 	&rule.MultilineIfInitRule{},
 	&rule.MarshalReceiverRule{},
+	&rule.NoIncrementDecrementRule{},
 }, defaultRules...)
 
 // allFormatters is a list of all available formatters to output the linting results.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -533,7 +533,7 @@ func TestGetLintingRules(t *testing.T) {
 		// len of defaultRules
 		defaultRulesCount = 23
 		// len of allRules: update this when adding new rules
-		allRulesCount = 104
+		allRulesCount = 105
 	)
 
 	tt := map[string]struct {

--- a/rule/no_increment_decrement.go
+++ b/rule/no_increment_decrement.go
@@ -1,0 +1,76 @@
+package rule
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// NoIncrementDecrementRule suggests replacing `i++` and `i--` with `i += 1` and `i -= 1`,
+// except when they are used as the post statement of a for loop (i.e. as loop counters).
+// It is the opposite of the increment-decrement rule.
+type NoIncrementDecrementRule struct{}
+
+// Apply applies the rule to given file.
+func (*NoIncrementDecrementRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	var failures []lint.Failure
+
+	walker := &lintNoIncrementDecrement{
+		file:      file,
+		loopPosts: map[ast.Stmt]struct{}{},
+		onFailure: func(failure lint.Failure) {
+			failures = append(failures, failure)
+		},
+	}
+
+	ast.Walk(walker, file.AST)
+
+	return failures
+}
+
+// Name returns the rule name.
+func (*NoIncrementDecrementRule) Name() string {
+	return "no-increment-decrement"
+}
+
+type lintNoIncrementDecrement struct {
+	file      *lint.File
+	loopPosts map[ast.Stmt]struct{}
+	onFailure func(lint.Failure)
+}
+
+func (w *lintNoIncrementDecrement) Visit(n ast.Node) ast.Visitor {
+	switch stmt := n.(type) {
+	case *ast.ForStmt:
+		if stmt.Post != nil {
+			// The post statement of a for loop is the idiomatic place for a loop
+			// counter, so it is exempted from the rule.
+			w.loopPosts[stmt.Post] = struct{}{}
+		}
+	case *ast.IncDecStmt:
+		if _, isLoopPost := w.loopPosts[stmt]; isLoopPost {
+			return w
+		}
+
+		var replacement string
+		switch stmt.Tok {
+		case token.INC:
+			replacement = "+= 1"
+		case token.DEC:
+			replacement = "-= 1"
+		default:
+			return w
+		}
+
+		w.onFailure(lint.Failure{
+			Confidence: 0.8,
+			Node:       stmt,
+			Category:   lint.FailureCategoryUnaryOp,
+			Failure:    fmt.Sprintf("should replace %s with %s %s", w.file.Render(stmt), w.file.Render(stmt.X), replacement),
+		})
+	}
+
+	return w
+}

--- a/test/no_increment_decrement_test.go
+++ b/test/no_increment_decrement_test.go
@@ -1,0 +1,11 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestNoIncrementDecrement(t *testing.T) {
+	testRule(t, "no_increment_decrement", &rule.NoIncrementDecrementRule{})
+}

--- a/testdata/no_increment_decrement.go
+++ b/testdata/no_increment_decrement.go
@@ -1,0 +1,28 @@
+package fixtures
+
+func standaloneIncrementDecrement() {
+	x := 0
+	x++ // MATCH /should replace x++ with x += 1/
+	x-- // MATCH /should replace x-- with x -= 1/
+}
+
+func loopCounters() {
+	for i := 0; i < 10; i++ {
+		_ = i
+	}
+	for j := 10; j > 0; j-- {
+		_ = j
+	}
+}
+
+func incrementInLoopBody() {
+	count := 0
+	for range []int{1, 2, 3} {
+		count++ // MATCH /should replace count++ with count += 1/
+	}
+	_ = count
+}
+
+func selectorOperand(s *struct{ n int }) {
+	s.n++ // MATCH /should replace s.n++ with s.n += 1/
+}

--- a/untyped.toml
+++ b/untyped.toml
@@ -57,6 +57,7 @@
 [rule.marshal-receiver]
 [rule.modifies-parameter]
 [rule.nested-structs]
+[rule.no-increment-decrement]
 [rule.optimize-operands-order]
 [rule.package-comments]
 [rule.package-directory-mismatch]


### PR DESCRIPTION
This adds `no-increment-decrement`, a new rule that is the mirror image of the existing `increment-decrement` rule, for people who prefer the explicit `i += 1` / `i -= 1` forms over `i++` / `i--`.

As raised in #910, `increment-decrement` is opinionated in the direction of `++`/`--`, but plenty of styles (and languages) go the other way, and in practice `++`/`--` are rarely used in Go outside of loop counters. The new rule spots `i++` and `i--` statements and proposes replacing them with `i += 1` and `i -= 1`. Increment/decrement statements that appear as the post statement of a `for` loop are intentionally left alone, since that is the idiomatic place for a loop counter (see the `for i := 0; i < n; i++` example in the docs).

Like every other revive rule it is opt-in, so the default behaviour is unchanged. It works purely on the AST and requires no type information, so it is registered in `untyped.toml`.

Naming: I went with `no-increment-decrement` to make it easy to find as the counterpart of `increment-decrement`, but I'm happy to rename it if you'd prefer something else.

Changes:
- `rule/no_increment_decrement.go` — the rule.
- `test/no_increment_decrement_test.go` + `testdata/no_increment_decrement.go` — fixtures covering standalone `++`/`--`, a selector operand, a counter incremented inside a loop body (flagged), and `for`-loop counters (not flagged).
- Registered the rule in `config/config.go` and `untyped.toml`, bumped the rule count in `config/config_test.go`, and documented it in `RULES_DESCRIPTIONS.md`.

Testing: `go test ./...` passes, and both `revive --config revive.toml ./...` and `golangci-lint run` are clean on the new files.

Closes #910