### PR TITLE
redefines-builtin-id: report `comparable`

### DIFF
--- a/rule/redefines_builtin_id.go
+++ b/rule/redefines_builtin_id.go
@@ -43,6 +43,7 @@ var builtFunctionsAfterGo121 = map[string]bool{
 var builtInTypes = map[string]bool{
 	"bool":       true,
 	"byte":       true,
+	"comparable": true,
 	"complex128": true,
 	"complex64":  true,
 	"error":      true,

--- a/testdata/redefines_builtin_id.go
+++ b/testdata/redefines_builtin_id.go
@@ -52,3 +52,14 @@ func foo2() (new int) { // MATCH /redefinition of the built-in function new/
 
 func foo3[new any]() { // MATCH /redefinition of the built-in function new/
 }
+
+type comparable int // MATCH /redefinition of the built-in type comparable/
+
+func comparable() {} // MATCH /redefinition of the built-in type comparable/
+
+var comparable int // MATCH /redefinition of the built-in type comparable/
+
+const comparable = 1 // MATCH /redefinition of the built-in type comparable/
+
+func foo4[comparable any]() { // MATCH /redefinition of the built-in type comparable/
+}


### PR DESCRIPTION
`builtInTypes` is missing `comparable` — the only member of `go/types.Universe` (44 names) absent from the rule's four tables (43): `MISSING: [comparable]`, `EXTRA: []`.

Closes #1785.

AI-assisted (Claude Code, claude-opus-5); reviewed and verified by me.
