### PR TITLE
chore: use Go 1.26 for linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go and register problem matcher
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: stable
+          go-version: '1.26'
 
       - name: Install revive
         run: go install


### PR DESCRIPTION
It will be changed to the `stable` (Go `1.27`) when we upgrade to Golangci-lint 2.13.