### PR TITLE
feat: add `exit-after-defer` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ List of all [available rules](./RULES_DESCRIPTIONS.md).
 | [`error-return`](./RULES_DESCRIPTIONS.md#error-return)        |  n/a   | The error return parameter should be last.                       | 1.0 |   yes    |  no   |
 | [`error-strings`](./RULES_DESCRIPTIONS.md#error-strings)       |  []string   | Conventions around error strings.                                | 1.0 |   yes    |  no   |
 | [`errorf`](./RULES_DESCRIPTIONS.md#errorf)              |  n/a   | Should replace `errors.New(fmt.Sprintf())` with `fmt.Errorf()`   | 1.0 |   yes    |  yes  |
+| [`exit-after-defer`](./RULES_DESCRIPTIONS.md#exit-after-defer) |  n/a   | Spots `os.Exit`, `syscall.Exit` or `log.Fatal` calls reachable after a `defer` | 1.0 |    no    |  no   |
 | [`exported`](./RULES_DESCRIPTIONS.md#exported)            |  []string   | Naming and commenting conventions on exported symbols.           | 1.0 |   yes    |  no   |
 | [`file-header`](./RULES_DESCRIPTIONS.md#file-header)         | string (defaults to none)| Header which each file should have.                              | 1.0 |    no    |  no   |
 | [`file-length-limit`](./RULES_DESCRIPTIONS.md#file-length-limit) | map (optional)| Enforces a maximum number of lines per file | 1.0 |    no    |  no   |

--- a/RULES_DESCRIPTIONS.md
+++ b/RULES_DESCRIPTIONS.md
@@ -39,6 +39,7 @@ List of all available rules.
 - [error-return](#error-return)
 - [error-strings](#error-strings)
 - [errorf](#errorf)
+- [exit-after-defer](#exit-after-defer)
 - [exported](#exported)
 - [file-header](#file-header)
 - [file-length-limit](#file-length-limit)
@@ -907,6 +908,31 @@ _Description_: It is possible to get a simpler program by replacing `errors.New(
 This rule spots that kind of simplification opportunities.
 
 _Configuration_: N/A
+
+## exit-after-defer
+
+_Go version_: 1.0.
+
+_Description_: Calls to `os.Exit`, `syscall.Exit` or the `log.Fatal` family stop the program immediately without running deferred functions.
+When such a call is reachable after a `defer` statement, the deferred call will never run, which is usually a mistake.
+
+`panic` and the `log.Panic` family are not reported because deferred functions still run while a panic unwinds the stack.
+
+_Configuration_: N/A
+
+### Examples (exit-after-defer)
+
+```go
+import "log"
+
+func run() {
+	defer cleanup()
+
+	if err := work(); err != nil {
+		log.Fatal(err) // cleanup is never called
+	}
+}
+```
 
 ## exported
 

--- a/config/config.go
+++ b/config/config.go
@@ -125,6 +125,7 @@ var allRules = append([]lint.Rule{
 	&rule.PackageNamingRule{},
 	&rule.MultilineIfInitRule{},
 	&rule.MarshalReceiverRule{},
+	&rule.ExitAfterDeferRule{},
 }, defaultRules...)
 
 // AllRules returns a copy of the list of all rules registered in revive.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -533,7 +533,7 @@ func TestGetLintingRules(t *testing.T) {
 		// len of defaultRules
 		defaultRulesCount = 23
 		// len of allRules: update this when adding new rules
-		allRulesCount = 104
+		allRulesCount = 105
 	)
 
 	tt := map[string]struct {

--- a/rule/exit_after_defer.go
+++ b/rule/exit_after_defer.go
@@ -1,0 +1,105 @@
+package rule
+
+import (
+	"fmt"
+	"go/ast"
+
+	"github.com/mgechev/revive/lint"
+)
+
+// ExitAfterDeferRule spots calls to [os.Exit], [syscall.Exit] or [log.Fatal] that
+// are reachable after a defer statement, since such calls stop the program without
+// running the deferred functions.
+type ExitAfterDeferRule struct{}
+
+// Name returns the rule name.
+func (*ExitAfterDeferRule) Name() string {
+	return "exit-after-defer"
+}
+
+// Apply applies the rule to given file.
+func (*ExitAfterDeferRule) Apply(file *lint.File, _ lint.Arguments) []lint.Failure {
+	var failures []lint.Failure
+	onFailure := func(failure lint.Failure) {
+		failures = append(failures, failure)
+	}
+
+	ast.Inspect(file.AST, func(n ast.Node) bool {
+		switch fn := n.(type) {
+		case *ast.FuncDecl:
+			if fn.Body != nil {
+				checkExitAfterDefer(fn.Body, onFailure)
+			}
+			return false
+		case *ast.FuncLit:
+			checkExitAfterDefer(fn.Body, onFailure)
+			return false
+		}
+		return true
+	})
+
+	return failures
+}
+
+// checkExitAfterDefer reports exit calls that follow a defer statement within
+// the same function scope. Function literals are analyzed on their own because
+// they introduce a new defer scope.
+func checkExitAfterDefer(body *ast.BlockStmt, onFailure func(lint.Failure)) {
+	deferred := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.FuncLit:
+			checkExitAfterDefer(n.Body, onFailure)
+			return false
+		case *ast.DeferStmt:
+			deferred = true
+			// A deferred function literal has its own defer scope.
+			if lit, ok := n.Call.Fun.(*ast.FuncLit); ok {
+				checkExitAfterDefer(lit.Body, onFailure)
+			}
+			return false
+		case *ast.CallExpr:
+			if !deferred {
+				return true
+			}
+			if pkg, fn, ok := isUnrecoverableExitCall(n); ok {
+				onFailure(lint.Failure{
+					Confidence: 1,
+					Node:       n,
+					Category:   lint.FailureCategoryBadPractice,
+					Failure:    fmt.Sprintf("%s.%s after a defer statement prevents deferred calls from running", pkg, fn),
+				})
+			}
+		}
+		return true
+	})
+}
+
+// isUnrecoverableExitCall reports whether call terminates the program without
+// running deferred functions: [os.Exit], [syscall.Exit] or one of the [log.Fatal]
+// functions (which call [os.Exit]).
+//
+// panic and [log.Panic] are intentionally excluded: deferred functions still run
+// while a panic unwinds the stack.
+func isUnrecoverableExitCall(call *ast.CallExpr) (pkg, fn string, ok bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", "", false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", "", false
+	}
+
+	pkg, fn = id.Name, sel.Sel.Name
+	switch pkg {
+	case "os", "syscall":
+		return pkg, fn, fn == "Exit"
+	case "log":
+		switch fn {
+		case "Fatal", "Fatalf", "Fatalln":
+			return pkg, fn, true
+		}
+	}
+	return "", "", false
+}

--- a/test/exit_after_defer_test.go
+++ b/test/exit_after_defer_test.go
@@ -1,0 +1,11 @@
+package test_test
+
+import (
+	"testing"
+
+	"github.com/mgechev/revive/rule"
+)
+
+func TestExitAfterDefer(t *testing.T) {
+	testRule(t, "exit_after_defer", &rule.ExitAfterDeferRule{})
+}

--- a/testdata/exit_after_defer.go
+++ b/testdata/exit_after_defer.go
@@ -1,0 +1,69 @@
+package fixtures
+
+import (
+	"log"
+	"os"
+	"syscall"
+)
+
+func exitAfterDefer() {
+	defer println("cleanup")
+	os.Exit(1) // MATCH /os.Exit after a defer statement prevents deferred calls from running/
+}
+
+func exitBeforeDeferIsFine() {
+	os.Exit(1)
+	defer println("cleanup")
+}
+
+func exitWithoutDeferIsFine() {
+	os.Exit(1)
+}
+
+func fatalAfterDefer() {
+	defer println("cleanup")
+	log.Fatal("boom")   // MATCH /log.Fatal after a defer statement prevents deferred calls from running/
+	log.Fatalf("%d", 1) // MATCH /log.Fatalf after a defer statement prevents deferred calls from running/
+	log.Fatalln("boom") // MATCH /log.Fatalln after a defer statement prevents deferred calls from running/
+}
+
+func syscallExitAfterDefer() {
+	defer println("cleanup")
+	syscall.Exit(1) // MATCH /syscall.Exit after a defer statement prevents deferred calls from running/
+}
+
+func panicAfterDeferIsFine() {
+	defer println("cleanup")
+	// deferred functions still run while a panic unwinds the stack.
+	log.Panic("boom")
+	panic("boom")
+}
+
+func exitInBranchAfterDefer() {
+	defer println("cleanup")
+	if len(os.Args) > 1 {
+		os.Exit(1) // MATCH /os.Exit after a defer statement prevents deferred calls from running/
+	}
+}
+
+func nestedFuncLitHasOwnScope() {
+	go func() {
+		defer println("cleanup")
+		os.Exit(1) // MATCH /os.Exit after a defer statement prevents deferred calls from running/
+	}()
+}
+
+func deferredFuncLitExitIsFine() {
+	defer func() {
+		os.Exit(0)
+	}()
+	println("work")
+}
+
+func exitInFuncLitBeforeOuterDefer() {
+	f := func() {
+		os.Exit(1)
+	}
+	defer println("cleanup")
+	f()
+}

--- a/untyped.toml
+++ b/untyped.toml
@@ -31,6 +31,7 @@
 [rule.error-naming]
 [rule.error-return]
 [rule.error-strings]
+[rule.exit-after-defer]
 [rule.exported]
 [rule.file-header]
 [rule.file-length-limit]


### PR DESCRIPTION
Adds a new `exit-after-defer` rule that flags calls to `os.Exit`, `syscall.Exit` or `log.Fatal` that are reachable after a `defer` statement, since the deferred calls will not run in that case.

`panic` and `log.Panic` are not reported because deferred functions still run while a panic unwinds the stack.

The rule is opt-in like the others, so existing configurations are unaffected. Tests and docs are included.

Closes #1300