### PR TITLE
feat(identical-switch-branches): add allow-identical-default option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ The canonical example is [`rule/argument_limit.go`](rule/argument_limit.go). For
 
     If the rule takes arguments, also implement `lint.ConfigurableRule.Configure(lint.Arguments) error`.
     Validate arguments there and return errors rather than panicking.
+    Any newly added option must be passed as a `map[string]any` (a single map argument with named keys),
+    not as a positional/scalar argument — this keeps rule configuration extensible and self-documenting.
 2. **Naming** — `Name()` returns `kebab-case` (e.g. `argument-limit`).
    The Go type is `ArgumentsLimitRule`. Source file is `argument_limit.go`. Keep these three in lockstep.
 3. **Concurrency** — `Apply` may be called concurrently for different files.

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ List of all [available rules](./RULES_DESCRIPTIONS.md).
 | [`identical-branches`](./RULES_DESCRIPTIONS.md#identical-branches)          |  n/a   | Spots if-then-else statements with identical `then` and `else` branches       | 1.0 |    no    |  no   |
 | [`identical-ifelseif-branches`](./RULES_DESCRIPTIONS.md#identical-ifelseif-branches)          |  n/a   | Spots `if ... else if` chains with identical branches.       | 1.0 |    no    |  no   |
 | [`identical-ifelseif-conditions`](./RULES_DESCRIPTIONS.md#identical-ifelseif-conditions)          |  n/a   | Spots identical conditions in  `if ... else if` chains.       | 1.0 |    no    |  no   |
-| [`identical-switch-branches`](./RULES_DESCRIPTIONS.md#identical-switch-branches)          |  n/a   | Spots `switch` with identical branches.       | 1.0 |    no    |  no   |
+| [`identical-switch-branches`](./RULES_DESCRIPTIONS.md#identical-switch-branches)          |  map   | Spots `switch` with identical branches.       | 1.0 |    no    |  no   |
 | [`identical-switch-conditions`](./RULES_DESCRIPTIONS.md#identical-switch-conditions)          |  n/a   | Spots identical conditions in case clauses of `switch` statements.       | 1.0 |    no    |  no   |
 | [`if-return`](./RULES_DESCRIPTIONS.md#if-return)           |  n/a   | Redundant if when returning an error.                            | 1.0 |   no    |  no   |
 | [`import-alias-naming`](./RULES_DESCRIPTIONS.md#import-alias-naming)         | string or map[string]string (defaults to allow regex pattern `^[a-z][a-z0-9]{0,}$`) | Conventions around the naming of import aliases.                              | 1.0 |    no    |  no   |

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1139,6 +1139,23 @@ _Description_: A `switch` with identical branches makes maintenance harder
 and might be a source of bugs. Duplicated branches should be consolidated
 in one case clause.
 
+_Configuration_: ([]string) Specifies exceptions to the rule. The available option is:
+
+- "allow-identical-default": do not report a `default` case clause that is identical to another
+  case clause.
+
+Configuration example:
+
+When switching over values from an external package, spelling out a fallback that repeats a
+listed case can be deliberate: it documents which values are explicitly handled and that
+everything else lands on the same code. To keep the rule for identical `case` clauses while
+allowing that:
+
+```toml
+[rule.identical-switch-branches]
+arguments = ["allow-identical-default"]
+```
+
 ## identical-switch-conditions
 
 _Go version_: 1.0.

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -1135,25 +1135,36 @@ _Configuration_: N/A
 
 _Go version_: 1.0.
 
-_Description_: A `switch` with identical branches makes maintenance harder
-and might be a source of bugs. Duplicated branches should be consolidated
-in one case clause.
+_Description_: A `switch` with identical branches makes maintenance harder and might be a source of bugs.
+Duplicated branches should be consolidated in one case clause.
 
-_Configuration_: ([]string) Specifies exceptions to the rule. The available option is:
+_Configuration_: (optional) single map of options (`map[string]any`), provided as the single configuration argument in the rule's arguments array.
 
-- "allow-identical-default": do not report a `default` case clause that is identical to another
-  case clause.
+- `allow-identical-default`: (bool) If `true`, do not report a `default` case clause that is identical to another case clause. Default: `false`.
 
-Configuration example:
+### Examples (identical-switch-branches)
 
-When switching over values from an external package, spelling out a fallback that repeats a
-listed case can be deliberate: it documents which values are explicitly handled and that
-everything else lands on the same code. To keep the rule for identical `case` clauses while
-allowing that:
+When switching over values from an external package, spelling out a fallback that repeats a listed case can be deliberate:
+it documents which values are explicitly handled and that everything else lands on the same code.
+
+```go
+switch http.SameSite(s) {
+case http.SameSiteNoneMode:
+	return SameSiteNoneMode
+case http.SameSiteLaxMode:
+	return SameSiteLaxMode
+case http.SameSiteStrictMode:
+	return SameSiteStrictMode
+default:
+	return SameSiteLaxMode
+}
+```
+
+To keep the rule for identical `case` clauses while allowing that:
 
 ```toml
 [rule.identical-switch-branches]
-arguments = ["allow-identical-default"]
+arguments = [{ allow-identical-default = true }]
 ```
 
 ## identical-switch-conditions

--- a/rule/identical_switch_branches.go
+++ b/rule/identical_switch_branches.go
@@ -18,17 +18,25 @@ type IdenticalSwitchBranchesRule struct {
 //
 // Configuration implements the [lint.ConfigurableRule] interface.
 func (r *IdenticalSwitchBranchesRule) Configure(arguments lint.Arguments) error {
-	for _, arg := range arguments {
-		argStr, ok := arg.(string)
-		if !ok {
-			return fmt.Errorf("invalid argument for rule %s; expected string but got %T", r.Name(), arg)
-		}
+	if len(arguments) < 1 {
+		return nil // use defaults
+	}
 
+	argKV, ok := arguments[0].(map[string]any)
+	if !ok {
+		return fmt.Errorf("invalid argument to the %s rule. Expecting a k,v map, got %T", r.Name(), arguments[0])
+	}
+
+	for k, v := range argKV {
 		switch {
-		case isRuleOption(argStr, "allowIdenticalDefault"):
-			r.allowIdenticalDefault = true
+		case isRuleOption(k, "allowIdenticalDefault"):
+			allow, ok := v.(bool)
+			if !ok {
+				return fmt.Errorf("invalid configuration value for %q in %s rule; need bool but got %T", k, r.Name(), v)
+			}
+			r.allowIdenticalDefault = allow
 		default:
-			return fmt.Errorf(`invalid argument %q for rule %s; expected "allow-identical-default"`, argStr, r.Name())
+			return fmt.Errorf(`invalid argument %q for rule %s; expected "allow-identical-default"`, k, r.Name())
 		}
 	}
 

--- a/rule/identical_switch_branches.go
+++ b/rule/identical_switch_branches.go
@@ -10,10 +10,33 @@ import (
 )
 
 // IdenticalSwitchBranchesRule warns on identical switch branches.
-type IdenticalSwitchBranchesRule struct{}
+type IdenticalSwitchBranchesRule struct {
+	allowIdenticalDefault bool // allow the default clause to be identical to a case clause
+}
+
+// Configure validates the rule configuration, and configures the rule accordingly.
+//
+// Configuration implements the [lint.ConfigurableRule] interface.
+func (r *IdenticalSwitchBranchesRule) Configure(arguments lint.Arguments) error {
+	for _, arg := range arguments {
+		argStr, ok := arg.(string)
+		if !ok {
+			return fmt.Errorf("invalid argument for rule %s; expected string but got %T", r.Name(), arg)
+		}
+
+		switch {
+		case isRuleOption(argStr, "allowIdenticalDefault"):
+			r.allowIdenticalDefault = true
+		default:
+			return fmt.Errorf(`invalid argument %q for rule %s; expected "allow-identical-default"`, argStr, r.Name())
+		}
+	}
+
+	return nil
+}
 
 // Apply applies the rule to given file.
-func (*IdenticalSwitchBranchesRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+func (r *IdenticalSwitchBranchesRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
 	var failures []lint.Failure
 
 	onFailure := func(failure lint.Failure) {
@@ -24,7 +47,11 @@ func (*IdenticalSwitchBranchesRule) Apply(file *lint.File, _ lint.Arguments) []l
 		return file.ToPosition(s.Pos()).Line
 	}
 
-	w := &lintIdenticalSwitchBranches{getStmtLine: getStmtLine, onFailure: onFailure}
+	w := &lintIdenticalSwitchBranches{
+		getStmtLine:           getStmtLine,
+		onFailure:             onFailure,
+		allowIdenticalDefault: r.allowIdenticalDefault,
+	}
 	for _, decl := range file.AST.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
@@ -43,8 +70,9 @@ func (*IdenticalSwitchBranchesRule) Name() string {
 }
 
 type lintIdenticalSwitchBranches struct {
-	getStmtLine func(ast.Stmt) int
-	onFailure   func(lint.Failure)
+	getStmtLine           func(ast.Stmt) int
+	onFailure             func(lint.Failure)
+	allowIdenticalDefault bool
 }
 
 func (w *lintIdenticalSwitchBranches) Visit(node ast.Node) ast.Visitor {
@@ -66,11 +94,23 @@ func (w *lintIdenticalSwitchBranches) Visit(node ast.Node) ast.Visitor {
 		return ok && ft.Tok == token.FALLTHROUGH
 	}
 
+	// A case clause with no expression list is the default clause.
+	isDefault := func(cc *ast.CaseClause) bool { return cc.List == nil }
+
 	hashes := map[string]int{} // map hash(branch code) -> branch line
 	for _, cc := range switchStmt.Body.List {
 		caseClause := cc.(*ast.CaseClause)
 		if doesFallthrough(caseClause.Body) {
 			continue // skip fallthrough branches
+		}
+
+		if w.allowIdenticalDefault && isDefault(caseClause) {
+			// Spelling out a fallback that repeats a listed case is a documented choice: it says
+			// which values are explicitly handled and that anything else lands on the same code.
+			// Walk into it so nested switches are still analyzed, but neither report it nor record
+			// its hash, so a later clause cannot be reported against it either.
+			ast.Walk(w, &ast.BlockStmt{List: caseClause.Body})
+			continue
 		}
 		branch := &ast.BlockStmt{
 			List: caseClause.Body,

--- a/rule/identical_switch_branches_test.go
+++ b/rule/identical_switch_branches_test.go
@@ -1,0 +1,100 @@
+package rule
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mgechev/revive/lint"
+)
+
+func TestIdenticalSwitchBranchesRule_Configure(t *testing.T) {
+	tests := []struct {
+		name                      string
+		arguments                 lint.Arguments
+		wantErr                   error
+		wantAllowIdenticalDefault bool
+	}{
+		{
+			name:                      "no arguments",
+			arguments:                 lint.Arguments{},
+			wantErr:                   nil,
+			wantAllowIdenticalDefault: false,
+		},
+		{
+			name: "allow-identical-default enabled",
+			arguments: lint.Arguments{map[string]any{
+				"allow-identical-default": true,
+			}},
+			wantErr:                   nil,
+			wantAllowIdenticalDefault: true,
+		},
+		{
+			name: "allow-identical-default disabled",
+			arguments: lint.Arguments{map[string]any{
+				"allow-identical-default": false,
+			}},
+			wantErr:                   nil,
+			wantAllowIdenticalDefault: false,
+		},
+		{
+			name: "camelCased argument",
+			arguments: lint.Arguments{map[string]any{
+				"allowIdenticalDefault": true,
+			}},
+			wantErr:                   nil,
+			wantAllowIdenticalDefault: true,
+		},
+		{
+			name: "lowercased argument",
+			arguments: lint.Arguments{map[string]any{
+				"allowidenticaldefault": true,
+			}},
+			wantErr:                   nil,
+			wantAllowIdenticalDefault: true,
+		},
+		{
+			name:      "invalid argument type",
+			arguments: lint.Arguments{123},
+			wantErr:   errors.New("invalid argument to the identical-switch-branches rule. Expecting a k,v map, got int"),
+		},
+		{
+			name: "invalid allow-identical-default type",
+			arguments: lint.Arguments{map[string]any{
+				"allow-identical-default": "invalid",
+			}},
+			wantErr: errors.New(`invalid configuration value for "allow-identical-default" in identical-switch-branches rule; need bool but got string`),
+		},
+		{
+			name: "unknown option",
+			arguments: lint.Arguments{map[string]any{
+				"unknown": true,
+			}},
+			wantErr: errors.New(`invalid argument "unknown" for rule identical-switch-branches; expected "allow-identical-default"`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rule IdenticalSwitchBranchesRule
+
+			err := rule.Configure(tt.arguments)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("unexpected error: got = nil, want = %v", tt.wantErr)
+					return
+				}
+				if err.Error() != tt.wantErr.Error() {
+					t.Errorf("unexpected error: got = %v, want = %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: got = %v, want = nil", err)
+			}
+			if rule.allowIdenticalDefault != tt.wantAllowIdenticalDefault {
+				t.Errorf("unexpected allowIdenticalDefault: got = %v, want %v", rule.allowIdenticalDefault, tt.wantAllowIdenticalDefault)
+			}
+		})
+	}
+}

--- a/test/identical_switch_branches_test.go
+++ b/test/identical_switch_branches_test.go
@@ -3,9 +3,13 @@ package test_test
 import (
 	"testing"
 
+	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/rule"
 )
 
 func TestIdenticalSwitchBranches(t *testing.T) {
 	testRule(t, "identical_switch_branches", &rule.IdenticalSwitchBranchesRule{})
+	testRule(t, "identical_switch_branches_allow_identical_default", &rule.IdenticalSwitchBranchesRule{}, &lint.RuleConfig{
+		Arguments: lint.Arguments{"allow-identical-default"},
+	})
 }

--- a/test/identical_switch_branches_test.go
+++ b/test/identical_switch_branches_test.go
@@ -10,6 +10,6 @@ import (
 func TestIdenticalSwitchBranches(t *testing.T) {
 	testRule(t, "identical_switch_branches", &rule.IdenticalSwitchBranchesRule{})
 	testRule(t, "identical_switch_branches_allow_identical_default", &rule.IdenticalSwitchBranchesRule{}, &lint.RuleConfig{
-		Arguments: lint.Arguments{"allow-identical-default"},
+		Arguments: lint.Arguments{map[string]any{"allow-identical-default": true}},
 	})
 }

--- a/testdata/identical_switch_branches_allow_identical_default.go
+++ b/testdata/identical_switch_branches_allow_identical_default.go
@@ -1,0 +1,58 @@
+package fixtures
+
+func identicalSwitchBranchesAllowIdenticalDefault() {
+	// The point of the option: a fallback that repeats a listed case is a
+	// deliberate choice, so it must not be reported...
+	switch a {
+	case 1:
+		foo()
+	case 2:
+		bar()
+	default:
+		foo()
+	}
+
+	// ...but identical *case* clauses are still reported, default or not.
+	switch a { // MATCH /"switch" with identical branches (lines 17 and 21)/
+	case 1:
+		foo()
+	case 2:
+		bar()
+	case 3:
+		foo()
+	default:
+		bar()
+	}
+
+	// An empty default matching an empty case is still allowed.
+	switch a {
+	case 1:
+
+	default:
+
+	}
+
+	// Nested switches inside an ignored default are still analyzed.
+	switch a {
+	case 1:
+		foo()
+	default:
+		switch b { // MATCH /"switch" with identical branches (lines 41 and 43)/
+		case 1:
+			bar()
+		case 2:
+			bar()
+		}
+	}
+
+	// Fallthrough handling is unchanged.
+	switch a {
+	case 1:
+		foo()
+		fallthrough
+	case 2:
+		bar()
+	default:
+		bar()
+	}
+}


### PR DESCRIPTION
Closes #1546.

## What

Adds an `allow-identical-default` option to `identical-switch-branches`.

Switching over values from an external package, a fallback that repeats a listed case is often deliberate — it documents which values are explicitly handled and that everything else lands on the same code. Today the rule reports that, and the only ways out are disabling the rule or annotating each switch, both of which also give up the identical-*case* check, which is the part that finds bugs.

## Behaviour

With the option set, a `default` clause:

- is not reported against an earlier branch, **and**
- does not record its own hash, so a later clause cannot be reported against it either

Its body is still walked, so a nested `switch` inside an ignored `default` is analyzed as before. Identical `case` clauses are still reported, and `fallthrough` handling is untouched. Default behaviour is unchanged — the existing `identical_switch_branches` fixture passes as-is.

Follows the `enforce-switch-style` pattern: a `Configure` method, `isRuleOption` for the name, and an error naming the valid option for anything else.

## Testing

New fixture `testdata/identical_switch_branches_allow_identical_default.go` covering: a default identical to a case (not reported), two identical *cases* alongside a default (still reported), an empty default matching an empty case, a nested switch inside an ignored default (still analyzed), and a fallthrough case.

I also checked the option is actually load-bearing rather than the fixture just being permissive — running the same fixture with the rule at its defaults produces **four** additional failures that the option suppresses:

```
got:  "switch" with identical branches (lines 7 and 11)
got:  "switch" with identical branches (lines 19 and 23)
got:  "switch" with identical branches (lines 29 and 31)
got:  "switch" with identical branches (lines 53 and 55)
```

```
go test ./...                      # all packages ok
go vet ./...                       # clean
gofmt -l .                         # clean
go run . --config revive.toml ./...  # clean (revive on itself)
```

`RULES_DESCRIPTIONS.md` documents the option with a config example.

## Naming

I went with `allow-identical-default` to sit beside `enforce-switch-style`'s `allow-no-default` / `allow-default-not-last`. Happy to rename if you'd prefer something like `ignore-default`.
