### PR TITLE
line-length-limit: add excludes to skip lines matching regexps

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ List of all [available rules](./RULES_DESCRIPTIONS.md).
 | [`increment-decrement`](./RULES_DESCRIPTIONS.md#increment-decrement) |  n/a   | Use `i++` and `i--` instead of `i += 1` and `i -= 1`.            |   yes    |  no   |
 | [`indent-error-flow`](./RULES_DESCRIPTIONS.md#indent-error-flow)   |  []string   | Prevents redundant else statements.                              |   yes    |  no   |
 | [`inefficient-map-lookup`](./RULES_DESCRIPTIONS.md#inefficient-map-lookup)   |  n/a  | Spots iterative searches for a key in a map           |   no    |  yes   |
-| [`line-length-limit`](./RULES_DESCRIPTIONS.md#line-length-limit)   | int (defaults to 80) | Specifies the maximum number of characters in a line             |    no    |  no   |
+| [`line-length-limit`](./RULES_DESCRIPTIONS.md#line-length-limit)   | int or map | Specifies the maximum number of characters in a line, with optional per-line exclusions |    no    |  no   |
 | [`marshal-receiver`](./RULES_DESCRIPTIONS.md#marshal-receiver) |  n/a   | Checks receiver type consistency for common marshal/unmarshal methods. |    no    |  no   |
 | [`max-control-nesting`](./RULES_DESCRIPTIONS.md#max-control-nesting) |  int (defaults to 5)  | Sets restriction for maximum nesting of control structures. |    no    |  no   |
 | [`max-public-structs`](./RULES_DESCRIPTIONS.md#max-public-structs)  |  int (defaults to 5)  | The maximum number of public structs in a file.                  |    no    |  no   |

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1387,6 +1387,30 @@ arguments = [80]
 arguments = [{ max = 80, excludes = ['^\s*//go:generate ', 'https?://'] }]
 ```
 
+### Examples (line-length-limit)
+
+Given the configuration:
+
+```toml
+[rule.line-length-limit]
+arguments = [{ max = 80, excludes = ['^\s*//go:generate ', 'https?://'] }]
+```
+
+for the file:
+
+```go
+package example
+
+//go:generate stringer -type=Color -output=color_string.go -linecomment -trimprefix=Color
+
+// Reference: https://example.com/some/really/long/documentation/url/kept/for/context/here
+
+const greeting = "a long enough line of code to comfortably exceed the eighty character limit"
+```
+
+only the last line is reported.
+The `//go:generate` directive and the line containing a URL match the `excludes` patterns and are skipped, even though both exceed 80 characters.
+
 ## marshal-receiver
 
 _Go version_: 1.0.

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1256,13 +1256,25 @@ _Configuration_: N/A
 
 _Description_: Warns in the presence of code lines longer than a configured maximum.
 
-_Configuration_: (int) maximum line length in characters. Default: `80`.
+_Configuration_: the rule accepts either an integer (the maximum line length) or a map of options:
 
-Configuration example:
+- `max`: (int) maximum line length in characters. Default: `80`.
+- `excludes`: ([]string) list of regular expressions; a line matching any of them is not checked. Default: none.
+
+The integer form is a shorthand for setting only `max`.
+
+Configuration examples:
 
 ```toml
 [rule.line-length-limit]
 arguments = [80]
+```
+
+```toml
+[rule.line-length-limit]
+arguments = [
+  { max = 80, excludes = ['^\s*//go:generate ', 'https?://'] },
+]
 ```
 
 ## marshal-receiver

--- a/rule/line_length_limit.go
+++ b/rule/line_length_limit.go
@@ -24,19 +24,16 @@ const defaultLineLengthLimit = 80
 // Configure validates the rule configuration, and configures the rule accordingly.
 //
 // Configuration implements the [lint.ConfigurableRule] interface.
-//
-// It accepts either a single integer (the maximum line length) for backward
-// compatibility, or a map of options with the keys "max" (the maximum line
-// length) and "excludes" (a list of regular expressions; lines matching any of
-// them are not checked).
 func (r *LineLengthLimitRule) Configure(arguments lint.Arguments) error {
 	r.max = defaultLineLengthLimit
+	r.excludes = nil
 	if len(arguments) < 1 {
 		return nil
 	}
 
 	switch arg := arguments[0].(type) {
 	case int64:
+		// backward compatibility: if the first argument is an integer, it is treated as the maximum line length.
 		return r.setMax(arg)
 	case map[string]any:
 		return r.configureFromMap(arg)

--- a/rule/line_length_limit.go
+++ b/rule/line_length_limit.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"go/token"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -14,7 +15,8 @@ import (
 
 // LineLengthLimitRule lints the number of characters in a line.
 type LineLengthLimitRule struct {
-	max int
+	max      int
+	excludes []*regexp.Regexp
 }
 
 const defaultLineLengthLimit = 80
@@ -22,19 +24,87 @@ const defaultLineLengthLimit = 80
 // Configure validates the rule configuration, and configures the rule accordingly.
 //
 // Configuration implements the [lint.ConfigurableRule] interface.
+//
+// It accepts either a single integer (the maximum line length) for backward
+// compatibility, or a map of options with the keys "max" (the maximum line
+// length) and "excludes" (a list of regular expressions; lines matching any of
+// them are not checked).
 func (r *LineLengthLimitRule) Configure(arguments lint.Arguments) error {
+	r.max = defaultLineLengthLimit
 	if len(arguments) < 1 {
-		r.max = defaultLineLengthLimit
 		return nil
 	}
 
-	maxLength, ok := arguments[0].(int64) // Alt. non panicking version
-	if !ok || maxLength < 0 {
+	switch arg := arguments[0].(type) {
+	case int64:
+		return r.setMax(arg)
+	case map[string]any:
+		return r.configureFromMap(arg)
+	default:
+		return fmt.Errorf(`invalid argument to the "line-length-limit" rule: expecting an integer or an options map, got %T`, arguments[0])
+	}
+}
+
+func (r *LineLengthLimitRule) setMax(value int64) error {
+	if value < 0 {
 		return errors.New(`invalid value passed as argument number to the "line-length-limit" rule`)
 	}
 
-	r.max = int(maxLength)
+	r.max = int(value)
 	return nil
+}
+
+func (r *LineLengthLimitRule) configureFromMap(options map[string]any) error {
+	for k, v := range options {
+		switch {
+		case isRuleOption(k, "max"):
+			maxLength, ok := v.(int64)
+			if !ok {
+				return fmt.Errorf(`invalid value for the "max" option of the "line-length-limit" rule: expecting an integer, got %T`, v)
+			}
+
+			if err := r.setMax(maxLength); err != nil {
+				return err
+			}
+		case isRuleOption(k, "excludes"):
+			excludes, err := parseLineLengthExcludes(v)
+			if err != nil {
+				return err
+			}
+
+			r.excludes = excludes
+		}
+	}
+
+	return nil
+}
+
+func parseLineLengthExcludes(value any) ([]*regexp.Regexp, error) {
+	list, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf(`invalid value for the "excludes" option of the "line-length-limit" rule: expecting a slice of strings, got %T`, value)
+	}
+
+	excludes := make([]*regexp.Regexp, 0, len(list))
+	for _, v := range list {
+		pattern, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf(`invalid value in the "excludes" option of the "line-length-limit" rule: expecting a string, got %T`, v)
+		}
+
+		if pattern == "" {
+			return nil, errors.New(`invalid value in the "excludes" option of the "line-length-limit" rule: regular expression must not be empty`)
+		}
+
+		exp, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf(`invalid value in the "excludes" option of the "line-length-limit" rule: regexp %q does not compile: %w`, pattern, err)
+		}
+
+		excludes = append(excludes, exp)
+	}
+
+	return excludes, nil
 }
 
 // Apply applies the rule to given file.
@@ -42,8 +112,9 @@ func (r *LineLengthLimitRule) Apply(file *lint.File, _ lint.Arguments) []lint.Fa
 	var failures []lint.Failure
 
 	checker := lintLineLengthNum{
-		max:  r.max,
-		file: file,
+		max:      r.max,
+		excludes: r.excludes,
+		file:     file,
 		onFailure: func(failure lint.Failure) {
 			failures = append(failures, failure)
 		},
@@ -61,6 +132,7 @@ func (*LineLengthLimitRule) Name() string {
 
 type lintLineLengthNum struct {
 	max       int
+	excludes  []*regexp.Regexp
 	file      *lint.File
 	onFailure func(lint.Failure)
 }
@@ -72,6 +144,11 @@ func (r lintLineLengthNum) check() {
 	s := bufio.NewScanner(f)
 	for s.Scan() {
 		t := s.Text()
+		if r.isExcluded(t) {
+			l++
+			continue
+		}
+
 		t = strings.ReplaceAll(t, "\t", spaces)
 		c := utf8.RuneCountInString(t)
 		if c > r.max {
@@ -96,4 +173,15 @@ func (r lintLineLengthNum) check() {
 		}
 		l++
 	}
+}
+
+// isExcluded reports whether the raw line matches any of the configured exclude patterns.
+func (r lintLineLengthNum) isExcluded(line string) bool {
+	for _, exclude := range r.excludes {
+		if exclude.MatchString(line) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/rule/line_length_limit_test.go
+++ b/rule/line_length_limit_test.go
@@ -1,0 +1,144 @@
+package rule
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+)
+
+func TestLineLengthLimitRule_Configure(t *testing.T) {
+	tests := []struct {
+		name         string
+		arguments    lint.Arguments
+		wantErr      error
+		wantMax      int
+		wantExcludes []string
+	}{
+		{
+			name:      "no arguments",
+			arguments: lint.Arguments{},
+			wantErr:   nil,
+			wantMax:   80,
+		},
+		{
+			name:      "integer argument",
+			arguments: lint.Arguments{int64(100)},
+			wantErr:   nil,
+			wantMax:   100,
+		},
+		{
+			name:      "negative integer argument",
+			arguments: lint.Arguments{int64(-1)},
+			wantErr:   errors.New(`invalid value passed as argument number to the "line-length-limit" rule`),
+		},
+		{
+			name: "valid map arguments",
+			arguments: lint.Arguments{map[string]any{
+				"max":      int64(100),
+				"excludes": []any{`^\s*//go:generate `, `https?://`},
+			}},
+			wantErr:      nil,
+			wantMax:      100,
+			wantExcludes: []string{`^\s*//go:generate `, `https?://`},
+		},
+		{
+			name: "valid capitalized max option",
+			arguments: lint.Arguments{map[string]any{
+				"Max": int64(100),
+			}},
+			wantErr: nil,
+			wantMax: 100,
+		},
+		{
+			name: "map without max keeps default",
+			arguments: lint.Arguments{map[string]any{
+				"excludes": []any{`https?://`},
+			}},
+			wantErr:      nil,
+			wantMax:      80,
+			wantExcludes: []string{`https?://`},
+		},
+		{
+			name:      "invalid argument type",
+			arguments: lint.Arguments{"invalid"},
+			wantErr:   errors.New(`invalid argument to the "line-length-limit" rule: expecting an integer or an options map, got string`),
+		},
+		{
+			name: "invalid max type",
+			arguments: lint.Arguments{map[string]any{
+				"max": "invalid",
+			}},
+			wantErr: errors.New(`invalid value for the "max" option of the "line-length-limit" rule: expecting an integer, got string`),
+		},
+		{
+			name: "negative max option",
+			arguments: lint.Arguments{map[string]any{
+				"max": int64(-1),
+			}},
+			wantErr: errors.New(`invalid value passed as argument number to the "line-length-limit" rule`),
+		},
+		{
+			name: "invalid excludes type",
+			arguments: lint.Arguments{map[string]any{
+				"excludes": "invalid",
+			}},
+			wantErr: errors.New(`invalid value for the "excludes" option of the "line-length-limit" rule: expecting a slice of strings, got string`),
+		},
+		{
+			name: "invalid excludes element type",
+			arguments: lint.Arguments{map[string]any{
+				"excludes": []any{123},
+			}},
+			wantErr: errors.New(`invalid value in the "excludes" option of the "line-length-limit" rule: expecting a string, got int`),
+		},
+		{
+			name: "empty excludes pattern",
+			arguments: lint.Arguments{map[string]any{
+				"excludes": []any{""},
+			}},
+			wantErr: errors.New(`invalid value in the "excludes" option of the "line-length-limit" rule: regular expression must not be empty`),
+		},
+		{
+			name: "excludes pattern that does not compile",
+			arguments: lint.Arguments{map[string]any{
+				"excludes": []any{"("},
+			}},
+			wantErr: errors.New("invalid value in the \"excludes\" option of the \"line-length-limit\" rule: regexp \"(\" does not compile: error parsing regexp: missing closing ): `(`"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rule LineLengthLimitRule
+
+			err := rule.Configure(tt.arguments)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("unexpected error: got = nil, want = %v", tt.wantErr)
+					return
+				}
+				if err.Error() != tt.wantErr.Error() {
+					t.Errorf("unexpected error: got = %v, want = %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: got = %v, want = nil", err)
+			}
+			if rule.max != tt.wantMax {
+				t.Errorf("unexpected max: got = %v, want %v", rule.max, tt.wantMax)
+			}
+
+			gotExcludes := make([]string, 0, len(rule.excludes))
+			for _, exclude := range rule.excludes {
+				gotExcludes = append(gotExcludes, exclude.String())
+			}
+			if !slices.Equal(gotExcludes, tt.wantExcludes) {
+				t.Errorf("unexpected excludes: got = %v, want %v", gotExcludes, tt.wantExcludes)
+			}
+		})
+	}
+}

--- a/test/line_length_limit_test.go
+++ b/test/line_length_limit_test.go
@@ -16,3 +16,24 @@ func TestLineLengthLimit(t *testing.T) {
 		Arguments: lint.Arguments{int64(100)},
 	})
 }
+
+func TestLineLengthLimitWithMaxOption(t *testing.T) {
+	testRule(t, "line_length_limit", &rule.LineLengthLimitRule{}, &lint.RuleConfig{
+		Arguments: lint.Arguments{map[string]any{"max": int64(100)}},
+	})
+}
+
+func TestLineLengthLimitExcludes(t *testing.T) {
+	testRule(t, "line_length_limit_excludes", &rule.LineLengthLimitRule{}, &lint.RuleConfig{
+		Arguments: lint.Arguments{map[string]any{
+			"max":      int64(80),
+			"excludes": []any{`^\s*//go:generate `, `https?://`},
+		}},
+	})
+	testRule(t, "line_length_limit_excludes", &rule.LineLengthLimitRule{}, &lint.RuleConfig{
+		Arguments: lint.Arguments{map[string]any{
+			"Max":      int64(80),
+			"excludes": []any{`^\s*//go:generate `, `https?://`},
+		}},
+	})
+}

--- a/testdata/line_length_limit_excludes.go
+++ b/testdata/line_length_limit_excludes.go
@@ -1,0 +1,15 @@
+package fixtures
+
+//go:generate echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+// A reference to https://example.com/very/long/path/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+// A perfectly ordinary but very long comment line that clearly exceeds the eighty character budget
+
+func foo() {
+	_ = "url inside code https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	_ = "no url here just a long enough string literal to exceed the eighty character line length yyy"
+}
+
+// MATCH:7 /line is 99 characters, out of limit 80/
+// MATCH:11 /line is 102 characters, out of limit 80/


### PR DESCRIPTION
This adds an `excludes` option to the `line-length-limit` rule so lines matching a configured regular expression are skipped.

Resolves #778.

Some lines are unavoidably long and can't be wrapped, most commonly `//go:generate` directives and URLs. Right now the only way to keep them is a per-line `// revive:disable:line-length-limit` comment, which gets noisy when a file has several of them. The standalone `lll` linter handles this with an `exclude` parameter, so this brings the same idea to revive.

To stay backward compatible the rule now accepts either the existing integer argument or a map with `max` and `excludes` keys, so current configs keep working unchanged:

```toml
[rule.line-length-limit]
arguments = [
  { max = 80, excludes = ['^\s*//go:generate ', 'https?://'] },
]
```

I added a fixture and tests for the exclusion matching (a URL in the middle of an indented line, a `//go:generate` line, and a long line that should still be flagged) plus a test for the `max` map option, and kept the original integer-argument tests.