### PR TITLE
refactor(cli): return an exit code from RunRevive instead of calling os.Exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,13 +704,15 @@ The full rule set of `revive` is also actionable by your application.
 package main
 
 import (
+	"os"
+
 	"github.com/mgechev/revive/cli"
 	"github.com/mgechev/revive/lint"
 	"github.com/mgechev/revive/revivelib"
 )
 
 func main() {
-	cli.RunRevive(revivelib.NewExtraRule(&myRule{}, lint.RuleConfig{}))
+	os.Exit(cli.RunRevive(revivelib.NewExtraRule(&myRule{}, lint.RuleConfig{})))
 }
 
 type myRule struct{}

--- a/cli/main.go
+++ b/cli/main.go
@@ -32,25 +32,34 @@ var (
 	AppFs = afero.NewOsFs()
 )
 
-func fail(err string) {
-	fmt.Fprintln(os.Stderr, err)
-	os.Exit(1) //revive:disable-line:deep-exit
+// RunRevive runs the CLI for revive and returns the exit code the process should
+// terminate with. It does not terminate the process itself: exiting is the caller's
+// decision, so revive can be embedded without taking the host process down with it.
+func RunRevive(extraRules ...revivelib.ExtraRule) int {
+	exitCode, err := runRevive(extraRules...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	return exitCode
 }
 
-// RunRevive runs the CLI for revive.
-func RunRevive(extraRules ...revivelib.ExtraRule) {
+// runRevive holds the actual CLI logic, reporting failures as errors so that every
+// path out of it is a return rather than an exit.
+func runRevive(extraRules ...revivelib.ExtraRule) (int, error) {
 	// Move parsing flags outside of init(); otherwise, tests don't work properly.
 	// More info: https://github.com/golang/go/issues/46869#issuecomment-865695953
 	initConfig()
 
 	if versionFlag {
 		fmt.Print(getVersion(builtBy, date, commit, version))
-		return
+		return 0, nil
 	}
 
 	conf, err := config.GetConfig(configPath)
 	if err != nil {
-		fail(err.Error())
+		return 0, err
 	}
 
 	revive, err := revivelib.New(
@@ -60,7 +69,7 @@ func RunRevive(extraRules ...revivelib.ExtraRule) {
 		extraRules...,
 	)
 	if err != nil {
-		fail(err.Error())
+		return 0, err
 	}
 
 	files := flag.Args()
@@ -76,19 +85,19 @@ func RunRevive(extraRules ...revivelib.ExtraRule) {
 
 	failures, err := revive.Lint(packages...)
 	if err != nil {
-		fail(err.Error())
+		return 0, err
 	}
 
 	output, exitCode, err := revive.Format(formatterName, failures)
 	if err != nil {
-		fail(err.Error())
+		return 0, err
 	}
 
 	if output != "" {
 		fmt.Println(output)
 	}
 
-	os.Exit(exitCode) //revive:disable-line:deep-exit
+	return exitCode, nil
 }
 
 var (

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// runReviveWith drives RunRevive with a clean flag set, since initConfig registers
+// flags on the global CommandLine and would panic on a second registration.
+func runReviveWith(t *testing.T, args ...string) int {
+	t.Helper()
+
+	oldArgs, oldCommandLine, oldUsage := os.Args, flag.CommandLine, flag.Usage
+	t.Cleanup(func() {
+		os.Args, flag.CommandLine, flag.Usage = oldArgs, oldCommandLine, oldUsage
+		versionFlag, configPath, formatterName = false, "", ""
+		setExitStatus, maxOpenFiles, excludePatterns = false, 0, nil
+	})
+
+	flag.CommandLine = flag.NewFlagSet("revive", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	excludePatterns = nil
+	os.Args = append([]string{"revive"}, args...)
+
+	return RunRevive()
+}
+
+// The point of returning the code instead of calling os.Exit: this test can exist at
+// all. Before, a bad config reached fail() -> os.Exit(1), which took the test binary
+// down with it, so no test could observe the failure path.
+func TestRunReviveReturnsOneOnUnreadableConfig(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.toml")
+
+	if got := runReviveWith(t, "-config", missing, "./testdata/..."); got != 1 {
+		t.Errorf("RunRevive() with an unreadable config = %d, want 1", got)
+	}
+}
+
+func TestRunReviveReturnsZeroForVersion(t *testing.T) {
+	if got := runReviveWith(t, "-version"); got != 0 {
+		t.Errorf("RunRevive(-version) = %d, want 0", got)
+	}
+}
+
+// The code must come from the lint result, not be a constant. With -set_exit_status,
+// a file with findings exits 1 and a clean one exits 0 — so this pins the plumbing
+// from revive.Format() through to the returned code.
+func TestRunReviveReturnsLintExitStatus(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, src string) string {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	clean := write("clean.go", "// Package clean is fine.\npackage clean\n\n// Add returns the sum of a and b.\nfunc Add(a, b int) int { return a + b }\n")
+	// Missing package and exported-function comments: `exported` reports both.
+	dirty := write("dirty.go", "package dirty\n\nfunc Add(a, b int) int { return a + b }\n")
+
+	if got := runReviveWith(t, "-set_exit_status", clean); got != 0 {
+		t.Errorf("RunRevive() on clean source = %d, want 0", got)
+	}
+
+	if got := runReviveWith(t, "-set_exit_status", dirty); got != 1 {
+		t.Errorf("RunRevive() on source with findings = %d, want 1", got)
+	}
+}

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -15,14 +15,17 @@ func runReviveWith(t *testing.T, args ...string) int {
 
 	oldArgs, oldCommandLine, oldUsage := os.Args, flag.CommandLine, flag.Usage
 	t.Cleanup(func() {
+		//nolint:reassign // restoring the globals this helper swapped; RunRevive reads them directly
 		os.Args, flag.CommandLine, flag.Usage = oldArgs, oldCommandLine, oldUsage
 		versionFlag, configPath, formatterName = false, "", ""
 		setExitStatus, maxOpenFiles, excludePatterns = false, 0, nil
 	})
 
+	//nolint:reassign // a fresh FlagSet per call; initConfig panics re-registering on the global one
 	flag.CommandLine = flag.NewFlagSet("revive", flag.ContinueOnError)
 	flag.CommandLine.SetOutput(io.Discard)
 	excludePatterns = nil
+	//nolint:reassign // RunRevive parses os.Args itself, so the case under test has to be put there
 	os.Args = append([]string{"revive"}, args...)
 
 	return RunRevive()

--- a/main.go
+++ b/main.go
@@ -1,8 +1,12 @@
 // Package main is the build entry point of revive.
 package main
 
-import "github.com/mgechev/revive/cli"
+import (
+	"os"
+
+	"github.com/mgechev/revive/cli"
+)
 
 func main() {
-	cli.RunRevive()
+	os.Exit(cli.RunRevive())
 }


### PR DESCRIPTION
Closes #1333.

Implements what @ccoVeille proposed in the linked review: `RunRevive` returns an exit code and `main.go` acts on it, so there is no deep exit.

## Change

`RunRevive` terminated the process itself — `fail()` did `os.Exit(1)`, and the happy path did `os.Exit(exitCode)`. Both needed `//revive:disable-line:deep-exit` to get past revive's own linting.

```go
func RunRevive(extraRules ...revivelib.ExtraRule) int {
	exitCode, err := runRevive(extraRules...)
	if err != nil {
		fmt.Fprintln(os.Stderr, err)
		return 1
	}
	return exitCode
}
```

The logic moved into an unexported `runRevive(...) (int, error)` so every path out is a `return`, and `fail()` is gone. `main()` is now `os.Exit(cli.RunRevive())`.

**Both `os.Exit` calls and both `deep-exit` suppressions are gone from the package** — the only one left is `flag.Parse()`'s, which is the flag package's own exit and predates this.

## On the signature change

The issue notes this changes an exported signature. In practice it does not break callers: Go permits a call used as an expression statement to discard its results, so existing `cli.RunRevive(...)` code still compiles unchanged. It would only break someone assigning `RunRevive` to a `func(...revivelib.ExtraRule)` variable.

The README embedding example is updated to the new idiom (`os.Exit(cli.RunRevive(...))`) even though the old form still compiles.

## Testing

The real payoff is that the failure paths became testable at all. New `cli/run_test.go`:

- `TestRunReviveReturnsOneOnUnreadableConfig` — the error path returns 1
- `TestRunReviveReturnsZeroForVersion` — `-version` returns 0
- `TestRunReviveReturnsLintExitStatus` — with `-set_exit_status`, a clean file returns 0 and a file with findings returns 1, pinning the code as coming from `revive.Format()` rather than being a constant

I checked these could not have been written before: running the same tests against the pre-refactor code (only the call site adapted so it compiles) **fails the test binary outright**, because `os.Exit(1)` takes it down mid-test:

```
cannot read the config file
FAIL	github.com/mgechev/revive/cli	0.626s
```

A helper swaps in a fresh `flag.CommandLine` and restores the package-level flag targets, since `initConfig` registers on the global set and would panic on a second registration.

```
go test ./...                        # all packages ok
go vet ./...                         # clean
gofmt -l .                           # clean
go run . --config revive.toml ./...  # clean (revive on itself, incl. deep-exit)
```
